### PR TITLE
feat(core): add stdlib logging for pipeline observability

### DIFF
--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -10,6 +10,7 @@ Public API:
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 from pollux.cache import CacheRegistry
@@ -36,6 +37,11 @@ if TYPE_CHECKING:
     from pollux.providers.base import Provider
 
 __version__ = "0.9.0"
+
+# Library-level NullHandler: stay silent unless the consumer configures logging.
+logging.getLogger("pollux").addHandler(logging.NullHandler())
+
+logger = logging.getLogger(__name__)
 
 # Module-level cache registry for reuse across calls
 _registry = CacheRegistry()
@@ -112,7 +118,7 @@ async def run_many(
                 raise
             except Exception as exc:
                 # Cleanup should never mask the primary failure.
-                _ = exc
+                logger.warning("Provider cleanup failed: %s", exc)
 
     return build_result(plan, trace)
 

--- a/src/pollux/cache.py
+++ b/src/pollux/cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 import hashlib
+import logging
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,8 @@ from pollux.retry import RetryPolicy, retry_async, should_retry_side_effect
 if TYPE_CHECKING:
     from pollux.providers.base import Provider
     from pollux.source import Source
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -32,6 +35,7 @@ class CacheRegistry:
         name, expires_at = entry
         if time.time() >= expires_at:
             del self._entries[key]
+            logger.debug("Cache expired key=%s…", key[:8])
             return None
         return name
 
@@ -82,6 +86,7 @@ async def get_or_create_cache(
         return None
 
     async def _work() -> str:
+        logger.debug("Creating cache key=%s…", key[:8])
         if retry_policy is None or retry_policy.max_attempts <= 1:
             return await provider.create_cache(
                 model=model,

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+import logging
 import os
 from pathlib import Path
 import time
@@ -22,6 +23,8 @@ from pollux.retry import (
 if TYPE_CHECKING:
     from pollux.plan import Plan
     from pollux.providers.base import Provider
+
+logger = logging.getLogger(__name__)
 
 
 def _with_call_idx(err: APIError, call_idx: int | None) -> APIError:
@@ -199,6 +202,12 @@ async def execute_plan(
     # Execute calls with concurrency control
     concurrency = config.request_concurrency
     sem = asyncio.Semaphore(concurrency)
+    logger.debug(
+        "Executing %d call(s) concurrency=%d cache=%s",
+        len(prompts),
+        concurrency,
+        cache_name or "disabled",
+    )
 
     async def _execute_call(call_idx: int) -> dict[str, Any]:
         async with sem:

--- a/src/pollux/retry.py
+++ b/src/pollux/retry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+import logging
 import random
 import time
 from typing import TYPE_CHECKING, TypeVar
@@ -20,6 +21,8 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -171,6 +174,13 @@ async def retry_async(
                     raise
                 delay = min(delay, remaining)
 
+            logger.debug(
+                "Retrying after %s (attempt %d/%d, delay %.2fs)",
+                type(exc).__name__,
+                attempt,
+                policy.max_attempts,
+                delay,
+            )
             if delay > 0:
                 await asyncio.sleep(delay)
 


### PR DESCRIPTION
## Summary

Adds `logging` calls to the four highest-value sites in the pipeline — retries, cache lifecycle, execution plan, and swallowed provider cleanup errors. Silent by default via `NullHandler`; consumers opt in by configuring the `"pollux"` logger.

## Related issue

None

## Test plan

Boundary coverage — existing tests already exercise every instrumented path. `test_provider_is_closed_on_success` now visibly confirms the WARNING log for swallowed `aclose()` errors in its live output. No new tests needed: the logging calls are trivial delegation to stdlib `logging` and introduce no branching.

```
make check  # lint + typecheck + 66 tests pass
```

## Notes

- All DEBUG except the swallowed `aclose()` error (WARNING) — a consumer with INFO-level logging configured for their own app won't see Pollux noise.
- Cache keys are logged truncated (`key[:8]`) to avoid leaking full content hashes.
- Nullscope (structured telemetry) was evaluated and intentionally deferred — it's a better fit as an optional extra (`pollux[telemetry]`) post-v1.0 once real usage patterns validate the need for per-phase timing data.

---

- [x] PR title follows [conventional commits](https://seanbrar.github.io/pollux/contributing/)
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)