### PR TITLE
chore(ci): add build dependencies installation step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.RELEASE_WORKFLOW_DEPLOY_KEY }}
 
+      - name: Install build dependencies
+        run: python -m pip install build
+
       - name: Create and Publish Release
         id: release
         uses: python-semantic-release/python-semantic-release@v10.2.0


### PR DESCRIPTION
### 1. GSoC Context & Goal 🎯

Resolves the final missing dependency preventing release workflow execution. The python-semantic-release action environment lacks the `build` package required by the project's build command, and this addition provides it directly, completing the release automation foundation.

### 2. The Change: What & Why 🛠️

Adds a simple step to install the `build` package using pip before the semantic-release action runs. The official action environment is minimal and doesn't include this dependency that the project's `pyproject.toml` build configuration requires. This ensures the release process can successfully execute the build command without failures.

### 3. How to Self-Verify 🧪

1. Trigger the release workflow and verify it completes without build-related errors
2. Confirm the build step executes successfully after the dependency installation
3. Test that the semantic-release action can now complete its full workflow including building packages
4. Validate that releases are created properly with all expected artifacts

### 4. Impact & Next Steps 🚀

**Immediate**: Release workflow should now execute completely from start to finish. The missing dependency that was preventing builds is resolved with a simple, targeted fix.

**Strategic**: Week 8 infrastructure foundation is truly complete! All automation prerequisites are satisfied and the release system is ready to support final project delivery.

**Next**: Infrastructure work is finished. Ready to dive into the major architectural refactor with confidence that the foundation will support development and delivery seamlessly! 🎉