### PR TITLE
chore(api): rename batch() to run_many() in core API

### DIFF
--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -1,8 +1,8 @@
-"""Pollux: Efficient batch interactions with LLM APIs.
+"""Pollux: Efficient multi-prompt interactions with LLM APIs.
 
 Public API:
     - run(): Single prompt execution
-    - batch(): Multi-prompt vectorized execution
+    - run_many(): Multi-prompt vectorized execution
     - Source: Explicit input types
     - Config: Configuration dataclass
 """
@@ -63,10 +63,10 @@ async def run(
         print(result["answers"][0])
     """
     sources = (source,) if source else ()
-    return await batch(prompt, sources=sources, config=config, options=options)
+    return await run_many(prompt, sources=sources, config=config, options=options)
 
 
-async def batch(
+async def run_many(
     prompts: str | list[str] | tuple[str, ...],
     *,
     sources: tuple[Source, ...] | list[Source] = (),
@@ -86,7 +86,7 @@ async def batch(
 
     Example:
         config = Config(provider="gemini", model="gemini-2.0-flash")
-        result = await batch(
+        result = await run_many(
             ["Question 1?", "Question 2?"],
             sources=[Source.from_text("Context...")],
             config=config,
@@ -143,6 +143,6 @@ __all__ = [
     "ResultEnvelope",
     "Source",
     "SourceError",
-    "batch",
     "run",
+    "run_many",
 ]

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -19,7 +19,7 @@ ResponseSchemaInput = type[BaseModel] | dict[str, Any]
 
 @dataclass(frozen=True)
 class Options:
-    """Optional execution features for `run()` and `batch()`."""
+    """Optional execution features for `run()` and `run_many()`."""
 
     response_schema: ResponseSchemaInput | None = None
     reasoning_effort: ReasoningEffort | None = None
@@ -68,7 +68,7 @@ class Options:
         if self.continue_from is not None and not isinstance(self.continue_from, dict):
             raise ConfigurationError(
                 "continue_from must be a prior Pollux result envelope",
-                hint="Pass the dict returned by run() or batch().",
+                hint="Pass the dict returned by run() or run_many().",
             )
 
     def response_schema_json(self) -> dict[str, Any] | None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,17 +68,17 @@ async def test_gemini_with_text_source(
 
 
 @pytest.mark.asyncio
-async def test_gemini_batch_returns_multiple_answers(
+async def test_gemini_run_many_returns_multiple_answers(
     gemini_api_key: str, gemini_test_model: str
 ) -> None:
-    """Smoke: Gemini batch produces one answer per prompt."""
+    """Smoke: Gemini run_many produces one answer per prompt."""
     config = Config(
         provider="gemini",
         model=gemini_test_model,
         api_key=gemini_api_key,
     )
 
-    result = await pollux.batch(
+    result = await pollux.run_many(
         prompts=["What is 1+1?", "What is 2+2?"],
         config=config,
     )
@@ -136,17 +136,17 @@ async def test_openai_with_text_source(
 
 
 @pytest.mark.asyncio
-async def test_openai_batch_returns_multiple_answers(
+async def test_openai_run_many_returns_multiple_answers(
     openai_api_key: str, openai_test_model: str
 ) -> None:
-    """Smoke: OpenAI batch produces one answer per prompt."""
+    """Smoke: OpenAI run_many produces one answer per prompt."""
     config = Config(
         provider="openai",
         model=openai_test_model,
         api_key=openai_api_key,
     )
 
-    result = await pollux.batch(
+    result = await pollux.run_many(
         prompts=["What is 1+1?", "What is 2+2?"],
         config=config,
     )


### PR DESCRIPTION
## Summary

Renames the `batch()` function to `run_many()` to create a clear family relationship with `run()` and avoid terminology collision with provider batch APIs.

## Notes

- **Disambiguation**: "batch" conflates with Google's Batch Prediction API (deferred async processing for cost savings). `run_many()` is honest about what it does—runs many prompts/sources—without claiming semantic precision about *how* efficiency is achieved.
- **The real magic is caching**: Pollux's efficiency comes from context caching, not batching itself. The old name implied the grouping was the optimization; the new name lets docs explain the actual mechanism.
- **API family**: `run()` → `run_many()` is an obvious progression, matching the v1.0 positioning of "multimodal orchestration" rather than leading with batching terminology.

---

- [x] PR title follows [conventional commits](https://seanbrar.github.io/pollux/contributing/)
- [ ] `make check` passes
- [x] Tests (if any) provide signal, not just coverage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a public API rename with corresponding documentation/test updates; risk is limited to downstream breakage for callers still using `batch()`.
> 
> **Overview**
> Renames the public multi-prompt entrypoint from `batch()` to `run_many()` and routes `run()` through `run_many()` for single-prompt execution.
> 
> Updates public exports and user-facing docs/error hints (`__init__.py`, `Options`) and rewrites integration/API tests to use `run_many()` instead of `batch()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a06d24d75e99fca15be5018ae4909a9570e2424. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->