### PR TITLE
chore(ci): disable Codecov status targets

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,14 +3,8 @@
 
 coverage:
   status:
-    project:
-      default:
-        target: 80%
-        threshold: 2%
-    patch:
-      default:
-        target: 70%
-        threshold: 5%
+    project: off
+    patch: off
 
 comment:
   layout: "reach,diff,flags,tree"


### PR DESCRIPTION
## Summary

Removes enforced coverage thresholds (80% project, 70% patch) from `codecov.yml`, keeping Codecov as a diagnostic-only tool. Aligns CI configuration with the project's MTMT testing philosophy, which treats coverage as a signal, not a gate.

## Related issue

None — prompted by reviewing alignment between CI tooling and testing philosophy.

## Test plan

**Non-behavioral change.** This only affects Codecov's status check behavior, not test execution. CI will continue to collect and upload coverage; Codecov will continue posting PR comments and updating the badge — it just won't post pass/fail status checks.