### PR TITLE
chore: README overhaul, dynamic version, domain migration, and docs alignment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 
 ---
 
-- [ ] PR title follows [conventional commits](https://seanbrar.github.io/pollux/contributing/)
+- [ ] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
 - [ ] `make check` passes
 - [ ] Tests cover the meaningful cases, not just the happy path
 - [ ] Docs updated (if this changes public API or user-facing behavior)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
       python-version: ${{ matrix.python-version }}
       test-command: make test
       enable-api-tests: false
-      upload-coverage: false
+      # Upload coverage from a single matrix entry to avoid duplicate Codecov reports.
+      upload-coverage: ${{ matrix.python-version == '3.13' }}
 
   api-tests:
     # Run API tests exactly once to avoid exhausting shared free-tier quota.

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -50,7 +50,12 @@ jobs:
           GEMINI_API_KEY: ${{ inputs.enable-api-tests && secrets.GEMINI_API_KEY || '' }}
           OPENAI_API_KEY: ${{ inputs.enable-api-tests && secrets.OPENAI_API_KEY || '' }}
           ENABLE_API_TESTS: ${{ inputs.enable-api-tests && '1' || '' }}
-        run: ${{ inputs.test-command }}
+        run: |
+          if [ "${{ inputs.upload-coverage }}" = "true" ]; then
+            ${{ inputs.test-command }} --cov=src/pollux --cov-report=xml
+          else
+            ${{ inputs.test-command }}
+          fi
 
       - name: Upload coverage to Codecov
         if: inputs.upload-coverage == true

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -52,7 +52,7 @@ jobs:
           ENABLE_API_TESTS: ${{ inputs.enable-api-tests && '1' || '' }}
         run: |
           if [ "${{ inputs.upload-coverage }}" = "true" ]; then
-            ${{ inputs.test-command }} --cov=src/pollux --cov-report=xml
+            make test-cov
           else
             ${{ inputs.test-command }}
           fi
@@ -62,4 +62,5 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
           fail_ci_if_error: false

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PYTEST_ARGS = -v
 # ------------------------------------------------------------------------------
 # Main Commands
 # ------------------------------------------------------------------------------
-.PHONY: help install-dev lint format typecheck check test test-api docs-serve docs-build demo-data clean-demo-data clean hooks
+.PHONY: help install-dev lint format typecheck check test test-cov test-api docs-serve docs-build demo-data clean-demo-data clean hooks
 .PHONY: mutmut
 
 help: ## Show this help message
@@ -48,6 +48,9 @@ check: lint typecheck test ## Run all checks (lint + typecheck + tests)
 
 test: ## Run all tests
 	$(PYTEST) $(PYTEST_ARGS) -m "not api"
+
+test-cov: ## Run tests with coverage (CI only)
+	$(PYTEST) $(PYTEST_ARGS) -m "not api" --cov=src/pollux --cov-report=xml
 
 test-api: .check-api-keys ## Run API tests (requires ENABLE_API_TESTS=1 + provider API key)
 	ENABLE_API_TESTS=1 $(PYTEST) $(PYTEST_ARGS) -m "api"

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+polluxlib.dev

--- a/docs/cookbook/getting-started/structured-output-extraction.md
+++ b/docs/cookbook/getting-started/structured-output-extraction.md
@@ -33,7 +33,7 @@ Real API (returns actual structured data):
 
 ```bash
 python -m cookbook getting-started/structured-output-extraction \
-  --input path/to/file.pdf --no-mock --provider openai --model gpt-4.1-mini
+  --input path/to/file.pdf --no-mock --provider openai --model gpt-5-nano
 ```
 
 ## What You'll See

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,11 @@ complexity — so you don't.
 
 ## Why Pollux?
 
-- **Multimodal-first** — PDFs, images, videos, YouTube URLs. Same API.
+- **Multimodal-first** — PDFs, images, video, YouTube URLs, and arXiv papers. Same API.
 - **Source patterns** — Fan-out, fan-in, and broadcast execution over your content.
 - **Context caching** — Upload once, reuse across prompts. Save tokens and money.
-- **Production-ready core** — Async pipeline, explicit capability checks, clear errors.
+- **Structured output** — Get typed responses via Pydantic schemas.
+- **Built for reliability** — Async execution, retries, concurrency control, and clear errors.
 
 ## Install
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -38,7 +38,7 @@
       </h1>
       <p class="pollux-hero__tagline">
         You describe what to analyze. Pollux handles source patterns,
-        context caching, rate limits, and retries&nbsp;&mdash;
+        context caching, and multimodal complexity&nbsp;&mdash;
         so you don&rsquo;t.
       </p>
       <div class="pollux-hero__actions">
@@ -66,7 +66,7 @@ result = await run(
     source=Source.from_file("paper.pdf"),
     config=Config(
         provider="gemini",
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash-lite",
     ),
 )
 print(result["answers"][0])</code></pre>
@@ -99,7 +99,7 @@ print(result["answers"][0])</code></pre>
         </p>
       </div>
       <div class="pollux-features__card">
-        <h2 class="pollux-features__title">Production-ready</h2>
+        <h2 class="pollux-features__title">Built for reliability</h2>
         <p class="pollux-features__desc">
           Async pipeline, retries with backoff,
           structured output, usage tracking.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Pollux
 repo_url: https://github.com/seanbrar/pollux
 repo_name: seanbrar/pollux
-site_url: https://seanbrar.github.io/pollux/
+site_url: https://polluxlib.dev/
 edit_uri: edit/main/docs/
 
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ exclude_lines = [
 [tool.coverage.html]
 directory = "coverage_html_report"
 
+[tool.coverage.xml]
+output = "coverage.xml"
+
 # --- MyPy ---
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/seanbrar/pollux"
+Homepage = "https://polluxlib.dev"
+Documentation = "https://polluxlib.dev"
 Repository = "https://github.com/seanbrar/pollux"
 Changelog = "https://github.com/seanbrar/pollux/blob/main/CHANGELOG.md"
 Issues = "https://github.com/seanbrar/pollux/issues"

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -36,7 +36,12 @@ from pollux.source import Source
 if TYPE_CHECKING:
     from pollux.providers.base import Provider
 
-__version__ = "0.9.0"
+try:
+    from importlib.metadata import PackageNotFoundError, version
+
+    __version__ = version("pollux-ai")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 
 # Library-level NullHandler: stay silent unless the consumer configures logging.
 logging.getLogger("pollux").addHandler(logging.NullHandler())

--- a/uv.lock
+++ b/uv.lock
@@ -1388,7 +1388,7 @@ wheels = [
 
 [[package]]
 name = "pollux-ai"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },


### PR DESCRIPTION
## Summary

Rewrites the README to showcase multi-provider support, structured output, YouTube/arXiv sources, and stronger feature messaging. Migrates all doc URLs from `seanbrar.github.io/pollux` to `polluxlib.dev`, replaces the hardcoded `__version__` with `importlib.metadata`, and aligns the docs homepage/index vocabulary with the new README.

## Related issue

None

## Test plan

**Non-behavioral change** — docs, config URLs, and version metadata only. No library logic changed.

- `make check` passes (lint, typecheck, 66 tests): all green
- `python -c "from pollux import __version__; print(__version__)"` → `1.0.0rc2` (confirms `importlib.metadata` resolution)
- Verified `docs/CNAME` contains `polluxlib.dev` for GitHub Pages custom domain

## Notes

- `__version__` uses `version("pollux-ai")` (the PyPI distribution name), not `__name__` (which resolves to `pollux`, the import name). Falls back to `"0.0.0+unknown"` if the package isn't installed.
- Codecov upload is now gated to a single matrix entry (Python 3.13) to avoid duplicate reports.
- Homepage tagline, feature card titles, and model names in docs were aligned with README to eliminate presentation discrepancies.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)