### PR TITLE
feat(api): add Gemini conversation support and tool message pass-through

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,7 +154,7 @@ Both are mutually exclusive — use one per call.
   `run_many()`. Pollux extracts the conversation state automatically.
 
 Conversation continuity requires a provider with conversation support
-(currently OpenAI only) and exactly one prompt per call.
+(Gemini and OpenAI) and exactly one prompt per call.
 
 ### Tool Calling
 
@@ -249,9 +249,10 @@ async def main():
 asyncio.run(main())
 ```
 
-Conversation options are provider-dependent: OpenAI supports
-`history`/`continue_from` with tool messages; Gemini conversation
-support is not yet available.
+Conversation options are supported by both Gemini and OpenAI. Both
+providers support tool messages in history. See
+[Provider Capabilities](reference/provider-capabilities.md) for
+provider-specific details.
 
 ## Safety Notes
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -1,16 +1,16 @@
 # Provider Capabilities
 
-This page defines the v1.1 capability contract by provider.
+This page defines the v1.2 capability contract by provider.
 
 Pollux is **capability-transparent**, not capability-equalizing: providers are allowed to differ, and those differences are surfaced clearly.
 
-## v1.1 Policy
+## Policy
 
 - Provider feature parity is **not** required for release.
 - Unsupported features must fail fast with clear errors.
 - New provider features do not require immediate cross-provider implementation.
 
-## Capability Matrix (v1.1)
+## Capability Matrix (v1.2)
 
 | Capability | Gemini | OpenAI | Notes |
 |---|---|---|---|
@@ -19,24 +19,34 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Local file inputs | ✅ | ✅ | OpenAI uses Files API upload |
 | PDF URL inputs | ✅ (via URI part) | ✅ (native `input_file.file_url`) | |
 | Image URL inputs | ✅ (via URI part) | ✅ (native `input_image.image_url`) | |
-| YouTube URL inputs | ✅ | ⚠️ limited | OpenAI parity layer (download/re-upload) is out of scope for v1.1 |
+| YouTube URL inputs | ✅ | ⚠️ limited | OpenAI parity layer (download/re-upload) is out of scope |
 | Provider-side context caching | ✅ | ❌ | OpenAI provider returns unsupported for caching |
 | Structured outputs (`response_schema`) | ✅ | ✅ | JSON-schema path in both providers |
 | Reasoning controls (`reasoning_effort`) | ❌ | ❌ | Reserved for future provider enablement |
-| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | Explicitly disabled in v1.1 |
+| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | Explicitly disabled |
 | Tool calling | ✅ | ✅ | Tool definitions via `Options.tools`; results in `ResultEnvelope.tool_calls` |
-| Tool message pass-through in history | ❌ | ✅ | OpenAI maps tool messages to `function_call`/`function_call_output` items |
-| Conversation continuity (`history`, `continue_from`) | ❌ | ✅ | OpenAI-native continuation; single prompt per call; supports tool messages |
+| Tool message pass-through in history | ✅ | ✅ | Gemini maps to `Content`/`Part` types; OpenAI maps to `function_call`/`function_call_output` |
+| Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | Single prompt per call; supports tool messages in history |
 
-## Important OpenAI Notes
+## Provider-Specific Notes
 
-- Pollux uploads local files with:
-  - `purpose="user_data"`
-  - finite `expires_after` metadata
-- Automatic file deletion is not part of v1.1 yet.
-- Remote URL support in v1.1 is intentionally narrow and explicit:
-  - PDFs
-  - images
+### Gemini
+
+- Context caching uses the Gemini Files API and `cachedContents`.
+- Conversation history is translated to `Content` objects with
+  `Part.from_function_call` / `Part.from_function_response` for tool turns.
+- Gemini does not support `previous_response_id`; conversation state is
+  carried entirely via `history`.
+
+### OpenAI
+
+- File uploads use `purpose="user_data"` with finite `expires_after` metadata.
+  Automatic file deletion is not yet managed by Pollux.
+- Remote URL support is intentionally narrow: PDFs and images only.
+- Conversation can use either explicit `history` or `previous_response_id`
+  (via `continue_from`). When `previous_response_id` is set, only tool
+  result messages are forwarded from history; the rest is handled
+  server-side by OpenAI.
 
 ## Error Semantics
 
@@ -50,7 +60,7 @@ from pollux import Config
 config = Config(
     provider="openai",
     model="gpt-5-nano",
-    enable_caching=True,  # not supported for OpenAI in v1.1
+    enable_caching=True,  # not supported for OpenAI
 )
 # At execution time, Pollux raises:
 # ConfigurationError: Provider does not support caching

--- a/docs/sources-and-patterns.md
+++ b/docs/sources-and-patterns.md
@@ -165,10 +165,10 @@ Example of a complete envelope:
 }
 ```
 
-## v1.1 Notes
+## Notes
 
-- Conversation continuity (`history`, `continue_from`) is currently
-  OpenAI-only and supports one prompt per call.
+- Conversation continuity (`history`, `continue_from`) supports one
+  prompt per call. Both Gemini and OpenAI support tool messages in history.
 - `delivery_mode="deferred"` remains reserved and disabled.
 - Provider feature support varies. See
   [Provider Capabilities](reference/provider-capabilities.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,8 +35,8 @@ Use this order — most failures resolve by step 2.
 
 3. **Unsupported feature** — Compare your options against
    [Provider Capabilities](reference/provider-capabilities.md).
-   `delivery_mode="deferred"` is reserved; conversation continuity is
-   provider-dependent (OpenAI-only in v1.1).
+   `delivery_mode="deferred"` is reserved. Conversation continuity
+   and tool calling are supported by both Gemini and OpenAI.
 
 4. **Source and payload** — Reduce to one source + one prompt and retry.
    For OpenAI remote URLs in v1.0, only PDF and image URLs are supported.


### PR DESCRIPTION
## Summary

Enable conversation continuity on the Gemini provider, bringing it to parity with OpenAI for multi-turn tool-call workflows. History items are translated to Gemini SDK `Content`/`Part` types (`from_function_call`, `from_function_response`). The no-history code path is left unchanged to avoid behavioral regression on existing calls.

Docs updated to reflect v1.2 capability matrix across all four affected pages.

## Related issue

None — follows from #117 (tool-call transparency) as the natural next step for provider parity.

## Test plan

- **New**: `test_gemini_maps_tool_history_to_content_format` — characterization test verifying the exact `Content`/`Part` structure sent to `generate_content` when history contains user, assistant+tool_calls, and tool result messages.
- **Existing**: All 84 non-API tests pass (`make test`). Lint and typecheck clean.
- **Boundary coverage (MTMT)**: The docs-only changes and signature-only changes (conversation=True flip) are covered by the new characterization test which exercises the full history→Content translation path.

## Notes

- The `custom` tool type handling (`t.get("type") == "custom"`) that was in a draft was removed — that's a separate feature if needed.
- The `contents` construction is split: no-history calls use the original `self._convert_parts(parts)` flat path; history calls use `Content`-wrapped objects. This avoids changing the payload shape for every Gemini call.
- Gemini has no equivalent to OpenAI's `previous_response_id`; conversation state is carried entirely via `history`.