### PR TITLE
chore(workflows): rename deploy key to match remote secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           # Fetches the entire Git history, which semantic-release needs
           # to analyze all commits since the last release.
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_WORKFLOW_DEPLOY_KEY }}
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
@@ -112,30 +113,12 @@ jobs:
       - name: Create and Publish Release
         if: inputs.dry_run == false && steps.semver.outputs.IS_NEW_RELEASE == 'true'
         env:
-          # Provide the token for the GitHub API calls (creating the release page).
+          # semantic-release requires this token to authenticate with the GitHub API.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Provide the deploy key for the Git push operation.
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         run: |
           echo "🚀 Creating and publishing release v${{ steps.semver.outputs.VERSION }}..."
-
-          # 1. Set up the SSH key from the secret
-          #    This creates a key file that git can use.
-          echo "${DEPLOY_KEY}" > deploy_key
-          chmod 600 deploy_key
-
-          # 2. Force all subsequent git commands to use this specific key.
-          #    This overrides any git defaults and prevents confusion.
-          SSH_KEY_PATH="$(pwd)/deploy_key"
-          export GIT_SSH_COMMAND="ssh -i ${SSH_KEY_PATH} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
-
-          # 3. Re-configure the git remote URL to use SSH.
-          #    The default checkout uses https; we must switch to the ssh protocol.
-          git remote set-url origin "git@github.com:${{ github.repository }}.git"
-
-          # 4. Run the release.
-          #    - The `git push` inside this command will now be forced to use the deploy key.
-          #    - The GitHub Release creation will use the GH_TOKEN.
+          # The 'publish' command automatically handles all release tasks: bumping the version,
+          # updating the changelog, creating a Git tag, and publishing a GitHub Release.
           semantic-release -v publish
 
       - name: Verify Release Artifacts


### PR DESCRIPTION
### 1. GSoC Context & Goal 🎯

Fixes the deploy key authentication by correcting the secret name mismatch between the workflow and GitHub repository configuration. This simple but critical fix ensures the release workflow can properly authenticate with branch protection bypassing capabilities.

### 2. The Change: What & Why 🛠️

Updates the secret reference from `DEPLOY_KEY` to `RELEASE_WORKFLOW_DEPLOY_KEY` to match the actual secret configured in the GitHub repository. Reverts to the cleaner approach of letting the checkout action handle deploy key configuration automatically rather than manual SSH setup. This eliminates the complex manual key handling while ensuring proper authentication.

### 3. How to Self-Verify 🧪

1. Trigger the release workflow and confirm it authenticates successfully without errors
2. Verify the checkout step uses the correct secret name that matches the repository configuration
3. Test that semantic-release can push to the protected main branch through the deploy key
4. Confirm the workflow completes end-to-end without authentication failures

### 4. Impact & Next Steps 🚀

**Immediate**: Release workflow should now function correctly with proper deploy key authentication. The secret name mismatch that was preventing authentication is resolved.

**Strategic**: Week 8 infrastructure foundation is truly complete with functional release automation. All foundation work is finished and ready to support the final project phases.

**Next**: With release workflow finally working, all infrastructure prerequisites are met. Ready to confidently begin the major architectural refactor with robust automation support.