### PR TITLE
feat(api): add tool-call transparency in conversation history

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,13 +228,20 @@ async def main():
             "content": output,
         })
 
+    # Append tool outputs to the saved conversation state
+    continued = dict(result)
+    state = dict(continued.get("_conversation_state", {}))
+    state_history = list(state.get("history", []))
+    state["history"] = [*state_history, *tool_results]
+    continued["_conversation_state"] = state
+
     # Turn 2: feed tool results back via continue_from
     result2 = await run(
         "Now summarize the weather.",
         config=config,
         options=Options(
             tools=tools,
-            continue_from=result,
+            continue_from=continued,
         ),
     )
     print(result2["answers"][0])

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,12 +136,115 @@ options = Options(
 | `response_schema` | `type[BaseModel] \| dict` | `None` | Expected JSON response format |
 | `reasoning_effort` | `str \| None` | `None` | Reserved for future o1/o3 support |
 | `delivery_mode` | `str` | `"realtime"` | Reserved for future batch delivery |
+| `history` | `list[dict] \| None` | `None` | Conversation history; mutually exclusive with `continue_from` |
+| `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result; mutually exclusive with `history` |
 
 See [Sources and Patterns](sources-and-patterns.md#structured-output) for
 a complete structured output example.
 
+### Conversation Continuity
+
+Pollux supports multi-turn conversations via `history` and `continue_from`.
+Both are mutually exclusive — use one per call.
+
+- **`history`**: Pass an explicit list of message dicts. Each item must have
+  a string `role` field. Regular messages include `content`; tool messages
+  may include `tool_call_id`, `tool_calls`, and other keys.
+- **`continue_from`**: Pass a prior `ResultEnvelope` returned by `run()` or
+  `run_many()`. Pollux extracts the conversation state automatically.
+
+Conversation continuity requires a provider with conversation support
+(currently OpenAI only) and exactly one prompt per call.
+
+### Tool Calling
+
+Pollux passes tool definitions to providers and surfaces tool call responses
+in the result envelope.
+
+**Defining tools** — pass a list of tool schemas in `Options.tools`:
+
+```python
+options = Options(
+    tools=[
+        {
+            "name": "get_weather",
+            "description": "Get weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+            },
+        }
+    ],
+    tool_choice="auto",  # "auto", "required", "none", or {"name": "..."}
+)
+```
+
+**Reading tool calls** — when the model invokes tools, the result envelope
+includes a `tool_calls` field:
+
+```python
+result = await pollux.run("What's the weather in NYC?", config=cfg, options=options)
+
+if "tool_calls" in result:
+    for call in result["tool_calls"][0]:  # per-prompt list
+        print(call["name"], call["arguments"])
+```
+
+### Tool-Call Loop Pattern
+
+Pollux is a single-turn orchestration layer — it does not execute tools or
+manage multi-turn loops. Your code owns the loop:
+
+```python
+import asyncio, json
+from pollux import Config, Options, run
+
+config = Config(provider="openai", model="gpt-5-nano")
+tools = [{"name": "get_weather", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}}}]
+
+async def main():
+    # Turn 1: initial request with tools
+    result = await run(
+        "What's the weather in NYC?",
+        config=config,
+        options=Options(tools=tools, tool_choice="auto"),
+    )
+
+    if "tool_calls" not in result:
+        print(result["answers"][0])
+        return
+
+    # Extract tool calls from the result
+    tool_calls = result["tool_calls"][0]
+
+    # Execute tools (your code)
+    tool_results = []
+    for tc in tool_calls:
+        # ... call your actual tool implementation ...
+        output = json.dumps({"temp": 72, "unit": "F"})
+        tool_results.append({
+            "role": "tool",
+            "tool_call_id": tc["id"],
+            "content": output,
+        })
+
+    # Turn 2: feed tool results back via continue_from
+    result2 = await run(
+        "Now summarize the weather.",
+        config=config,
+        options=Options(
+            tools=tools,
+            continue_from=result,
+        ),
+    )
+    print(result2["answers"][0])
+
+asyncio.run(main())
+```
+
 Conversation options are provider-dependent: OpenAI supports
-`history`/`continue_from`; Gemini conversation support is not yet available.
+`history`/`continue_from` with tool messages; Gemini conversation
+support is not yet available.
 
 ## Safety Notes
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -24,7 +24,9 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Structured outputs (`response_schema`) | ✅ | ✅ | JSON-schema path in both providers |
 | Reasoning controls (`reasoning_effort`) | ❌ | ❌ | Reserved for future provider enablement |
 | Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | Explicitly disabled in v1.1 |
-| Conversation continuity (`history`, `continue_from`) | ❌ | ✅ | OpenAI-native continuation; single prompt per call |
+| Tool calling | ✅ | ✅ | Tool definitions via `Options.tools`; results in `ResultEnvelope.tool_calls` |
+| Tool message pass-through in history | ❌ | ✅ | OpenAI maps tool messages to `function_call`/`function_call_output` items |
+| Conversation continuity (`history`, `continue_from`) | ❌ | ✅ | OpenAI-native continuation; single prompt per call; supports tool messages |
 
 ## Important OpenAI Notes
 

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -123,7 +123,7 @@ async def execute_plan(
     schema = options.response_schema_json()
 
     history = options.history
-    conversation_history: list[dict[str, str]] = []
+    conversation_history: list[dict[str, Any]] = []
     if history is not None:
         conversation_history = [dict(item) for item in history]
 
@@ -144,9 +144,7 @@ async def execute_plan(
             conversation_history = [
                 item
                 for item in state_history
-                if isinstance(item, dict)
-                and isinstance(item.get("role"), str)
-                and isinstance(item.get("content"), str)
+                if isinstance(item, dict) and isinstance(item.get("role"), str)
             ]
 
         if history is None:
@@ -310,10 +308,14 @@ async def execute_plan(
         prompt = prompts[0] if isinstance(prompts[0], str) else str(prompts[0])
         answer = responses[0].get("text")
         reply = answer if isinstance(answer, str) else ""
-        updated_history: list[dict[str, str]] = [
+        assistant_msg: dict[str, Any] = {"role": "assistant", "content": reply}
+        tool_calls = responses[0].get("tool_calls")
+        if tool_calls:
+            assistant_msg["tool_calls"] = tool_calls
+        updated_history: list[dict[str, Any]] = [
             *conversation_history,
             {"role": "user", "content": prompt},
-            {"role": "assistant", "content": reply},
+            assistant_msg,
         ]
         conversation_state = {"history": updated_history}
         response_id = responses[0].get("response_id")

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -39,7 +39,7 @@ class Options:
     #: ``"deferred"`` is reserved for future provider batch APIs.
     delivery_mode: DeliveryMode = "realtime"
     #: Mutually exclusive with *continue_from*.
-    history: list[dict[str, str]] | None = None
+    history: list[dict[str, Any]] | None = None
     #: Mutually exclusive with *history*.
     continue_from: ResultEnvelope | None = None
 
@@ -77,14 +77,14 @@ class Options:
                     hint="Pass history=[{'role': 'user', 'content': '...'}].",
                 )
             for item in self.history:
-                if (
-                    not isinstance(item, dict)
-                    or not isinstance(item.get("role"), str)
-                    or not isinstance(item.get("content"), str)
-                ):
+                if not isinstance(item, dict) or not isinstance(item.get("role"), str):
                     raise ConfigurationError(
-                        "history items must be dicts with string 'role' and 'content'",
-                        hint="Pass history=[{'role': 'user', 'content': '...'}].",
+                        "history items must be dicts with a string 'role' field",
+                        hint=(
+                            "Each item needs at least {'role': 'user', ...}. "
+                            "Tool messages may omit 'content' or include extra "
+                            "keys like 'tool_call_id'."
+                        ),
                     )
         if self.continue_from is not None and not isinstance(self.continue_from, dict):
             raise ConfigurationError(

--- a/src/pollux/providers/base.py
+++ b/src/pollux/providers/base.py
@@ -38,7 +38,7 @@ class Provider(Protocol):
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Literal["auto", "required", "none"] | dict[str, Any] | None = None,
         reasoning_effort: str | None = None,
-        history: list[dict[str, str]] | None = None,
+        history: list[dict[str, Any]] | None = None,
         delivery_mode: str = "realtime",
         previous_response_id: str | None = None,
     ) -> dict[str, Any]:

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -103,7 +103,7 @@ class GeminiProvider:
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Literal["auto", "required", "none"] | dict[str, Any] | None = None,
         reasoning_effort: str | None = None,
-        history: list[dict[str, str]] | None = None,
+        history: list[dict[str, Any]] | None = None,
         delivery_mode: str = "realtime",
         previous_response_id: str | None = None,
     ) -> dict[str, Any]:

--- a/src/pollux/providers/mock.py
+++ b/src/pollux/providers/mock.py
@@ -51,7 +51,7 @@ class MockProvider:
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Literal["auto", "required", "none"] | dict[str, Any] | None = None,
         reasoning_effort: str | None = None,
-        history: list[dict[str, str]] | None = None,
+        history: list[dict[str, Any]] | None = None,
         delivery_mode: str = "realtime",
         previous_response_id: str | None = None,
     ) -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ class FakeProvider:
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Any | None = None,
         reasoning_effort: str | None = None,
-        history: list[dict[str, str]] | None = None,
+        history: list[dict[str, Any]] | None = None,
         delivery_mode: str = "realtime",
         previous_response_id: str | None = None,
     ) -> dict[str, Any]:

--- a/tests/test_options_params.py
+++ b/tests/test_options_params.py
@@ -39,3 +39,14 @@ async def test_mock_generate_with_options() -> None:
     result = await run("Hello world!", config=config, options=opts)
     # Mock just returns the prompt but shouldn't crash
     assert "echo: Hello world!" in result["answers"][0]
+
+
+def test_history_with_none_content_accepted() -> None:
+    """Assistant messages with content: None pass validation (tool-call pattern)."""
+    opts = Options(
+        history=[
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "call_1"}]},
+        ]
+    )
+    assert opts.history is not None
+    assert opts.history[0]["content"] is None

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -718,7 +718,9 @@ async def test_openai_preserves_assistant_text_with_tool_calls() -> None:
             {
                 "role": "assistant",
                 "content": "Let me check that tool.",
-                "tool_calls": [{"id": "call_abc", "name": "get_weather", "arguments": "{}"}],
+                "tool_calls": [
+                    {"id": "call_abc", "name": "get_weather", "arguments": "{}"}
+                ],
             }
         ],
     )

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -638,3 +638,65 @@ async def test_openai_upload_characterization(golden: Any, tmp_path: Any) -> Non
     # Don't characterize the local file object itself; only stable kwargs.
     normalized = {k: v for k, v in files.last_kwargs.items() if k != "file"}
     assert expected_files_create == normalized
+
+
+# =============================================================================
+# OpenAI Tool History Mapping (Characterization)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_openai_maps_tool_history_to_responses_api_format() -> None:
+    """Tool messages in history should map to function_call/function_call_output."""
+    responses = _FakeResponses()
+    fake_client = type("Client", (), {"responses": responses})()
+
+    provider = OpenAIProvider("test-key")
+    provider._client = fake_client
+
+    await provider.generate(
+        model=OPENAI_MODEL,
+        parts=["Continue the conversation"],
+        history=[
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_abc",
+                        "name": "get_weather",
+                        "arguments": '{"location": "NYC"}',
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_abc",
+                "content": '{"temp": 72}',
+            },
+        ],
+    )
+
+    assert responses.last_kwargs is not None
+    input_msgs = responses.last_kwargs["input"]
+
+    # First: regular user message
+    assert input_msgs[0]["role"] == "user"
+    assert input_msgs[0]["content"] == [
+        {"type": "input_text", "text": "What's the weather?"}
+    ]
+
+    # Second: function_call from assistant tool_calls
+    assert input_msgs[1]["type"] == "function_call"
+    assert input_msgs[1]["call_id"] == "call_abc"
+    assert input_msgs[1]["name"] == "get_weather"
+    assert input_msgs[1]["arguments"] == '{"location": "NYC"}'
+
+    # Third: function_call_output from tool message
+    assert input_msgs[2]["type"] == "function_call_output"
+    assert input_msgs[2]["call_id"] == "call_abc"
+    assert input_msgs[2]["output"] == '{"temp": 72}'
+
+    # Fourth: the current user message
+    assert input_msgs[3]["role"] == "user"


### PR DESCRIPTION
## Summary

Makes Pollux a faithful pass-through for tool messages in conversation history, enabling downstream projects to build their own tool-call loops. Widens `history` type, relaxes validation, preserves tool_calls in state, and maps tool history to OpenAI Responses API format.

## Related issue

None

## Test plan

- `make check` passes (lint + typecheck + 80 tests)
- 6 new tests across 3 files:
  - `test_history_accepts_tool_messages` — tool-shaped messages pass validation
  - `test_history_still_rejects_items_without_role` — missing role still errors
  - `test_tool_calls_preserved_in_conversation_state` — state builder includes tool_calls
  - `test_continue_from_preserves_tool_history_items` — tool messages survive continue_from
  - `test_openai_maps_tool_history_to_responses_api_format` — characterization of OpenAI mapping
  - `test_history_with_none_content_accepted` — None content passes validation

## Notes

Stacked on #116. All changes are strictly additive/permissive — no existing valid input becomes invalid.