### PR TITLE
docs: refresh docs for v1.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,17 @@
-# Copy this file to `.env` and fill in values as needed.
+# Copy this file to `.env` and fill in values.
 # Never commit real secrets.
 
-# Provider API key (required only when enabling real API calls)
+# === Provider API Keys ===
+# Set the key for whichever provider(s) you use.
 GEMINI_API_KEY=
+OPENAI_API_KEY=
 
-# Library configuration
-# Accepted values: free | tier_1 | tier_2 | tier_3
-POLLUX_TIER=free
+# === Pollux Configuration ===
 
-# Enable calls to the real API (default is mock mode when unset or 0)
-POLLUX_USE_REAL_API=0
+# Optional: Force mock mode for testing (default: false/real API)
+# POLLUX_MOCK=1
 
-# Recommended defaults
-POLLUX_MODEL=gemini-2.0-flash
-POLLUX_ENABLE_CACHING=true
-
-# Optional: turn on telemetry (see docs for privacy/safety details)
-# POLLUX_TELEMETRY=1
+# Optional: Tune operational behavior
+# POLLUX_REQUEST_CONCURRENCY=6
+# POLLUX_ENABLE_CACHING=true
+# POLLUX_TTL_SECONDS=3600

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pollux
 
-Efficient multimodal analysis on Google's Gemini API.
+Multimodal orchestration for Gemini.
 
-> You describe what to analyze. Pollux handles batching, caching, rate limits, and retries—so you don't.
+> You describe what to analyze. Pollux handles source patterns, context caching, and multimodal complexity—so you don't.
 
 [Documentation](https://seanbrar.github.io/pollux/) ·
 [Quickstart](https://seanbrar.github.io/pollux/quickstart/) ·
@@ -18,12 +18,14 @@ Efficient multimodal analysis on Google's Gemini API.
 
 ```python
 import asyncio
-from pollux import run_simple, types
+from pollux import Config, Source, run
 
-async def main():
-    result = await run_simple(
+async def main() -> None:
+    config = Config(provider="gemini", model="gemini-2.5-flash-lite")
+    result = await run(
         "What are the key findings?",
-        source=types.Source.from_file("paper.pdf"),
+        source=Source.from_file("paper.pdf"),
+        config=config,
     )
     print(result["answers"][0])
 
@@ -33,9 +35,9 @@ asyncio.run(main())
 ## Why Pollux?
 
 - **Multimodal-first**: PDFs, images, videos, YouTube—same API
-- **Intelligent batching**: Fan-out across prompts and sources efficiently
-- **Context caching**: Reuse uploaded content, save tokens and money
-- **Production-ready**: Rate limiting, retries, async pipelines
+- **Source patterns**: Fan-out (one source → many prompts), fan-in, and broadcast
+- **Context caching**: Upload once, reuse across prompts—save tokens and money
+- **Production-ready core**: async execution, explicit capability checks, clear errors
 
 ## Installation
 
@@ -53,26 +55,21 @@ Get a key from [Google AI Studio](https://ai.dev/), then:
 export GEMINI_API_KEY="your-key-here"
 ```
 
-### Verify Setup
-
-```bash
-pollux-config doctor
-```
-
 ## Usage
 
-### Batch Processing
+### Multi-Source Analysis
 
 ```python
-from pollux import run_batch, types
+from pollux import Config, Source, batch
 
+config = Config(provider="gemini", model="gemini-2.5-flash-lite")
 sources = [
-    types.Source.from_file("paper1.pdf"),
-    types.Source.from_file("paper2.pdf"),
+    Source.from_file("paper1.pdf"),
+    Source.from_file("paper2.pdf"),
 ]
 prompts = ["Summarize the main argument.", "List key findings."]
 
-envelope = await run_batch(prompts, sources=sources)
+envelope = await batch(prompts, sources=sources, config=config)
 for answer in envelope["answers"]:
     print(answer)
 ```
@@ -80,26 +77,28 @@ for answer in envelope["answers"]:
 ### Configuration
 
 ```python
-from pollux import create_executor
-from pollux.config import resolve_config
+from pollux import Config
 
-config = resolve_config(overrides={
-    "model": "gemini-2.0-flash",
-    "tier": "tier_1",
-    "enable_caching": True,
-})
-
-executor = create_executor(config)
+config = Config(
+    provider="gemini",
+    model="gemini-2.5-flash-lite",
+    enable_caching=True,
+)
 ```
 
 See the [Configuration Guide](https://seanbrar.github.io/pollux/guides/configuration/) for details.
+
+### Provider Differences
+
+Pollux does not force strict feature parity across providers in v1.0.
+See the capability matrix: [Provider Capabilities](https://seanbrar.github.io/pollux/reference/provider-capabilities/).
 
 ## Documentation
 
 - [Quickstart](https://seanbrar.github.io/pollux/quickstart/) — First result in 2 minutes
 - [Guides](https://seanbrar.github.io/pollux/guides/installation/) — Installation, configuration, patterns
 - [API Reference](https://seanbrar.github.io/pollux/reference/api/) — Entry points and types
-- [Cookbook](./cookbook/) — 11 ready-to-run recipes
+- [Cookbook](./cookbook/) — scenario-driven, ready-to-run recipes
 
 ## Origins
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -2,13 +2,13 @@
 
 ## Origins
 
-Pollux began as a Google Summer of Code 2025 project with Google DeepMind. The goal: make multimodal batch processing on Gemini efficient, reliable, and accessible.
+Pollux began as a Google Summer of Code 2025 project with Google DeepMind. The goal: make multimodal analysis on Gemini efficient, reliable, and accessible.
 
 The project has since evolved beyond its GSoC roots into a production-ready library, but the research-minded approach remains. Every design decision is deliberate. Every abstraction was earned, not assumed.
 
 ## Philosophy
 
-**Absorbed complexity.** The library handles batching, caching, rate limiting, and retries so your code doesn't have to. You describe *what* to analyze. Pollux handles *how*.
+**Absorbed complexity.** The library handles source patterns, context caching, rate limiting, and retries so your code doesn't have to. You describe *what* to analyze. Pollux handles *how*.
 
 **Multimodal-native.** PDFs, videos, images, and YouTube URLs are first-class citizens alongside text. Not an afterthought—the core design.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,26 +19,51 @@ make test
 
 ## Before Opening a PR
 
-1. Run checks: `make check`
+1. Run `make check` (lint + typecheck + tests)
 2. If docs changed, preview locally: `make docs-serve`
-3. Keep changes focused: one PR, one idea
+3. Write a test plan—describe how you verified the change and why (see [Testing Philosophy](#testing-philosophy))
+4. Keep changes focused: one PR, one idea
 
 ## Pull Requests
 
 **Title**: Conventional Commits style—`type(scope): subject` (imperative)
 
 Examples:
+
 - `feat(api): add playlist support`
 - `fix(cache): handle expired tokens`
 - `docs(cookbook): add batch processing recipe`
 
-**Body**:
-1. Summary—what does this PR do? One or two sentences.
-2. Notes (optional)—anything reviewers should know.
+**Body** follows the [PR template](https://github.com/seanbrar/pollux/blob/main/.github/PULL_REQUEST_TEMPLATE.md) with four sections:
+
+1. **Summary** — what and why, one or two sentences
+2. **Related issue** — link with closing keywords (`Closes #123`), or "None" for unprompted changes
+3. **Test plan** — describe verification with evidence; if no new tests, explain why (see [Testing Philosophy](#testing-philosophy))
+4. **Notes** (optional) — context not obvious from the diff: rationale, trade-offs, deferred work, when to revisit
+
+**Checklist** (mirrors the template checkboxes):
+
+- [ ] PR title follows conventional commits
+- [ ] `make check` passes
+- [ ] Tests cover meaningful cases, not just the happy path
+- [ ] Docs updated if public API or user-facing behavior changed
+
+## Issues
+
+Issue templates exist for [bugs](https://github.com/seanbrar/pollux/issues/new?template=bug.md) and [feature requests](https://github.com/seanbrar/pollux/issues/new?template=feature.md). The templates carry most of the detail—here's the gist:
+
+- **Bug reports**: what happened, expected behavior, reproduction steps, environment (Pollux + Python version)
+- **Feature requests**: problem or use case, optional suggested approach
+
+When a PR addresses an issue, link it in the **Related issue** section using closing keywords (`Closes #123`, `Fixes #456`).
+
+Issues may also be filed during development when bugs or deferred work items are discovered out of scope of the current task. These follow the same templates and quality bar as any other issue.
 
 ## Testing Philosophy
 
 This project follows the [MTMT (Minimal Tests, Maximum Trust)](https://github.com/seanbrar/minimal-tests-maximum-trust) testing standard. See [TESTING.md](https://github.com/seanbrar/pollux/blob/main/TESTING.md) for guidance on what merits a test.
+
+Every PR includes a test plan. The MTMT criteria—architectural guarantee, boundary coverage, trivial delegation, non-behavioral change—are the vocabulary for explaining why tests were or weren't added.
 
 ## Documentation Standards
 

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -1,49 +1,52 @@
 # Caching
 
-Use provider-side caching when you run the same shared context repeatedly. It
-can reduce tokens and latency, especially for long sources.
+Use provider-side caching when you run the same shared context repeatedly. This
+can reduce tokens and latency.
 
 Prerequisites:
 
-- Real API enabled (`GEMINI_API_KEY`, `POLLUX_USE_REAL_API=1`)
-- A tier that supports caching, if applicable
+- Real API enabled (`GEMINI_API_KEY` or explicit key)
+- Provider that supports caching (Gemini in v1.0)
 
 ## Minimal example: create and reuse
 
-Run the same batch twice with a deterministic cache key.
+Run the same batch twice. Pollux computes cache identity from model + source content hash.
 
 ```python title="cache_min.py"
 import asyncio
-from pollux import run_batch, types
-from pollux.core.execution_options import ExecutionOptions, CacheOptions
+from pollux import Config, Source, batch
 
 async def main() -> None:
-    prompts = ["Summarize in one sentence.", "List 3 keywords."]
-    sources = [types.Source.from_text("Caching demo: shared context text")]
-
-    opts = ExecutionOptions(
-        cache=CacheOptions(deterministic_key="demo.shared.context.v1", ttl_seconds=3600)
+    config = Config(
+        provider="gemini",
+        model="gemini-2.5-flash-lite",
+        enable_caching=True,
+        ttl_seconds=3600,
     )
+    prompts = ["Summarize in one sentence.", "List 3 keywords."]
+    sources = [Source.from_text("Caching demo: shared context text")]
 
-    first = await run_batch(prompts=prompts, sources=sources, options=opts)
-    second = await run_batch(prompts=prompts, sources=sources, options=opts)
+    first = await batch(prompts=prompts, sources=sources, config=config)
+    second = await batch(prompts=prompts, sources=sources, config=config)
     print("first:", first["status"])
     print("second:", second["status"])
+    print("cache_used (2nd):", second.get("metrics", {}).get("cache_used"))
 
 asyncio.run(main())
 ```
 
 Expected result:
 
-- Mock mode: both runs print `ok` (cache is a no-op).
-- Real API: the second run should show cache reuse in metrics when supported.
+- Mock mode: both runs print `ok`; cache metrics are synthetic.
+- Real API: second run should show `metrics.cache_used=True` when supported.
 
 ## Verification tips
 
-- Look for `metrics.cache_application` on the second run.
-- Some providers expose `cached_*` usage counters; not all do.
+- Look for `metrics.cache_used` on the second run.
+- Usage counters are provider-dependent.
 
 ## Troubleshooting
 
-- No cache effects: confirm real API is enabled and the provider supports caching.
-- Missing counters: rely on `cache_application` rather than token deltas.
+- No cache effects: confirm `enable_caching=True` and a caching-capable provider.
+- OpenAI: caching is intentionally unsupported in v1.0.
+- See [Provider Capabilities](../reference/provider-capabilities.md).

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -50,24 +50,21 @@ make lint
 
 ## Enable the real API (optional)
 
-Mock mode is the default and needs no key. For real API calls:
+For real API calls, set an API key:
 
 === "Bash/Zsh"
 
 ```bash
 export GEMINI_API_KEY="<your key>"
-export POLLUX_TIER=free      # free | tier_1 | tier_2 | tier_3
-export POLLUX_USE_REAL_API=1
+export OPENAI_API_KEY="<your key>"
 ```
 
 === "PowerShell"
 
 ```powershell
 $Env:GEMINI_API_KEY = "<your key>"
-$Env:POLLUX_TIER = "free"
-$Env:POLLUX_USE_REAL_API = "1"
+$Env:OPENAI_API_KEY = "<your key>"
 ```
 
 !!! warning "Secrets & costs"
-    Never commit keys. Real API usage may incur costs - set `POLLUX_TIER` to match
-    your account.
+    Never commit keys. Real API usage may incur costs.

--- a/docs/guides/token-efficiency.md
+++ b/docs/guides/token-efficiency.md
@@ -1,0 +1,136 @@
+# Token Efficiency
+
+Pollux helps you get more value from every API call through **context caching** and **source patterns**. This guide explains the underlying economics and how to leverage them.
+
+## The Problem: Redundant Context
+
+When you ask multiple questions about the same content, naive approaches send that content repeatedly:
+
+```
+Question 1: [video tokens] + [question 1] → [answer 1]
+Question 2: [video tokens] + [question 2] → [answer 2]
+Question 3: [video tokens] + [question 3] → [answer 3]
+```
+
+For a 1-hour video (~946,800 tokens), asking 5 questions means transmitting ~4.7 million input tokens—even though the video content is identical each time.
+
+## The Solution: Context Caching
+
+Pollux uploads content once and caches it for reuse:
+
+```
+Upload:     [video tokens] → cached
+Question 1: [cache ref] + [question 1] → [answer 1]
+Question 2: [cache ref] + [question 2] → [answer 2]
+Question 3: [cache ref] + [question 3] → [answer 3]
+```
+
+Now you transmit ~946,800 tokens once, plus a small cache reference for each question. The savings compound with each additional question.
+
+## Quantifying the Savings
+
+```python
+def compare_efficiency(video_tokens: int, num_questions: int) -> None:
+    """Compare token usage between naive and cached approaches."""
+    question_tokens = 50   # Average question length
+    answer_tokens = 100    # Average answer length
+
+    # Naive: send full context each time
+    naive_total = num_questions * (video_tokens + question_tokens + answer_tokens)
+
+    # Cached: send context once, reference thereafter
+    cached_total = video_tokens + num_questions * (question_tokens + answer_tokens)
+
+    savings = naive_total - cached_total
+    savings_pct = (savings / naive_total) * 100
+
+    print(f"Questions: {num_questions}")
+    print(f"Naive approach: {naive_total:,} tokens")
+    print(f"Cached approach: {cached_total:,} tokens")
+    print(f"Savings: {savings:,} tokens ({savings_pct:.1f}%)")
+
+# Example: 1-hour video, 10 questions
+compare_efficiency(946_800, 10)
+# Savings: 8,521,200 tokens (90.0%)
+```
+
+**The efficiency scales with questions:** More questions on the same content = greater savings.
+
+## Source Patterns
+
+Pollux supports three patterns for multi-prompt/multi-source analysis:
+
+### Fan-Out: One Source → Many Prompts
+
+The most common efficiency pattern. Upload one piece of content, ask many questions.
+
+```python
+from pollux import Config, Source, run_many
+
+config = Config(provider="gemini", model="gemini-2.5-flash-lite")
+video = Source.from_file("lecture.mp4")
+
+prompts = [
+    "Summarize the main argument.",
+    "What evidence is presented?",
+    "What are the limitations mentioned?",
+    "How does this relate to prior work?",
+]
+
+envelope = await run_many(prompts, sources=[video], config=config)
+```
+
+### Fan-In: Many Sources → One Prompt
+
+Synthesize across multiple sources with a single question.
+
+```python
+papers = [
+    Source.from_file("paper1.pdf"),
+    Source.from_file("paper2.pdf"),
+    Source.from_file("paper3.pdf"),
+]
+
+envelope = await run_many(
+    ["Compare the methodologies across these papers."],
+    sources=papers,
+    config=config,
+)
+```
+
+### Broadcast: Many Sources × Many Prompts
+
+Apply the same analysis template across multiple sources.
+
+```python
+papers = [Source.from_file(f"paper{i}.pdf") for i in range(1, 6)]
+prompts = ["Summarize findings.", "List limitations.", "Rate methodology 1-5."]
+
+envelope = await run_many(prompts, sources=papers, config=config)
+# Returns 5 papers × 3 prompts = 15 answers
+```
+
+## When to Use `run()` vs `run_many()`
+
+| Scenario | Function | Why |
+|----------|----------|-----|
+| Quick single question | `run()` | Simpler API |
+| Multiple questions, same source | `run_many()` | Fan-out efficiency |
+| Same question, multiple sources | `run_many()` | Fan-in analysis |
+| Comparative analysis | `run_many()` | Broadcast pattern |
+
+## Best Practices
+
+1. **Group related questions.** If you'll ask 10 questions about the same video, call `run_many()` once, not `run()` ten times.
+
+2. **Keep sources cached.** Pollux manages cache TTLs automatically, but avoid unnecessary re-uploads by reusing `Source` objects.
+
+3. **Mind context limits.** Each provider has maximum context lengths. For very large sources, consider chunking strategies.
+
+4. **Start simple.** Use `run()` for prototyping, then switch to `run_many()` once your prompts are stable.
+
+## Further Reading
+
+- [Context Caching Guide](caching.md) — TTL management and cache behavior
+- [Usage Patterns](patterns.md) — More examples of `run()` and `run_many()`
+- [Provider Capabilities](../reference/provider-capabilities.md) — Provider-specific limits and features

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -2,51 +2,55 @@
 
 Fast fixes for common setup issues.
 
-## Real API enabled but no key
-
-**Symptom:** `pollux-config doctor` reports a missing `api_key`, or responses look like mock.
+## Missing API key
 
 **Fix:**
 
 ```bash
 export GEMINI_API_KEY="<your key>"
-export POLLUX_USE_REAL_API=1
+export OPENAI_API_KEY="<your key>"
 ```
 
-## Hitting rate limits immediately
+Or pass `api_key` explicitly in `Config(...)`.
 
-**Symptom:** requests throttle right after enabling the real API.
+## Unexpected mock responses
 
-**Fix:**
+**Symptom:** outputs look like `echo: ...`.
 
-```bash
-export POLLUX_TIER=free|tier_1|tier_2|tier_3
-```
+**Fix:** ensure `use_mock=False` (default) and key is present.
 
-Then reduce concurrency in your config or per-call options if needed.
+## Provider/model mismatch
 
-## Model/provider mismatch
+**Symptom:** configuration or API errors right at request time.
 
-**Symptom:** `Unknown model; provider defaulted to 'google'.`
+**Fix:** verify the model belongs to the selected provider.
 
-**Fix:** use a valid model string for your provider (e.g., `gemini-2.0-flash`).
+## Option not implemented in v1.0
 
-## Mock answers when expecting real results
+**Symptom:** `ConfigurationError` for:
 
-**Symptom:** outputs look like `echo: ...` or include `mock` metadata.
+- `delivery_mode="deferred"`
+- `history`
+- `continue_from`
 
-**Fix:** ensure the real API is enabled and the key is present, then re-run:
+**Explanation:** these are intentionally reserved/disabled in v1.0.
 
-```bash
-pollux-config doctor
-```
+## OpenAI multimodal limitations
+
+**Symptom:** remote source rejected with unsupported type.
+
+**Explanation (v1.0):** OpenAI remote URL support is explicit:
+
+- PDFs via `input_file.file_url`
+- Images via `input_image.image_url`
+
+Other remote MIME types are rejected by design.
 
 ## Secrets appear missing in logs
 
 **Symptom:** keys show as `***redacted***`.
 
-**Explanation:** redaction is intentional. Use `pollux-config env` or
-`pollux-config doctor` to confirm variables exist.
+**Explanation:** redaction is intentional.
 
 ## Python or import errors
 
@@ -54,8 +58,15 @@ pollux-config doctor
 
 - Use Python `3.13` and a clean virtual environment.
 - Install from releases (wheel) or source with `pip install -e .`.
+- Run:
+  - `make test`
+  - `make lint`
+  - `make typecheck`
 
 ## Still stuck?
 
-- Run `pollux-config doctor` and attach the output to any issue report.
-- See [CLI reference](../reference/cli.md) for diagnostic commands.
+- Include:
+  - provider + model
+  - source type(s)
+  - exact exception message
+- See [Provider Capabilities](../reference/provider-capabilities.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,19 @@
 # Pollux
 
-Efficient multimodal analysis on Google's Gemini API.
+Multimodal orchestration for Gemini.
 
-> You describe what to analyze. Pollux handles batching, caching, rate limits, and retries—so you don't.
+> You describe what to analyze. Pollux handles source patterns, context caching, and multimodal complexity—so you don't.
 
 ```python
 import asyncio
-from pollux import run_simple, types
+from pollux import Config, Source, run
 
-async def main():
-    result = await run_simple(
+async def main() -> None:
+    config = Config(provider="gemini", model="gemini-2.5-flash-lite")
+    result = await run(
         "What are the key findings?",
-        source=types.Source.from_file("paper.pdf"),
+        source=Source.from_file("paper.pdf"),
+        config=config,
     )
     print(result["answers"][0])
 
@@ -21,9 +23,9 @@ asyncio.run(main())
 ## Why Pollux?
 
 - **Multimodal-first** — PDFs, images, videos, YouTube URLs. Same API.
-- **Intelligent batching** — Fan-out across prompts and sources efficiently.
-- **Context caching** — Reuse uploaded content. Save tokens and money.
-- **Production-ready** — Rate limiting, retries, async pipelines.
+- **Source patterns** — Fan-out (one source → many prompts), fan-in, and broadcast.
+- **Context caching** — Upload once, reuse across prompts. Save tokens and money.
+- **Production-ready core** — Async execution, explicit capability checks, clear errors.
 
 ## Get Started
 
@@ -31,4 +33,6 @@ asyncio.run(main())
 
 **[Guides →](guides/installation.md)** — Installation, configuration, patterns
 
-**[Cookbook](https://github.com/seanbrar/pollux/tree/main/cookbook)** — 11 ready-to-run recipes
+**[Cookbook](cookbook/index.md)** — Scenario-driven, ready-to-run recipes
+
+**[Provider Capabilities](reference/provider-capabilities.md)** — Provider-by-provider feature matrix

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,12 +23,14 @@ export GEMINI_API_KEY="your-key-here"
 
 ```python
 import asyncio
-from pollux import run_simple, types
+from pollux import Config, Source, run
 
 async def main() -> None:
-    result = await run_simple(
+    config = Config(provider="gemini", model="gemini-2.5-flash-lite")
+    result = await run(
         "What are the key points?",
-        source=types.Source.from_file("document.pdf"),
+        source=Source.from_file("document.pdf"),
+        config=config,
     )
     print(result["answers"][0])
 
@@ -39,6 +41,7 @@ Expected result: a short answer printed to your terminal.
 
 ## Next Steps
 
-- **[Usage Patterns](guides/patterns.md)** — Batch processing, conversations
+- **[Usage Patterns](guides/patterns.md)** — Single-call and batched execution patterns
 - **[Configuration](guides/configuration.md)** — Models, tiers, and options
-- **[Cookbook](https://github.com/seanbrar/pollux/tree/main/cookbook)** — Ready-to-run recipes
+- **[Provider Capabilities](reference/provider-capabilities.md)** — Provider-specific features and limits
+- **[Cookbook](cookbook/index.md)** — Ready-to-run recipes

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,37 +1,37 @@
 # API Reference
 
-Quick reference for the public API. For usage examples, see the [Quickstart](../quickstart.md).
+Quick reference for the current public API.
 
----
+For provider-level feature differences, see [Provider Capabilities](provider-capabilities.md).
 
 ## Entry Points
 
-The main way to use Pollux:
+The primary execution functions are exported from `pollux`:
 
-::: pollux.frontdoor.run_simple
+::: pollux.run
 
-::: pollux.frontdoor.run_batch
+::: pollux.run_many
 
----
+## Core Types
 
-## Executor (Advanced)
+::: pollux.Source
 
-For fine-grained control:
+::: pollux.Config
 
-::: pollux.executor.create_executor
+::: pollux.ResultEnvelope
 
-::: pollux.executor.Executor
+## Error Types
 
----
+::: pollux.PolluxError
 
-## Sources
+::: pollux.ConfigurationError
 
-::: pollux.types.Source
+::: pollux.SourceError
 
----
+::: pollux.APIError
 
-## Configuration
+::: pollux.RateLimitError
 
-::: pollux.config.resolve_config
+::: pollux.CacheError
 
-::: pollux.config.FrozenConfig
+::: pollux.PlanningError

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -70,13 +70,22 @@ setup patterns.
 
 ## Cookbook Runner
 
-- Command: `python -m cookbook [--cwd-repo-root|--no-cwd-repo-root] [--list] <spec> [-- recipe_args]`
+### Prerequisites
+
+The cookbook runner requires a dev install so that recipe imports resolve correctly:
+
+```bash
+uv sync --all-extras          # or: pip install -e ".[dev]"
+```
+
+- Command: `python -m cookbook [--cwd-repo-root|--no-cwd-repo-root] [--list] <spec> [[--] recipe_args...]`
 - Spec forms:
   - Path relative to repo: `cookbook/production/resume-on-failure.py`
   - Path relative to `cookbook/`: `production/resume-on-failure.py`
   - Dotted (maps `_` -> `-` on disk): `production.resume_on_failure`
 - Default working directory: repository root. Opt out with `--no-cwd-repo-root`.
-- Pass recipe flags after `--` (everything after is forwarded to the recipe).
+- Recipe flags can be passed directly after the spec (recommended for most shells).
+- If you prefer explicit separation, include `--` and everything after is forwarded to the recipe unchanged.
 
 Examples:
 
@@ -84,11 +93,14 @@ Examples:
 # List available recipes
 python -m cookbook --list
 
-# Run via path and pass recipe args
+# Run via path and pass recipe args (no separator required)
+python -m cookbook optimization/cache-warming-and-ttl --limit 2 --ttl 3600
+
+# Optional explicit separator
 python -m cookbook optimization/cache-warming-and-ttl -- --limit 2 --ttl 3600
 
 # Run via dotted spec
-python -m cookbook production.resume_on_failure -- --limit 1
+python -m cookbook production.resume_on_failure --limit 1
 ```
 
 Notes:
@@ -102,8 +114,8 @@ Notes:
 
 ```bash
 python -m cookbook --list
-python -m cookbook optimization/cache-warming-and-ttl -- --limit 2 --ttl 3600
-python -m cookbook production.resume_on_failure -- --limit 1
+python -m cookbook optimization/cache-warming-and-ttl --limit 2 --ttl 3600
+python -m cookbook production.resume_on_failure --limit 1
 ```
 
 === "PowerShell (Windows)"
@@ -111,8 +123,8 @@ python -m cookbook production.resume_on_failure -- --limit 1
 ```powershell
 # Prefer the dotted form for portability
 py -m cookbook --list
-py -m cookbook optimization.cache_warming_and_ttl -- --limit 2 --ttl 3600
-py -m cookbook production.resume_on_failure -- --limit 1
+py -m cookbook optimization.cache_warming_and_ttl --limit 2 --ttl 3600
+py -m cookbook production.resume_on_failure --limit 1
 
 # You can also use paths; forward slashes work cross-platform
 py -m cookbook optimization/cache-warming-and-ttl.py -- --limit 2 --ttl 3600
@@ -123,11 +135,11 @@ py -m cookbook optimization/cache-warming-and-ttl.py -- --limit 2 --ttl 3600
 ```bat
 py -m cookbook --list
 py -m cookbook optimization\\cache-warming-and-ttl.py -- --limit 2 --ttl 3600
-py -m cookbook production.resume_on_failure -- --limit 1
+py -m cookbook production.resume_on_failure --limit 1
 ```
 
 Tips:
 
 - Use the dotted spec (e.g., `production.resume_on_failure`) for consistency across shells.
-- Pass recipe arguments after `--`; everything after is forwarded to the recipe unchanged.
+- You can pass recipe arguments directly after the spec, or place `--` before recipe args for explicit separation.
 - The runner defaults to executing from the repository root; opt out with `--no-cwd-repo-root` when needed.

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -1,0 +1,45 @@
+# Provider Capabilities
+
+This page defines the v1.0 capability contract by provider.
+
+Pollux is **capability-transparent**, not capability-equalizing: providers are allowed to differ, and those differences are surfaced clearly.
+
+## v1.0 Policy
+
+- Provider feature parity is **not** required for release.
+- Unsupported features must fail fast with clear errors.
+- New provider features do not require immediate cross-provider implementation.
+
+## Capability Matrix (v1.0)
+
+| Capability | Gemini | OpenAI | Notes |
+|---|---|---|---|
+| Text generation | ✅ | ✅ | Core feature |
+| Batch prompts (`batch`) | ✅ | ✅ | One call per prompt, shared context |
+| Local file inputs | ✅ | ✅ | OpenAI uses Files API upload |
+| PDF URL inputs | ✅ (via URI part) | ✅ (native `input_file.file_url`) | |
+| Image URL inputs | ✅ (via URI part) | ✅ (native `input_image.image_url`) | |
+| YouTube URL inputs | ✅ | ⚠️ limited | OpenAI parity layer (download/re-upload) is out of scope for v1.0 |
+| Provider-side context caching | ✅ | ❌ | OpenAI provider returns unsupported for caching |
+| Structured outputs (`response_schema`) | ✅ | ✅ | JSON-schema path in both providers |
+| Reasoning controls (`reasoning_effort`) | ❌ | ❌ | Reserved for future provider enablement |
+| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | Explicitly disabled in v1.0 |
+| Conversation continuity (`history`, `continue_from`) | ❌ | ❌ | Reserved/disabled in v1.0 |
+
+## Important OpenAI Notes
+
+- Pollux uploads local files with:
+  - `purpose="user_data"`
+  - finite `expires_after` metadata
+- Automatic file deletion is not part of v1.0 yet.
+- Remote URL support in v1.0 is intentionally narrow and explicit:
+  - PDFs
+  - images
+
+## Error Semantics
+
+When a requested feature is unsupported for the selected provider or release scope, Pollux raises `ConfigurationError` or `APIError` with a concrete hint, instead of degrading silently.
+
+## Design Intent
+
+The goal for v1.0 is a stable and interpretable core. Capability expansion continues in v1.1+ without masking provider realities.


### PR DESCRIPTION
## Summary

Refresh docs to match Pollux v1.0 vocabulary and configuration patterns (explicit `Config`, source patterns, caching), and add missing pages referenced in nav.

## Related issue

None

## Test plan

- `uv run mkdocs build --strict --clean`

## Notes

This is intentionally a broad docs sync pass; deeper rewrites can land in a follow-up PR.

---

- [x] PR title follows conventional commits
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a `.env.example` refresh; no runtime code paths or security-sensitive logic are modified.
> 
> **Overview**
> Refreshes user-facing docs and examples to match the v1.0 API vocabulary: explicit `Config` objects passed into `run`/`batch`/`run_many`, updated source patterns, and revised caching guidance/metrics.
> 
> Adds new documentation pages for **token efficiency** and a **provider capability matrix**, and updates troubleshooting/installation/configuration/contributing/CLI docs to reflect the new API key env vars (`OPENAI_API_KEY`), mock-mode knob (`POLLUX_MOCK`), and v1.0 feature limitations (e.g., reserved `history`/`continue_from`/`delivery_mode`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560b81c9f0c0e147119dbc0753df2f1cd83fa7ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->