### PR TITLE
test(core): extract hardcoded model names into shared constants and fixtures

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,61 +10,72 @@ from pollux.errors import ConfigurationError
 pytestmark = pytest.mark.unit
 
 
-def test_config_creation_with_mock_mode() -> None:
+def test_config_creation_with_mock_mode(gemini_model: str) -> None:
     """Config can be created with mock mode (no API key needed)."""
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=gemini_model, use_mock=True)
     assert cfg.provider == "gemini"
-    assert cfg.model == "gemini-2.0-flash"
+    assert cfg.model == gemini_model
 
 
 def test_config_auto_resolves_api_key_from_env(
     monkeypatch: pytest.MonkeyPatch,
+    gemini_model: str,
 ) -> None:
     """API key should be auto-resolved from environment."""
     monkeypatch.setenv("GEMINI_API_KEY", "env-key")
 
-    cfg = Config(provider="gemini", model="gemini-2.0-flash")
+    cfg = Config(provider="gemini", model=gemini_model)
 
     assert cfg.api_key == "env-key"
 
 
 def test_explicit_api_key_takes_precedence(
     monkeypatch: pytest.MonkeyPatch,
+    gemini_model: str,
 ) -> None:
     """Explicit api_key should override env."""
     monkeypatch.setenv("GEMINI_API_KEY", "env-key")
 
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", api_key="explicit-key")
+    cfg = Config(provider="gemini", model=gemini_model, api_key="explicit-key")
 
     assert cfg.api_key == "explicit-key"
 
 
-def test_openai_provider_uses_openai_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_openai_provider_uses_openai_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    openai_model: str,
+) -> None:
     """Provider-specific env key selection should prefer OPENAI_API_KEY."""
     monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
 
-    cfg = Config(provider="openai", model="gpt-5-nano")
+    cfg = Config(provider="openai", model=openai_model)
 
     assert cfg.provider == "openai"
     assert cfg.api_key == "openai-secret"
 
 
-def test_missing_api_key_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_missing_api_key_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+    gemini_model: str,
+) -> None:
     """Missing API key without mock mode must fail clearly."""
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
 
     with pytest.raises(ConfigurationError, match="API key required") as exc:
-        Config(provider="gemini", model="gemini-2.0-flash")
+        Config(provider="gemini", model=gemini_model)
     assert exc.value.hint is not None
     assert "GEMINI_API_KEY" in exc.value.hint
 
 
-def test_mock_mode_does_not_require_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_mock_mode_does_not_require_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    gemini_model: str,
+) -> None:
     """Mock mode should work without an API key."""
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
 
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=gemini_model, use_mock=True)
 
     assert cfg.use_mock is True
     assert cfg.api_key is None
@@ -76,10 +87,10 @@ def test_unknown_provider_raises_error() -> None:
         Config(provider="unknown", model="some-model", use_mock=True)  # type: ignore[arg-type]
 
 
-def test_config_str_and_repr_redact_api_key() -> None:
+def test_config_str_and_repr_redact_api_key(gemini_model: str) -> None:
     """String representations must not leak secrets."""
     secret = "top-secret-key"
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", api_key=secret)
+    cfg = Config(provider="gemini", model=gemini_model, api_key=secret)
 
     assert secret not in str(cfg)
     assert secret not in repr(cfg)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,7 +20,7 @@ from pollux.providers.base import ProviderCapabilities
 from pollux.request import normalize_request
 from pollux.retry import RetryPolicy
 from pollux.source import Source
-from tests.conftest import FakeProvider
+from tests.conftest import CACHE_MODEL, GEMINI_MODEL, OPENAI_MODEL, FakeProvider
 from tests.helpers import CaptureProvider as KwargsCaptureProvider
 from tests.helpers import GateProvider, ScriptedProvider
 
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.integration
 @pytest.mark.asyncio
 async def test_run_and_run_many_smoke() -> None:
     """Smoke: public API returns stable envelope shapes."""
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     with_source = await pollux.run(
         "Summarize this text",
@@ -72,7 +72,7 @@ async def test_run_and_run_many_smoke() -> None:
 
 def test_request_rejects_non_source_objects() -> None:
     """Source inputs must be explicit Source objects."""
-    config = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    config = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
     with pytest.raises(SourceError) as exc:
         normalize_request("hello", sources=["not-a-source"], config=config)  # type: ignore[list-item]
 
@@ -108,7 +108,7 @@ async def test_api_error_metadata(
 
     cfg = Config(
         provider="gemini",
-        model="gemini-2.0-flash",
+        model=GEMINI_MODEL,
         use_mock=True,
         retry=RetryPolicy(max_attempts=1),
     )
@@ -140,7 +140,7 @@ async def test_api_error_metadata(
 
     cfg = Config(
         provider="openai",
-        model="gpt-5-nano",
+        model=OPENAI_MODEL,
         use_mock=True,
         retry=RetryPolicy(max_attempts=1),
     )
@@ -173,7 +173,7 @@ async def test_api_error_metadata(
 
     cfg = Config(
         provider="gemini",
-        model="cache-model",
+        model=CACHE_MODEL,
         use_mock=True,
         enable_caching=True,
         retry=RetryPolicy(max_attempts=1),
@@ -223,7 +223,7 @@ async def test_provider_is_closed_on_success(monkeypatch: pytest.MonkeyPatch) ->
         ("generate fails + close fails", True, True),
     ]
 
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
     for name, fail_generate, fail_close in scenarios:
         fake = _Provider(fail_generate=fail_generate, fail_close=fail_close)
         monkeypatch.setattr(pollux, "_get_provider", lambda _config, _fake=fake: _fake)
@@ -305,7 +305,7 @@ async def test_retry_matrix(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> N
         monkeypatch.setattr(pollux, "_get_provider", lambda _config, _fake=fake: _fake)
         cfg = Config(
             provider="gemini",
-            model="gemini-2.0-flash",
+            model=GEMINI_MODEL,
             use_mock=True,
             retry=retry,
         )
@@ -368,7 +368,7 @@ async def test_cache_single_flight_propagates_failure_and_clears_inflight(
 
     cfg = Config(
         provider="gemini",
-        model="cache-model",
+        model=CACHE_MODEL,
         use_mock=True,
         enable_caching=True,
         retry=RetryPolicy(max_attempts=1),
@@ -411,7 +411,7 @@ async def test_file_placeholders_are_uploaded_before_generate(
     file_path = tmp_path / "doc.txt"
     file_path.write_text("hello")
 
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
     await pollux.run_many(
         ("Read this",), sources=(Source.from_file(file_path),), config=cfg
     )
@@ -437,7 +437,7 @@ async def test_upload_single_flight_propagates_failure_and_can_recover(
 
     cfg = Config(
         provider="gemini",
-        model="gemini-2.0-flash",
+        model=GEMINI_MODEL,
         use_mock=True,
         retry=RetryPolicy(max_attempts=1),
     )
@@ -516,7 +516,7 @@ async def test_cached_context_is_not_resent_on_each_call(
 
     cfg = Config(
         provider="gemini",
-        model="cache-model",
+        model=CACHE_MODEL,
         use_mock=True,
         enable_caching=True,
     )
@@ -533,7 +533,7 @@ async def test_cached_context_is_not_resent_on_each_call(
 
 def test_cache_identity_uses_content_digest_not_identifier_only() -> None:
     """Regression: cache identity keys must not collide across distinct sources."""
-    model = "gemini-2.0-flash"
+    model = GEMINI_MODEL
 
     # Same identifier, different content should not collide.
     same_id_a = Source.from_text("AAAA", identifier="same")
@@ -591,7 +591,7 @@ def test_source_from_arxiv_rejects_non_arxiv_urls() -> None:
 @pytest.mark.asyncio
 async def test_options_response_schema_requires_provider_capability() -> None:
     """Strict capability checks reject unsupported structured outputs."""
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
     with pytest.raises(ConfigurationError, match="structured outputs"):
         await pollux.run(
             "Extract fields",
@@ -620,7 +620,7 @@ async def test_options_are_forwarded_when_provider_supports_features(
         )
     )
     monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     await pollux.run_many(
         ("Q1?",),
@@ -658,7 +658,7 @@ async def test_delivery_mode_deferred_is_explicitly_not_implemented(
         )
     )
     monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     with pytest.raises(ConfigurationError, match="not implemented yet"):
         await pollux.run_many(
@@ -723,7 +723,7 @@ async def test_structured_output_returns_pydantic_instances(
 
     fake = _StructuredProvider()
     monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     result = await pollux.run(
         "Extract",
@@ -756,7 +756,7 @@ async def test_conversation_options_are_lifecycle_gated_by_default(
         )
     )
     monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     with pytest.raises(ConfigurationError, match="reserved for a future release"):
         await pollux.run_many(
@@ -794,7 +794,7 @@ async def test_continue_from_requires_conversation_state(
     )
     monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
     monkeypatch.setenv("POLLUX_EXPERIMENTAL_CONVERSATION", "1")
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     with pytest.raises(ConfigurationError, match="missing _conversation_state"):
         await pollux.run_many(
@@ -837,7 +837,7 @@ async def test_planning_error_wraps_source_loader_failure() -> None:
         content_loader=_boom,
     )
 
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
     with pytest.raises(PlanningError, match="Failed to load content"):
         await pollux.run_many(
             ("Q",),
@@ -877,7 +877,7 @@ async def test_result_status_classification(
     """Status classification should be stable across refactors."""
     fake = ScriptedProvider(script=list(script))
     monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     result = await pollux.run_many(("A", "B"), config=cfg)
 
@@ -913,7 +913,7 @@ async def test_structured_validation_failure_returns_none_in_structured_list(
         ],
     )
     monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
-    cfg = Config(provider="gemini", model="gemini-2.0-flash", use_mock=True)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     result = await pollux.run(
         "Extract",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -20,6 +20,7 @@ from pollux.errors import APIError
 from pollux.providers._errors import extract_retry_after_s, wrap_provider_error
 from pollux.providers.gemini import GeminiProvider
 from pollux.providers.openai import OpenAIProvider, _to_openai_strict_schema
+from tests.conftest import GEMINI_MODEL, OPENAI_MODEL
 
 pytestmark = pytest.mark.contract
 
@@ -187,7 +188,6 @@ def test_gemini_parse_response_extracts_text_and_usage() -> None:
     """Characterize extraction of text and usage from Gemini response."""
     provider = GeminiProvider("test-key")
 
-    # Simulate a typical Gemini SDK response object
     fake_usage = MagicMock()
     fake_usage.prompt_token_count = 10
     fake_usage.candidates_token_count = 25
@@ -213,7 +213,6 @@ def test_gemini_parse_response_extracts_structured_from_parsed() -> None:
     """Characterize structured output extraction when .parsed exists."""
     provider = GeminiProvider("test-key")
 
-    # Use spec to control which attributes exist
     fake_response = MagicMock(spec=["text", "parsed"])
     fake_response.text = '{"title": "Test", "score": 95}'
     fake_response.parsed = {"title": "Test", "score": 95}
@@ -259,7 +258,6 @@ def test_gemini_parse_response_handles_missing_attributes() -> None:
     """Characterize graceful handling of responses missing expected attrs."""
     provider = GeminiProvider("test-key")
 
-    # Minimal response with no .text attribute
     fake_response = MagicMock(spec=[])  # spec=[] means no attributes
 
     result = provider._parse_response(fake_response)
@@ -284,10 +282,8 @@ async def test_gemini_generate_characterizes_config_shape(golden: Any) -> None:
         captured["model"] = model
         captured["contents"] = contents
         captured["config"] = config
-        # Return minimal response
         return MagicMock(text="ok", parsed=None, usage_metadata=None)
 
-    # Create provider and inject fake client
     provider = GeminiProvider("test-key")
     fake_models = MagicMock()
     fake_models.generate_content = fake_generate_content
@@ -297,7 +293,7 @@ async def test_gemini_generate_characterizes_config_shape(golden: Any) -> None:
     provider._client.aio = fake_aio
 
     await provider.generate(
-        model="gemini-2.0-flash",
+        model=GEMINI_MODEL,
         parts=["What is 2+2?"],
         system_instruction="Be concise.",
         cache_name="cachedContents/abc123",
@@ -307,7 +303,7 @@ async def test_gemini_generate_characterizes_config_shape(golden: Any) -> None:
         },
     )
 
-    assert captured["model"] == "gemini-2.0-flash"
+    assert captured["model"] == GEMINI_MODEL
     assert golden.out["config"] == captured["config"]
 
 
@@ -328,7 +324,7 @@ async def test_gemini_generate_omits_config_when_no_options() -> None:
     provider._client = MagicMock()
     provider._client.aio = fake_aio
 
-    await provider.generate(model="gemini-2.0-flash", parts=["Hello"])
+    await provider.generate(model=GEMINI_MODEL, parts=["Hello"])
 
     assert captured["config"] is None
 
@@ -525,7 +521,7 @@ async def test_openai_generate_characterizes_multimodal_request_shape(
     provider._client = fake_client
 
     await provider.generate(
-        model="gpt-5-nano",
+        model=OPENAI_MODEL,
         parts=[
             "Summarize these assets.",
             {"uri": "https://example.com/report.pdf", "mime_type": "application/pdf"},
@@ -551,7 +547,7 @@ async def test_openai_rejects_unsupported_remote_mime_type() -> None:
 
     with pytest.raises(APIError, match="Unsupported remote mime type"):
         await provider.generate(
-            model="gpt-5-nano",
+            model=OPENAI_MODEL,
             parts=[{"uri": "https://example.com/video.mp4", "mime_type": "video/mp4"}],
         )
 


### PR DESCRIPTION
## Summary

Centralizes ~40 hardcoded model name strings across test files into shared constants (`GEMINI_MODEL`, `OPENAI_MODEL`, `CACHE_MODEL`) and pytest fixtures (`gemini_model`, `openai_model`, `cache_model`) in `conftest.py`. Also promotes private API-test model constants to public names and trims verbose section separators and redundant comments.

## Related issue

None

## Test plan

No new tests — this is a non-behavioral change (refactor of test infrastructure only). All existing tests pass unchanged:

```
make check   # lint + typecheck + 66 tests passed
```

## Notes

- Constants are used via direct import in `test_pipeline.py` and `test_providers.py` (which construct configs inline), while `test_config.py` uses the fixture form since its tests accept injected parameters.
- `_GEMINI_TEST_MODEL` / `_OPENAI_TEST_MODEL` renamed to `GEMINI_API_TEST_MODEL` / `OPENAI_API_TEST_MODEL` for consistency with the new public constants.

---

- [x] PR title follows [conventional commits](https://seanbrar.github.io/pollux/contributing/)
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [ ] Docs updated (if this changes public API or user-facing behavior) — N/A, test-only change