### PR TITLE
chore(ci): update release workflow to authenticate with deploy key for branch protection bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
           # Fetches the entire Git history, which semantic-release needs
           # to analyze all commits since the last release.
           fetch-depth: 0
-          # Uses the built-in token to authenticate repository operations.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Authenticates with the deploy key to bypass branch protection.
+          token: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5


### PR DESCRIPTION
### 1. GSoC Context & Goal 🎯

Completes the release workflow infrastructure by addressing branch protection compatibility. This small but critical change ensures the release process functions correctly with the new branch protections on `main`, finalizing the foundation infrastructure before the major architectural refactor.

### 2. The Change: What & Why 🛠️

Switches the release workflow authentication from `GITHUB_TOKEN` to `DEPLOY_KEY` in the checkout action. The GitHub token cannot bypass branch protection rules, but the deploy key (configured with appropriate permissions) can push releases directly to the protected `main` branch. This ensures semantic-release can create release commits and tags without manual intervention.

### 3. How to Self-Verify 🧪

1. Trigger a release workflow run (with dry-run mode) and confirm it completes without authentication errors
2. Verify the workflow can access the repository and analyze commit history properly
3. Check that semantic-release would be able to push to `main` if dry-run were disabled

### 4. Impact & Next Steps 🚀

**Immediate**: Release workflow is now fully functional with branch protections enabled. The foundation infrastructure is complete and battle-tested.

**Next**: All Week 8 infrastructure work is finalized. Ready to confidently begin the major `feature/pipeline-architecture` refactor with robust automation supporting the development process.