### PR TITLE
ci: add nightly schedule for API tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ name: Continuous Integration
   # Run on pull requests that target the main branch
   pull_request:
     branches: [main, "release/**"]
+  # Run API tests nightly to detect provider-side drift during quiet periods
+  schedule:
+    - cron: "0 8 * * *" # 8am UTC daily
 
 jobs:
   lint-workflows:
@@ -38,8 +41,8 @@ jobs:
 
   api-tests:
     # Run API tests exactly once to avoid exhausting shared free-tier quota.
-    # Run on PRs only to avoid quota burn on every branch push.
-    if: github.event_name == 'pull_request'
+    # Run on PRs and nightly schedule to detect provider-side drift.
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
     uses: ./.github/workflows/reusable-checks.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Adds a nightly scheduled run (8am UTC) for API tests to detect provider-side drift during quiet development periods. This acts as a safety net—if Gemini or OpenAI change their SDK behavior without warning, the scheduled run will surface it even when no PRs are active.

## Related issue

None

## Test plan

- **Verified YAML syntax:** `actionlint .github/workflows/ci.yml` passes with no errors
- **Reviewed trigger logic:** `schedule` event added correctly; `api-tests` job condition expanded to `github.event_name == 'pull_request' || github.event_name == 'schedule'`
- **No new tests added:** Non-behavioral change (CI configuration only). The scheduled workflow will verify itself on first nightly run.

## Notes

This PR is part of a broader strategy to handle Gemini free-tier rate limits:
1. **Primary fix:** Enable billing on GCP project (removes 250 RPD limit for ~$0.02/mo)
2. **Safety net:** This scheduled run catches provider drift during quiet periods

---

- [x] PR title follows [conventional commits](https://seanbrar.github.io/pollux/contributing/)
- [x] `make check` passes (CI will verify)
- [x] Tests cover the meaningful cases, not just the happy path (N/A - config change)
- [x] Docs updated (if this changes public API or user-facing behavior) (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/release workflow changes (including scheduled runs and PyPI publishing) can affect build cadence and deployment safety; changes are mostly infra/docs but touch release automation and live API-test execution.
> 
> **Overview**
> Adds a nightly scheduled CI run and reshapes the pipeline so **fast checks run in a Python-version matrix** while **live provider API tests run once** (on PRs + schedule) with injected `GEMINI_API_KEY`/`OPENAI_API_KEY` gated behind an `enable-api-tests` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb58950894c0ab2c7b8e3dc2cd3d86cc0b0ba2ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->