### PR TITLE
fix(rate-limiter): disable rate constraints during mock API operations

### DIFF
--- a/tests/unit/pipeline/test_rate_limiting_behavior.py
+++ b/tests/unit/pipeline/test_rate_limiting_behavior.py
@@ -1,0 +1,48 @@
+import pytest
+
+from gemini_batch.config import resolve_config
+from gemini_batch.core.types import InitialCommand, ResolvedCommand, Success
+from gemini_batch.executor import create_executor
+from gemini_batch.pipeline.planner import ExecutionPlanner
+from gemini_batch.pipeline.rate_limit_handler import RateLimitHandler
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_planner_omits_rate_constraint_in_dry_mode_and_sets_in_real_mode():
+    # Dry mode (use_real_api=False) → no rate constraint
+    cfg_dry = resolve_config(overrides={"use_real_api": False})
+    initial_dry = InitialCommand(
+        sources=(), prompts=("hello",), config=cfg_dry, history=()
+    )
+    resolved_dry = ResolvedCommand(initial=initial_dry, resolved_sources=())
+    planner = ExecutionPlanner()
+    res_dry = await planner.handle(resolved_dry)
+    assert isinstance(res_dry, Success)
+    plan_dry = res_dry.value.execution_plan
+    assert plan_dry.rate_constraint is None
+
+    # Real mode (use_real_api=True) → constraint present (model + tier known by default)
+    cfg_real = resolve_config(overrides={"use_real_api": True, "api_key": "dummy"})
+    initial_real = InitialCommand(
+        sources=(), prompts=("hello",), config=cfg_real, history=()
+    )
+    resolved_real = ResolvedCommand(initial=initial_real, resolved_sources=())
+    res_real = await planner.handle(resolved_real)
+    assert isinstance(res_real, Success)
+    plan_real = res_real.value.execution_plan
+    assert plan_real.rate_constraint is not None
+    assert plan_real.rate_constraint.requests_per_minute > 0
+
+
+@pytest.mark.unit
+def test_executor_pipeline_always_includes_rate_limiter():
+    # Pipeline includes RateLimitHandler for both dry and real modes.
+    # Enforcement is plan-driven via ExecutionPlan.rate_constraint.
+    cfg_dry = resolve_config(overrides={"use_real_api": False})
+    exec_dry = create_executor(cfg_dry)
+    assert any(isinstance(h, RateLimitHandler) for h in exec_dry._pipeline)
+
+    cfg_real = resolve_config(overrides={"use_real_api": True, "api_key": "dummy"})
+    exec_real = create_executor(cfg_real)
+    assert any(isinstance(h, RateLimitHandler) for h in exec_real._pipeline)


### PR DESCRIPTION
### 1. GSoC Context & Goal 🎯

This fix addresses a performance regression introduced after the configuration system revamp. The rate limiting system was inappropriately applying constraints during mock API operations, causing unnecessary delays in tests and development workflows.

### 2. The Change: What & Why 🛠️

Modifies the execution planner to only attach `RateConstraint` when `use_real_api=True`. The planner now checks the configuration flag before resolving rate limits, ensuring that mock API operations run at full speed without artificial throttling.

This maintains the architectural principle of plan-driven enforcement while eliminating the unintended slowdown. The `RateLimitHandler` remains in the pipeline but becomes a no-op when no constraint is present, preserving the handler's context-free design.

### 3. How to Self-Verify 🧪

1. Run `make test-progressive` and observe fast execution times (< 1 second for most suites)
2. Verify the new test `test_rate_limiting_behavior.py` passes both scenarios
3. Confirm planner omits rate constraints when `use_real_api=False`
4. Check that real API mode still applies proper rate constraints when enabled
5. Test conversation extension workflows run without delays

### 4. Impact & Next Steps 🚀

  **Immediate Impact:**

- Development and testing workflows return to expected performance levels
- Mock API operations no longer experience artificial rate limiting delays
- Test suites run significantly faster, improving developer experience

  **Architectural Benefits:**

- Reinforces plan-driven enforcement pattern in the pipeline
- Maintains clean separation between mock and real API execution paths
- Preserves rate limiter's context-free handler design

### 5. Key Files Changed

- `src/gemini_batch/pipeline/planner.py`: Added `use_real_api` check before rate limit resolution
- `src/gemini_batch/executor.py`: Code cleanup and clarifying comments
- `tests/unit/pipeline/test_rate_limiting_behavior.py`: Comprehensive test coverage for both modes