### PR TITLE
chore(github): improve pr template and add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+## What happened?
+
+<!-- One or two sentences. What did you do, and what went wrong? -->
+
+## Expected behavior
+
+<!-- What should have happened instead? -->
+
+## Reproduction
+
+<!-- Minimal code, command, or steps to reproduce. -->
+
+```python
+
+```
+
+## Environment
+
+- Pollux version:
+- Python version:

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+labels: enhancement
+---
+
+## Problem or use case
+
+<!-- What are you trying to do, and why is it hard or impossible today? -->
+
+## Suggested approach
+
+<!-- Optional: how you'd imagine this working. API sketch, behavior description, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,22 @@
 ## Summary
 
-<!-- What does this PR do? One or two sentences. -->
+<!-- What does this PR do and why? One or two sentences on the change, plus motivation if not obvious from the linked issue. -->
+
+## Related issue
+
+<!-- Link the issue this PR addresses. Use closing keywords if applicable: "Closes #123", "Fixes #456". Write "None" for unprompted changes. -->
+
+## Test plan
+
+<!-- Describe verification with evidence. Include what was tested and why. If no new tests were added, explain why (e.g., architecture guarantee, covered by existing boundary tests, trivial delegation, or non-behavioral change). -->
 
 ## Notes
 
-<!-- Optional: anything reviewers should know, or context for your future self. -->
+<!-- Optional: what should a reviewer (or future-you) know that isn't obvious from the diff? e.g., why this approach, what's deliberately deferred, when to revisit. -->
 
 ---
 
 - [ ] PR title follows [conventional commits](https://seanbrar.github.io/pollux/contributing/)
 - [ ] `make check` passes
-- [ ] Tests (if any) provide signal, not just coverage
+- [ ] Tests cover the meaningful cases, not just the happy path
+- [ ] Docs updated (if this changes public API or user-facing behavior)


### PR DESCRIPTION
## Summary

Improve the PR template to include related issue + test plan sections, and add basic GitHub issue templates for bugs and feature requests.

## Related issue

None

## Test plan

- N/A (repo metadata only)

## Notes

This aligns PR expectations with the guidance in `docs/contributing.md`.

---

- [x] PR title follows conventional commits
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo metadata-only changes affecting GitHub issue/PR authoring flow; no runtime code paths or security-sensitive logic impacted.
> 
> **Overview**
> Adds GitHub issue templates for `Bug report` and `Feature request` to standardize incoming reports (including reproduction and environment fields for bugs).
> 
> Updates `.github/PULL_REQUEST_TEMPLATE.md` to require clearer motivation, a *Related issue* link, and a *Test plan*, and strengthens the checklist with explicit guidance on meaningful test coverage and doc updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4dc3053eecd7f91a929a67e518218f49495a3e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->