### PR TITLE
docs: refine roadmap and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Something isn't working as expected
-labels: bug
+labels: [bug]
 ---
 
 ## What happened?
@@ -20,7 +20,30 @@ labels: bug
 
 ```
 
+## Error output (optional)
+
+<!-- Paste the full traceback or error message (redact secrets). -->
+
+```text
+
+```
+
 ## Environment
 
 - Pollux version:
 - Python version:
+- OS:
+- Provider + model (if applicable):
+
+## Additional context (optional)
+
+<!--
+Anything that may affect repro:
+- Input type (local file, PDF URL, image URL, YouTube URL)
+- Config toggles (for example enable_caching)
+- Expected limits/cost considerations
+-->
+
+## Acceptance criteria (optional)
+
+<!-- If you plan to fix this, describe "done means..." in one or two bullets. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,13 +1,30 @@
 ---
 name: Feature request
 about: Suggest a new capability or improvement
-labels: enhancement
+labels: [enhancement]
 ---
 
 ## Problem or use case
 
 <!-- What are you trying to do, and why is it hard or impossible today? -->
 
-## Suggested approach
+## Proposed change (optional)
 
-<!-- Optional: how you'd imagine this working. API sketch, behavior description, etc. -->
+<!-- If you have a specific idea, describe desired behavior and/or an API sketch. -->
+
+## Acceptance criteria (optional)
+
+<!--
+Definition of done. Keep it short and user-visible when possible.
+Examples:
+- "Raises ConfigurationError with a clear hint when unsupported"
+- "Adds a cookbook recipe and updates docs"
+-->
+
+## Out of scope (optional)
+
+<!-- What this should NOT include (helps keep the change minimal). -->
+
+## Notes (optional)
+
+<!-- Provider-specific considerations, compatibility constraints, or related links. -->

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ site/
 
 # Editors/IDEs
 .idea/
+.claude/
 
 # OS files (cross-platform)
 Thumbs.db
@@ -55,6 +56,8 @@ Thumbs.db
 # Project root scratch files
 /*.txt
 /*.log
+/test.py
+/.worktrees/
 
 # Root-level media
 /*.mp4
@@ -77,3 +80,4 @@ cookbook/data/demo/*
 cookbook/data/demo/text-medium/*
 cookbook/data/demo/text-full/*
 cookbook/data/demo/multimodal-basic/*
+outputs/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,38 @@
+# Pollux Roadmap
+
+This roadmap is intentionally scope-constrained: ship a stable, high-quality core in v1.0, then expand deliberately.
+
+- **Intent**: communicate priorities and scope boundaries (not a promise or contract).
+- **Last updated**: 2026-02-08
+- **Status tracking**: Issues and PRs are the source of truth for current work.
+
+## Product Strategy
+
+- **Policy**: Pollux is capability-transparent, not capability-equalizing.
+- Provider differences are allowed when clearly documented and surfaced via explicit errors.
+- Provider feature parity is a nice-to-have, not a v1.0 requirement.
+- New provider features do not require simultaneous implementation across all providers.
+
+## v1.0 (Release Gate)
+
+- Stable core API: `run`, `run_many`, `Config`, `Source`, `Options`, `ResultEnvelope`.
+- Correct multimodal behavior for supported provider + input combinations.
+- Clear capability boundaries with fail-fast errors for unsupported options.
+- Quality gates pass: `make test`, `make lint`, `make typecheck`.
+
+### Explicitly Out of Scope for v1.0
+
+- Feature-parity layers that mask provider differences (example: automatic YouTube download/re-upload for OpenAI).
+- Conversation continuity (`history`, `continue_from`).
+- Deferred delivery (`delivery_mode="deferred"`).
+
+## Post-1.0 Candidates
+
+- Conversation continuity with clear lifecycle semantics.
+- Optional lifecycle controls for provider-managed artifacts (for example, OpenAI uploaded files).
+- Expand/maintain the provider capability matrix as features evolve.
+- Selective parity adapters only when justified by user demand and maintenance cost.
+
+## References
+
+- Provider-by-provider contract: `docs/reference/provider-capabilities.md`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,10 +50,10 @@ Examples:
 
 ## Issues
 
-Issue templates exist for [bugs](https://github.com/seanbrar/pollux/issues/new?template=bug.md) and [feature requests](https://github.com/seanbrar/pollux/issues/new?template=feature.md). The templates carry most of the detail—here's the gist:
+Issue templates exist for [bugs](https://github.com/seanbrar/pollux/issues/new?template=bug.md) and [feature requests](https://github.com/seanbrar/pollux/issues/new?template=feature.md). Keep issues small and concrete. The templates carry most of the detail; at a glance:
 
-- **Bug reports**: what happened, expected behavior, reproduction steps, environment (Pollux + Python version)
-- **Feature requests**: problem or use case, optional suggested approach
+- **Bug reports**: what happened, expected behavior, reproduction steps, error output, environment (Pollux/Python/OS, provider + model if applicable)
+- **Feature requests**: problem or use case, optional proposed change, optional acceptance criteria / out of scope
 
 When a PR addresses an issue, link it in the **Related issue** section using closing keywords (`Closes #123`, `Fixes #456`).
 


### PR DESCRIPTION
## Summary

Refines the pre-v1.0 roadmap to be minimal and low-maintenance, and improves GitHub issue templates + contributing guidance to support clear, small issues.

## Related issue

None

## Test plan

- `make check`

## Notes

This PR intentionally keeps templates lightweight: it adds optional sections (error output, acceptance criteria, out-of-scope) without making them mandatory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes to GitHub templates, roadmap, and ignores; no runtime or API behavior changes.
> 
> **Overview**
> Tightens project process docs by adding a new `ROADMAP.md` that clearly defines v1.0 release gates, explicit out-of-scope items, and post-1.0 candidates.
> 
> Improves GitHub issue templates: bug reports now request optional error output, OS, provider/model, additional context, and acceptance criteria; feature requests add optional proposed change, acceptance criteria, out-of-scope, and notes. Updates `docs/contributing.md` to reflect the new issue template expectations, and extends `.gitignore` to exclude local scratch/artifact directories (e.g. `.claude/`, `.worktrees/`, `outputs/`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1178a149785ccc5100cf21aa4365ce66c6736f19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->