### PR TITLE
chore(tests): remove unused home config isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ check: lint typecheck test ## Run all checks (lint + typecheck + tests)
 test: ## Run all tests
 	$(PYTEST) $(PYTEST_ARGS)
 
-test-api: .check-api-key ## Run API tests (requires GEMINI_API_KEY)
-	$(PYTEST) $(PYTEST_ARGS) -m "api"
+test-api: .check-api-keys ## Run API tests (requires ENABLE_API_TESTS=1 + provider API key)
+	ENABLE_API_TESTS=1 $(PYTEST) $(PYTEST_ARGS) -m "api"
 
 # ------------------------------------------------------------------------------
 # Documentation
@@ -84,11 +84,17 @@ clean: ## Clean up all test and build artifacts
 # ------------------------------------------------------------------------------
 # Internal Checks
 # ------------------------------------------------------------------------------
-.PHONY: .check-api-key
+.PHONY: .check-api-keys
 
-.check-api-key:
-	@if [ -z "$$GEMINI_API_KEY" ]; then \
-		echo "ERROR: GEMINI_API_KEY is not set."; \
-		echo "Get a key from https://ai.dev/ and export the variable."; \
+.check-api-keys:
+	@if [ -z "$$GEMINI_API_KEY" ] && [ -z "$$OPENAI_API_KEY" ]; then \
+		echo "ERROR: no provider API key is set."; \
+		echo "Set GEMINI_API_KEY and/or OPENAI_API_KEY, then rerun."; \
 		exit 1; \
+	fi
+	@if [ -z "$$GEMINI_API_KEY" ]; then \
+		echo "NOTE: GEMINI_API_KEY is not set; Gemini API tests will be skipped."; \
+	fi
+	@if [ -z "$$OPENAI_API_KEY" ]; then \
+		echo "NOTE: OPENAI_API_KEY is not set; OpenAI API tests will be skipped."; \
 	fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,6 @@ markers = [
     # Fixture control (opt-out of default isolation)
     "allow_dotenv: Opt-in to load .env in a specific test",
     "allow_env_pollution: Opt-in to keep current env (no cleanup)",
-    "allow_real_home_config: Opt-in to use the real home config path",
 ]
 
 # --- Ruff ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,21 +139,6 @@ def isolate_provider_env(request, monkeypatch):
     monkeypatch.delenv("POLLUX_DEBUG_CONFIG", raising=False)
 
 
-@pytest.fixture(autouse=True)
-def neutral_home_config(request, monkeypatch, tmp_path):
-    """Point home-config path to an isolated temp file by default.
-
-    Opt-out: @pytest.mark.allow_real_home_config
-    """
-    if request.node.get_closest_marker("allow_real_home_config"):
-        return
-
-    fake_home_dir = tmp_path / "home_config_isolated"
-    fake_home_dir.mkdir(parents=True, exist_ok=True)
-    fake_home_file = fake_home_dir / "pollux.toml"
-    monkeypatch.setenv("POLLUX_CONFIG_HOME", str(fake_home_file))
-
-
 # =============================================================================
 # Logging
 # =============================================================================


### PR DESCRIPTION
## Summary
- Remove the unused autouse fixture that set `POLLUX_CONFIG_HOME`.
- Remove the corresponding unused pytest marker.
- Align `make test-api` with the documented double-gating: sets `ENABLE_API_TESTS=1` and requires at least one provider API key (prints skip notes otherwise).

## Related issue
None

## Test plan
- make check

## Notes
- No library behavior changes; this is test harness / developer workflow cleanup.
