### PR TITLE
chore(tests): simplify pytest markers following test streamlining

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,22 +117,18 @@ log_cli_format = "%(name)-40s - %(levelname)-8s - %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 markers = [
-    "contract: Architectural contract tests (fast)",
-    "unit: Unit tests (fast)",
-    "integration: Cross-component integration tests (may be slow)",
-    "characterization: Golden file/snapshot tests (fast)",
-    "golden_test: Golden file tests (alias; legacy marker)",
-    "workflows: CI/CD workflow tests (fast)",
-    "cookbook: Cookbook recipe tests (fast, mocked)",
-    "slow: Tests that take > 1s (subset of integration)",
-    "api: Tests requiring external API (slow)",
-    "security: Security and secret handling tests",
+    # Primary test types (mutually exclusive)
+    "contract: Architectural invariant tests spanning modules",
+    "unit: Fast, isolated unit tests",
+    "integration: Cross-component integration tests with mocked APIs",
+    "api: External API tests (requires GEMINI_API_KEY, auto-skipped otherwise)",
+    # Secondary attributes (stackable with primary type)
+    "security: Security-sensitive tests",
+    "slow: Tests taking >1s (for CI optimization)",
+    # Fixture control (opt-out of default isolation)
     "allow_dotenv: Opt-in to load .env in a specific test",
-    "allow_real_home_config: Opt-in to use the real home config path",
     "allow_env_pollution: Opt-in to keep current env (no cleanup)",
-    "smoke: Very fast, critical path checks (<1m)",
-    "scenario: Curated advanced end-to-end scenarios",
-    "legacy: Legacy tests kept for reference/quarantine",
+    "allow_real_home_config: Opt-in to use the real home config path",
 ]
 
 # --- Ruff ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,19 +87,6 @@ def _api_tests_enabled() -> bool:
     return bool(os.getenv("GEMINI_API_KEY") and os.getenv("ENABLE_API_TESTS"))
 
 
-def pytest_configure(config):
-    """Register custom markers."""
-    markers = [
-        "unit: Fast, isolated unit tests",
-        "integration: Component integration tests with mocked APIs",
-        "api: Real API integration tests (requires API key)",
-        "characterization: Golden master tests to detect behavior changes",
-        "slow: Tests that take >1 second",
-    ]
-    for marker in markers:
-        config.addinivalue_line("markers", marker)
-
-
 def pytest_collection_modifyitems(items):
     """Automatically skip API tests when credentials are unavailable."""
     if _api_tests_enabled():

--- a/tests/test_cookbook.py
+++ b/tests/test_cookbook.py
@@ -15,7 +15,7 @@ import cookbook.__main__ as runner
 if TYPE_CHECKING:
     from pathlib import Path
 
-pytestmark = [pytest.mark.unit, pytest.mark.cookbook]
+pytestmark = pytest.mark.unit
 
 
 class TestCookbookRunner:


### PR DESCRIPTION
## Summary

Simplifies the pytest marking system by reducing markers from 16 to 9 and categorizing them into primary types (e.g., unit, integration) and secondary attributes.

## Notes

Establishes `pyproject.toml` as the single source of truth for marker definitions by removing the redundant hook in `conftest.py`. The removed markers were unused or redundant, reducing configuration complexity.

---

- [x] PR title follows [conventional commits](https://seanbrar.github.io/pollux/contributing/)
- [x] `make check` passes
- [x] Tests (if any) provide signal, not just coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-configuration cleanup; main risk is CI/test selection changing if any jobs still rely on removed/renamed markers.
> 
> **Overview**
> Consolidates pytest marker definitions in `pyproject.toml`, trimming/recategorizing markers into primary test types and secondary attributes and updating their descriptions.
> 
> Removes the redundant `pytest_configure` marker-registration hook from `tests/conftest.py`, making the TOML config the single source of truth, and drops the unused `pytest.mark.cookbook` from `tests/test_cookbook.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fffc0de224ab9c65a9bfd472adf8b0dbc8a1e0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->