### PR TITLE
feat(api): add system_instruction and conversation continuity

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,14 +115,18 @@ is longer: the computed backoff or the server hint).
 from pollux import Options
 
 options = Options(
+    system_instruction="You are a concise analyst.",  # Optional global behavior guide
     response_schema=MyPydanticModel,  # Structured output extraction
     reasoning_effort="medium",        # Reserved for future provider support
-    delivery_mode="realtime",         # "deferred" reserved for v1.1+
+    delivery_mode="realtime",         # "deferred" reserved for future provider batch APIs
 )
 ```
 
 See [Sources and Patterns](sources-and-patterns.md#structured-output) for
 a complete structured output example.
+
+Conversation options are provider-dependent in v1.1: OpenAI supports
+`history`/`continue_from`; Gemini remains unsupported.
 
 ## Safety Notes
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -20,6 +20,7 @@
     .md-footer {
       margin-left: 0 !important;
       margin-right: 0 !important;
+      max-width: none !important;
       padding-inline: 0;
     }
   </style>

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -1,16 +1,16 @@
 # Provider Capabilities
 
-This page defines the v1.0 capability contract by provider.
+This page defines the v1.1 capability contract by provider.
 
 Pollux is **capability-transparent**, not capability-equalizing: providers are allowed to differ, and those differences are surfaced clearly.
 
-## v1.0 Policy
+## v1.1 Policy
 
 - Provider feature parity is **not** required for release.
 - Unsupported features must fail fast with clear errors.
 - New provider features do not require immediate cross-provider implementation.
 
-## Capability Matrix (v1.0)
+## Capability Matrix (v1.1)
 
 | Capability | Gemini | OpenAI | Notes |
 |---|---|---|---|
@@ -19,20 +19,20 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Local file inputs | ✅ | ✅ | OpenAI uses Files API upload |
 | PDF URL inputs | ✅ (via URI part) | ✅ (native `input_file.file_url`) | |
 | Image URL inputs | ✅ (via URI part) | ✅ (native `input_image.image_url`) | |
-| YouTube URL inputs | ✅ | ⚠️ limited | OpenAI parity layer (download/re-upload) is out of scope for v1.0 |
+| YouTube URL inputs | ✅ | ⚠️ limited | OpenAI parity layer (download/re-upload) is out of scope for v1.1 |
 | Provider-side context caching | ✅ | ❌ | OpenAI provider returns unsupported for caching |
 | Structured outputs (`response_schema`) | ✅ | ✅ | JSON-schema path in both providers |
 | Reasoning controls (`reasoning_effort`) | ❌ | ❌ | Reserved for future provider enablement |
-| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | Explicitly disabled in v1.0 |
-| Conversation continuity (`history`, `continue_from`) | ❌ | ❌ | Reserved/disabled in v1.0 |
+| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | Explicitly disabled in v1.1 |
+| Conversation continuity (`history`, `continue_from`) | ❌ | ✅ | OpenAI-native continuation; single prompt per call |
 
 ## Important OpenAI Notes
 
 - Pollux uploads local files with:
   - `purpose="user_data"`
   - finite `expires_after` metadata
-- Automatic file deletion is not part of v1.0 yet.
-- Remote URL support in v1.0 is intentionally narrow and explicit:
+- Automatic file deletion is not part of v1.1 yet.
+- Remote URL support in v1.1 is intentionally narrow and explicit:
   - PDFs
   - images
 
@@ -48,7 +48,7 @@ from pollux import Config
 config = Config(
     provider="openai",
     model="gpt-5-nano",
-    enable_caching=True,  # not supported for OpenAI in v1.0
+    enable_caching=True,  # not supported for OpenAI in v1.1
 )
 # At execution time, Pollux raises:
 # ConfigurationError: Provider does not support caching

--- a/docs/sources-and-patterns.md
+++ b/docs/sources-and-patterns.md
@@ -165,10 +165,10 @@ Example of a complete envelope:
 }
 ```
 
-## v1.0 Notes
+## v1.1 Notes
 
-- Conversation continuity (`history`, `continue_from`) is reserved and
-  disabled in v1.0.
-- `delivery_mode="deferred"` is reserved and disabled in v1.0.
+- Conversation continuity (`history`, `continue_from`) is currently
+  OpenAI-only and supports one prompt per call.
+- `delivery_mode="deferred"` remains reserved and disabled.
 - Provider feature support varies. See
   [Provider Capabilities](reference/provider-capabilities.md).

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -11,7 +11,7 @@
   --pollux-sidebar-bottom-space: 1.25rem;
   --pollux-nav-gutter: 0.25rem;
   --pollux-nav-indent: 0.45rem;
-  --pollux-nav-link-margin-top: 0.5em;
+  --pollux-nav-link-margin-top: 0.35em;
   --pollux-toc-link-size: 0.72rem;
   --pollux-toc-link-line-height: 1.45;
   --pollux-toc-link-padding-y: 0.18rem;
@@ -122,6 +122,7 @@ body {
 /* ── Navigation links ────────────────────────────────────────── */
 
 .md-nav__item--section > .md-nav__link {
+  font-size: 0.7rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -288,6 +289,17 @@ body {
   .md-nav--primary .md-nav__link {
     margin-top: var(--pollux-nav-link-margin-top);
     padding: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .md-nav__item--section {
+    margin-top: 0.75em;
+  }
+
+  .md-nav__item--section:first-child {
+    margin-top: 0;
   }
 
   /* Boosted-specificity active link: .md-nav--primary prefix matches
@@ -341,8 +353,11 @@ body {
     font-size: var(--pollux-toc-link-size);
     line-height: var(--pollux-toc-link-line-height);
     margin-top: 0;
+    overflow: hidden;
     padding-block: var(--pollux-toc-link-padding-y);
     position: relative;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .md-nav--secondary .md-nav__link--active::before {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,8 +34,9 @@ Use this order — most failures resolve by step 2.
    provider. Re-run a minimal prompt after fixing any mismatch.
 
 3. **Unsupported feature** — Compare your options against
-   [Provider Capabilities](reference/provider-capabilities.md). In v1.0,
-   `delivery_mode="deferred"`, `history`, and `continue_from` are reserved.
+   [Provider Capabilities](reference/provider-capabilities.md).
+   `delivery_mode="deferred"` is reserved; conversation continuity is
+   provider-dependent (OpenAI-only in v1.1).
 
 4. **Source and payload** — Reduce to one source + one prompt and retry.
    For OpenAI remote URLs in v1.0, only PDF and image URLs are supported.
@@ -61,12 +62,13 @@ Or pass `api_key` directly in `Config(...)`.
 
 **Fix:** verify the model belongs to the selected provider.
 
-## Option Not Implemented in v1.0
+## Option Not Implemented Yet
 
 **Symptom:** `ConfigurationError` mentioning `delivery_mode="deferred"`,
 `history`, or `continue_from`.
 
-These are intentionally reserved and disabled in v1.0.
+`delivery_mode="deferred"` is intentionally reserved.
+`history`/`continue_from` require a provider with conversation support.
 
 ## `status == "partial"`
 

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -21,6 +21,8 @@ ResponseSchemaInput = type[BaseModel] | dict[str, Any]
 class Options:
     """Optional execution features for `run()` and `run_many()`."""
 
+    #: Optional system-level instruction for model behavior.
+    system_instruction: str | None = None
     #: Pydantic ``BaseModel`` subclass or JSON Schema dict for structured output.
     response_schema: ResponseSchemaInput | None = None
     #: Reserved — not yet wired in v1.0.
@@ -34,6 +36,14 @@ class Options:
 
     def __post_init__(self) -> None:
         """Validate option shapes early for clear errors."""
+        if self.system_instruction is not None and not isinstance(
+            self.system_instruction, str
+        ):
+            raise ConfigurationError(
+                "system_instruction must be a string",
+                hint="Pass system_instruction='You are a concise assistant.'",
+            )
+
         if self.response_schema is not None and not (
             isinstance(self.response_schema, dict)
             or (

--- a/src/pollux/plan.py
+++ b/src/pollux/plan.py
@@ -43,7 +43,11 @@ def build_plan(request: Request) -> Plan:
     if use_cache:
         from pollux.cache import compute_cache_key
 
-        cache_key = compute_cache_key(config.model, sources)
+        cache_key = compute_cache_key(
+            config.model,
+            sources,
+            system_instruction=request.options.system_instruction,
+        )
 
     return Plan(
         request=request,

--- a/src/pollux/result.py
+++ b/src/pollux/result.py
@@ -87,6 +87,8 @@ def build_result(plan: Plan, trace: ExecutionTrace) -> ResultEnvelope:
     )
     if wants_structured:
         envelope["structured"] = structured_values
+    if trace.conversation_state is not None:
+        envelope["_conversation_state"] = trace.conversation_state
     return envelope
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,9 +63,10 @@ class FakeProvider:
         delivery_mode: str = "realtime",
         previous_response_id: str | None = None,
     ) -> dict[str, Any]:
-        del model, system_instruction, cache_name
+        del model, cache_name
         self.last_parts = parts
         self.last_generate_kwargs = {
+            "system_instruction": system_instruction,
             "response_schema": response_schema,
             "reasoning_effort": reasoning_effort,
             "history": history,


### PR DESCRIPTION
## Summary

Adds a global `system_instruction` configuration option and implements conversation continuity (`history` and `continue_from`) specifically for the OpenAI provider in v1.1.

## Related issue

None

## Test plan

I have verified these changes locally using the project's verification suite.
- **Architectural Guarantee / Boundary Coverage:** Added new E2E API logic in `tests/test_api.py` testing the system instructions and roundtripping of the conversation state.
- **Trivial Delegation:** Ensured OpenAI parameters are accurately mapped and routed to the OpenAI Responses API (`tests/test_providers.py`).
- **Integration:** Ran `make check` locally, confirming 100% pass rate for Ruff format/linting, MyPy type checks, and 71 Pytest test cases.

## Notes

- `delivery_mode="deferred"` remains intentionally reserved.
- Conversation continuity is currently OpenAI-only, as Gemini is not yet supported for this feature in Pollux. The provider capability matrix has been updated to reflect this explicitly.