### PR TITLE
chore(core): v1.2 hardening — validation, upload cleanup, dead code removal

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,11 @@ options = Options(
 | `history` | `list[dict] \| None` | `None` | Conversation history; mutually exclusive with `continue_from` |
 | `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result; mutually exclusive with `history` |
 
+!!! note
+    OpenAI GPT-5 family models (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`) reject
+    sampling controls like `temperature` and `top_p` with provider errors.
+    Older OpenAI models (for example `gpt-4.1-nano`) still accept them.
+
 See [Sources and Patterns](sources-and-patterns.md#structured-output) for
 a complete structured output example.
 
@@ -194,8 +199,10 @@ Token usage includes `reasoning_tokens` when the provider reports them.
 
 !!! note
     Pollux passes `reasoning_effort` through to the provider as-is.
-    Models that use a different thinking interface (e.g. Gemini 2.5's
-    `thinking_budget`) will return a provider error — see
+    Gemini support is currently practical on Gemini 3 models (for example
+    `gemini-3-flash-preview`) where `reasoning_effort` maps to
+    `thinking_level`. Gemini 2.x models use different controls (for example
+    `thinking_budget`) and will return a provider error — see
     [Provider Capabilities](reference/provider-capabilities.md) for details.
 
 ### Tool Calling

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -38,24 +38,28 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 - Gemini does not support `previous_response_id`; conversation state is
   carried entirely via `history`.
 - Reasoning: `reasoning_effort` maps to `ThinkingConfig(thinking_level=...)`.
-  Full thinking text is returned in `ResultEnvelope.reasoning`. Gemini 2.5
-  models use a different control (`thinking_budget`) and will return a
+  Full thinking text is returned in `ResultEnvelope.reasoning`. This maps
+  cleanly on Gemini 3 models (for example `gemini-3-flash-preview`). Gemini
+  2.x models use a different control (`thinking_budget`) and will return a
   provider error if `reasoning_effort` is set.
 
 ### OpenAI
 
 - File uploads use `purpose="user_data"` with finite `expires_after` metadata.
-  Automatic file deletion is not yet managed by Pollux.
+  Pollux performs best-effort cleanup of uploaded files after execution.
 - Remote URL support is intentionally narrow: PDFs and images only.
 - Conversation can use either explicit `history` or `previous_response_id`
   (via `continue_from`). When `previous_response_id` is set, only tool
   result messages are forwarded from history; the rest is handled
   server-side by OpenAI.
+- Sampling controls are model-specific: GPT-5 family models currently reject
+  `temperature` and `top_p`, while older models (for example `gpt-4.1-nano`)
+  accept them.
 - Reasoning: `reasoning_effort` maps to `reasoning.effort` with automatic
   `summary: "auto"` to request reasoning summaries. Summaries appear in
   `ResultEnvelope.reasoning`; raw reasoning traces are not exposed by OpenAI.
   Reasoning token counts may appear in `ResultEnvelope.usage["reasoning_tokens"]`
-  when OpenAI returns them.
+  when OpenAI returns them. Some older models reject `reasoning.effort`.
 
 ## Error Semantics
 

--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -55,6 +55,16 @@ class Config:
             )
 
         # Validate numeric fields
+        if not isinstance(self.request_concurrency, int):
+            raise ConfigurationError(
+                f"request_concurrency must be an integer, got {type(self.request_concurrency).__name__}",
+                hint="Pass a whole number ≥ 1 for request_concurrency.",
+            )
+        if not isinstance(self.ttl_seconds, int):
+            raise ConfigurationError(
+                f"ttl_seconds must be an integer, got {type(self.ttl_seconds).__name__}",
+                hint="Pass a whole number ≥ 0 for ttl_seconds.",
+            )
         if self.request_concurrency < 1:
             raise ConfigurationError(
                 f"request_concurrency must be ≥ 1, got {self.request_concurrency}",

--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -54,6 +54,18 @@ class Config:
                 hint="Supported providers: 'gemini', 'openai'",
             )
 
+        # Validate numeric fields
+        if self.request_concurrency < 1:
+            raise ConfigurationError(
+                f"request_concurrency must be ≥ 1, got {self.request_concurrency}",
+                hint="This controls how many API calls run in parallel.",
+            )
+        if self.ttl_seconds < 0:
+            raise ConfigurationError(
+                f"ttl_seconds must be ≥ 0, got {self.ttl_seconds}",
+                hint="This controls the cache time-to-live in seconds (0 disables caching TTL).",
+            )
+
         # Auto-resolve API key from environment if not provided
         if self.api_key is None and not self.use_mock:
             env_var = _API_KEY_ENV_VARS[self.provider]

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -157,175 +157,178 @@ async def execute_plan(
     upload_inflight: dict[tuple[str, str], asyncio.Future[str]] = {}
     upload_lock = asyncio.Lock()
     retry_policy = config.retry
+    cache_name: str | None = None
+    responses: list[dict[str, Any]] = []
+    total_usage: dict[str, int] = {}
+    conversation_state: dict[str, Any] | None = None
 
-    # Handle caching
-    cache_name = None
-    if plan.use_cache:
-        # Resolve uploads for shared parts first, as cache creation requires URIs
-        shared_parts = list(plan.shared_parts)
-        if shared_parts:
-            shared_parts = await _substitute_upload_parts(
-                shared_parts,
-                provider=provider,
-                call_idx=None,
-                upload_cache=upload_cache,
-                upload_inflight=upload_inflight,
-                upload_lock=upload_lock,
-                retry_policy=retry_policy,
-            )
-
-        if plan.cache_key:
-            try:
-                cache_name = await get_or_create_cache(
-                    provider,
-                    registry,
-                    key=plan.cache_key,
-                    model=config.model,
-                    parts=shared_parts,  # Use resolved parts with URIs
-                    system_instruction=options.system_instruction,
-                    ttl_seconds=config.ttl_seconds,
-                    retry_policy=retry_policy,
-                )
-            except asyncio.CancelledError:
-                raise
-            except PolluxError:
-                raise
-            except Exception as e:
-                raise InternalError(
-                    f"Cache creation failed: {type(e).__name__}: {e}",
-                    hint="This is a Pollux internal error. Please report it.",
-                ) from e
-
-    # Execute calls with concurrency control
-    concurrency = config.request_concurrency
-    sem = asyncio.Semaphore(concurrency)
-    logger.debug(
-        "Executing %d call(s) concurrency=%d cache=%s",
-        len(prompts),
-        concurrency,
-        cache_name or "disabled",
-    )
-
-    async def _execute_call(call_idx: int) -> dict[str, Any]:
-        async with sem:
-            try:
-                # Build parts: shared context + prompt
-                shared_parts = [] if cache_name is not None else list(plan.shared_parts)
-                raw_parts = [*shared_parts, prompts[call_idx]]
-                parts = await _substitute_upload_parts(
-                    raw_parts,
+    try:
+        # Handle caching
+        if plan.use_cache:
+            # Resolve uploads for shared parts first, as cache creation requires URIs
+            shared_parts = list(plan.shared_parts)
+            if shared_parts:
+                shared_parts = await _substitute_upload_parts(
+                    shared_parts,
                     provider=provider,
-                    call_idx=call_idx,
+                    call_idx=None,
                     upload_cache=upload_cache,
                     upload_inflight=upload_inflight,
                     upload_lock=upload_lock,
                     retry_policy=retry_policy,
                 )
 
-                if retry_policy.max_attempts <= 1:
-                    return await provider.generate(
-                        model=model,
-                        parts=parts,
+            if plan.cache_key:
+                try:
+                    cache_name = await get_or_create_cache(
+                        provider,
+                        registry,
+                        key=plan.cache_key,
+                        model=config.model,
+                        parts=shared_parts,  # Use resolved parts with URIs
                         system_instruction=options.system_instruction,
-                        cache_name=cache_name,
-                        response_schema=schema,
-                        temperature=options.temperature,
-                        top_p=options.top_p,
-                        tools=options.tools,
-                        tool_choice=options.tool_choice,
-                        reasoning_effort=options.reasoning_effort,
-                        history=history,
-                        delivery_mode=options.delivery_mode,
-                        previous_response_id=previous_response_id,
+                        ttl_seconds=config.ttl_seconds,
+                        retry_policy=retry_policy,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except PolluxError:
+                    raise
+                except Exception as e:
+                    raise InternalError(
+                        f"Cache creation failed: {type(e).__name__}: {e}",
+                        hint="This is a Pollux internal error. Please report it.",
+                    ) from e
+
+        # Execute calls with concurrency control
+        concurrency = config.request_concurrency
+        sem = asyncio.Semaphore(concurrency)
+        logger.debug(
+            "Executing %d call(s) concurrency=%d cache=%s",
+            len(prompts),
+            concurrency,
+            cache_name or "disabled",
+        )
+
+        async def _execute_call(call_idx: int) -> dict[str, Any]:
+            async with sem:
+                try:
+                    # Build parts: shared context + prompt
+                    shared_parts = (
+                        [] if cache_name is not None else list(plan.shared_parts)
+                    )
+                    raw_parts = [*shared_parts, prompts[call_idx]]
+                    parts = await _substitute_upload_parts(
+                        raw_parts,
+                        provider=provider,
+                        call_idx=call_idx,
+                        upload_cache=upload_cache,
+                        upload_inflight=upload_inflight,
+                        upload_lock=upload_lock,
+                        retry_policy=retry_policy,
                     )
 
-                return await retry_async(
-                    lambda: provider.generate(
-                        model=model,
-                        parts=parts,
-                        system_instruction=options.system_instruction,
-                        cache_name=cache_name,
-                        response_schema=schema,
-                        temperature=options.temperature,
-                        top_p=options.top_p,
-                        tools=options.tools,
-                        tool_choice=options.tool_choice,
-                        reasoning_effort=options.reasoning_effort,
-                        history=history,
-                        delivery_mode=options.delivery_mode,
-                        previous_response_id=previous_response_id,
-                    ),
-                    policy=retry_policy,
-                    should_retry=should_retry_generate,
-                )
-            except asyncio.CancelledError:
-                raise
-            except APIError as e:
-                if e.call_idx is None:
-                    e.call_idx = call_idx
-                raise
-            except PolluxError:
-                raise
-            except Exception as e:
+                    if retry_policy.max_attempts <= 1:
+                        return await provider.generate(
+                            model=model,
+                            parts=parts,
+                            system_instruction=options.system_instruction,
+                            cache_name=cache_name,
+                            response_schema=schema,
+                            temperature=options.temperature,
+                            top_p=options.top_p,
+                            tools=options.tools,
+                            tool_choice=options.tool_choice,
+                            reasoning_effort=options.reasoning_effort,
+                            history=history,
+                            delivery_mode=options.delivery_mode,
+                            previous_response_id=previous_response_id,
+                        )
+
+                    return await retry_async(
+                        lambda: provider.generate(
+                            model=model,
+                            parts=parts,
+                            system_instruction=options.system_instruction,
+                            cache_name=cache_name,
+                            response_schema=schema,
+                            temperature=options.temperature,
+                            top_p=options.top_p,
+                            tools=options.tools,
+                            tool_choice=options.tool_choice,
+                            reasoning_effort=options.reasoning_effort,
+                            history=history,
+                            delivery_mode=options.delivery_mode,
+                            previous_response_id=previous_response_id,
+                        ),
+                        policy=retry_policy,
+                        should_retry=should_retry_generate,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except APIError as e:
+                    if e.call_idx is None:
+                        e.call_idx = call_idx
+                    raise
+                except PolluxError:
+                    raise
+                except Exception as e:
+                    raise InternalError(
+                        f"Call {call_idx} failed: {type(e).__name__}: {e}",
+                        hint="This is a Pollux internal error. Please report it.",
+                    ) from e
+
+        # Execute all calls. We intentionally collect *all* task outcomes before
+        # raising so failures don't leave background tasks with unobserved
+        # exceptions.
+        tasks = [asyncio.create_task(_execute_call(i)) for i in range(len(prompts))]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for item in results:
+            if isinstance(item, asyncio.CancelledError):
+                raise item
+            if isinstance(item, BaseException):
+                # Deterministic: prefer lowest call index, not "first to fail".
+                raise item
+
+        for item in results:
+            if not isinstance(item, dict):
                 raise InternalError(
-                    f"Call {call_idx} failed: {type(e).__name__}: {e}",
-                    hint="This is a Pollux internal error. Please report it.",
-                ) from e
+                    f"Provider returned invalid response type: {type(item).__name__}",
+                    hint="Providers must return dict payloads with at least a 'text' field.",
+                )
+            responses.append(item)
 
-    # Execute all calls. We intentionally collect *all* task outcomes before
-    # raising so failures don't leave background tasks with unobserved
-    # exceptions.
-    tasks = [asyncio.create_task(_execute_call(i)) for i in range(len(prompts))]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    for item in results:
-        if isinstance(item, asyncio.CancelledError):
-            raise item
-        if isinstance(item, BaseException):
-            # Deterministic: prefer lowest call index, not "first to fail".
-            raise item
+        # Aggregate usage
+        for resp in responses:
+            usage = resp.get("usage", {})
+            for k, v in usage.items():
+                if isinstance(v, int):
+                    total_usage[k] = total_usage.get(k, 0) + v
 
-    responses: list[dict[str, Any]] = []
-    for item in results:
-        if not isinstance(item, dict):
-            raise InternalError(
-                f"Provider returned invalid response type: {type(item).__name__}",
-                hint="Providers must return dict payloads with at least a 'text' field.",
-            )
-        responses.append(item)
-
-    # Aggregate usage
-    total_usage: dict[str, int] = {}
-    for resp in responses:
-        usage = resp.get("usage", {})
-        for k, v in usage.items():
-            if isinstance(v, int):
-                total_usage[k] = total_usage.get(k, 0) + v
+        if wants_conversation and responses:
+            prompt = prompts[0] if isinstance(prompts[0], str) else str(prompts[0])
+            answer = responses[0].get("text")
+            reply = answer if isinstance(answer, str) else ""
+            assistant_msg: dict[str, Any] = {"role": "assistant", "content": reply}
+            tool_calls = responses[0].get("tool_calls")
+            if tool_calls:
+                assistant_msg["tool_calls"] = tool_calls
+            updated_history: list[dict[str, Any]] = [
+                *conversation_history,
+                {"role": "user", "content": prompt},
+                assistant_msg,
+            ]
+            conversation_state = {"history": updated_history}
+            response_id = responses[0].get("response_id")
+            if isinstance(response_id, str):
+                conversation_state["response_id"] = response_id
+            elif previous_response_id is not None:
+                conversation_state["response_id"] = previous_response_id
+    finally:
+        # Clean up uploaded files (best-effort; server-side TTL is the backstop).
+        await _cleanup_uploads(upload_cache, provider)
 
     duration_s = time.perf_counter() - start_time
-
-    conversation_state: dict[str, Any] | None = None
-    if wants_conversation and responses:
-        prompt = prompts[0] if isinstance(prompts[0], str) else str(prompts[0])
-        answer = responses[0].get("text")
-        reply = answer if isinstance(answer, str) else ""
-        assistant_msg: dict[str, Any] = {"role": "assistant", "content": reply}
-        tool_calls = responses[0].get("tool_calls")
-        if tool_calls:
-            assistant_msg["tool_calls"] = tool_calls
-        updated_history: list[dict[str, Any]] = [
-            *conversation_history,
-            {"role": "user", "content": prompt},
-            assistant_msg,
-        ]
-        conversation_state = {"history": updated_history}
-        response_id = responses[0].get("response_id")
-        if isinstance(response_id, str):
-            conversation_state["response_id"] = response_id
-        elif previous_response_id is not None:
-            conversation_state["response_id"] = previous_response_id
-
-    # Clean up uploaded files (best-effort; server-side TTL is the backstop)
-    await _cleanup_uploads(upload_cache, provider)
 
     return ExecutionTrace(
         responses=responses,

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -169,9 +169,7 @@ class OpenAIProvider:
         if tools is not None:
             create_kwargs["tools"] = []
             for t in tools:
-                if t.get("type") == "custom":
-                    create_kwargs["tools"].append(t)
-                elif "name" in t:
+                if "name" in t:
                     tool_def: dict[str, Any] = {
                         "type": "function",
                         "name": t["name"],
@@ -247,14 +245,6 @@ class OpenAIProvider:
                             "id": getattr(item, "call_id", None),
                             "name": getattr(item, "name", None),
                             "arguments": getattr(item, "arguments", None),
-                        }
-                    )
-                elif item_type == "custom_tool_call":
-                    tool_calls.append(
-                        {
-                            "id": getattr(item, "call_id", None),
-                            "name": getattr(item, "name", None),
-                            "arguments": getattr(item, "input", None),
                         }
                     )
                 elif item_type == "reasoning":

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -322,6 +322,11 @@ class OpenAIProvider:
         _ = model, parts, system_instruction, ttl_seconds
         raise APIError("OpenAI provider does not support context caching")
 
+    async def delete_file(self, file_id: str) -> None:
+        """Delete a previously uploaded file from OpenAI storage."""
+        client = self._get_client()
+        await client.files.delete(file_id)
+
     async def aclose(self) -> None:
         """Close underlying async client resources."""
         client = self._client

--- a/src/pollux/request.py
+++ b/src/pollux/request.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from pollux.errors import SourceError
+from pollux.errors import ConfigurationError, SourceError
 from pollux.options import Options
 from pollux.source import Source
 
@@ -46,6 +46,15 @@ def normalize_request(
     """
     # Normalize prompts to tuple
     prompts = (prompts,) if isinstance(prompts, str) else tuple(prompts)
+
+    # Validate prompts (empty list is a valid no-op for run_many)
+    for i, p in enumerate(prompts):
+        if not isinstance(p, str) or not p.strip():
+            idx_label = f"prompts[{i}]" if len(prompts) > 1 else "prompt"
+            raise ConfigurationError(
+                f"{idx_label} is empty or whitespace-only",
+                hint="Each prompt must be a non-empty string.",
+            )
 
     # Validate sources
     source_tuple = tuple(sources)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,10 +106,34 @@ def test_negative_request_concurrency_raises_clear_error(gemini_model: str) -> N
     assert exc.value.hint is not None
 
 
+def test_non_integer_request_concurrency_raises_clear_error(gemini_model: str) -> None:
+    """Non-integer concurrency should raise ConfigurationError, not TypeError."""
+    with pytest.raises(ConfigurationError, match="must be an integer") as exc:
+        Config(
+            provider="gemini",
+            model=gemini_model,
+            use_mock=True,
+            request_concurrency="2",  # type: ignore[arg-type]
+        )
+    assert exc.value.hint is not None
+
+
 def test_negative_ttl_seconds_raises_clear_error(gemini_model: str) -> None:
     """Negative TTL is nonsensical; must fail at construction."""
     with pytest.raises(ConfigurationError, match="ttl_seconds must be") as exc:
         Config(provider="gemini", model=gemini_model, use_mock=True, ttl_seconds=-1)
+    assert exc.value.hint is not None
+
+
+def test_non_integer_ttl_seconds_raises_clear_error(gemini_model: str) -> None:
+    """Non-integer TTL should raise ConfigurationError, not TypeError."""
+    with pytest.raises(ConfigurationError, match="must be an integer") as exc:
+        Config(
+            provider="gemini",
+            model=gemini_model,
+            use_mock=True,
+            ttl_seconds="3600",  # type: ignore[arg-type]
+        )
     assert exc.value.hint is not None
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,6 +87,38 @@ def test_unknown_provider_raises_error() -> None:
         Config(provider="unknown", model="some-model", use_mock=True)  # type: ignore[arg-type]
 
 
+def test_zero_request_concurrency_raises_clear_error(gemini_model: str) -> None:
+    """request_concurrency=0 would hang the pipeline; must fail at construction."""
+    with pytest.raises(ConfigurationError, match="request_concurrency must be") as exc:
+        Config(
+            provider="gemini", model=gemini_model, use_mock=True, request_concurrency=0
+        )
+    assert exc.value.hint is not None
+    assert "parallel" in exc.value.hint
+
+
+def test_negative_request_concurrency_raises_clear_error(gemini_model: str) -> None:
+    """Negative concurrency is always a caller mistake."""
+    with pytest.raises(ConfigurationError, match="request_concurrency must be") as exc:
+        Config(
+            provider="gemini", model=gemini_model, use_mock=True, request_concurrency=-1
+        )
+    assert exc.value.hint is not None
+
+
+def test_negative_ttl_seconds_raises_clear_error(gemini_model: str) -> None:
+    """Negative TTL is nonsensical; must fail at construction."""
+    with pytest.raises(ConfigurationError, match="ttl_seconds must be") as exc:
+        Config(provider="gemini", model=gemini_model, use_mock=True, ttl_seconds=-1)
+    assert exc.value.hint is not None
+
+
+def test_zero_ttl_seconds_is_allowed(gemini_model: str) -> None:
+    """ttl_seconds=0 is valid (disables caching TTL)."""
+    cfg = Config(provider="gemini", model=gemini_model, use_mock=True, ttl_seconds=0)
+    assert cfg.ttl_seconds == 0
+
+
 def test_config_str_and_repr_redact_api_key(gemini_model: str) -> None:
     """String representations must not leak secrets."""
     secret = "top-secret-key"


### PR DESCRIPTION
## Summary

Three targeted hardening changes for v1.2, scoped to fail-fast validation, resource cleanup, and dead code removal.

- **Fail-fast input validation**: Reject empty/whitespace-only prompts at normalization time and invalid `Config` numeric fields (`request_concurrency < 1`, `ttl_seconds < 0`) at construction time — all with actionable `ConfigurationError` hints. `run_many(prompts=[])` remains a valid no-op.
- **OpenAI upload lifecycle cleanup**: Delete provider-managed uploaded files (`openai://file/...`) after pipeline completion. Best-effort with debug logging; the 24-hour server-side TTL remains the backstop. Providers without `delete_file` (Gemini, Mock) skip cleanup silently.
- **Remove untested custom tool passthrough**: Delete the `type=="custom"` tool definition passthrough and `custom_tool_call` response parser from the OpenAI provider. Both branches were untested, undocumented, and not part of the public contract.

## Related issue

None — these are brainstormed v1.2 hardening items from roadmap review.

## Test plan

12 new tests across `test_config.py` and `test_pipeline.py`:

**Input validation** (8 tests):
- `request_concurrency=0` and `-1` both raise `ConfigurationError` with hint (`test_config.py`)
- `ttl_seconds=-1` raises; `ttl_seconds=0` is accepted (`test_config.py`)
- Empty string, whitespace-only, and per-index identification in batches all raise (`test_pipeline.py`)
- Empty prompt list `[]` remains a valid no-op (`test_pipeline.py`)

**Upload lifecycle** (4 tests):
- `openai://file/...` URIs trigger `delete_file` after pipeline completion (`test_pipeline.py`)
- `openai://text/...` URIs (inline, no server artifact) are not cleaned up (`test_pipeline.py`)
- Failed deletion is swallowed (logged, not raised) (`test_pipeline.py`)
- Providers without `delete_file` skip cleanup silently (`test_pipeline.py`)

**Custom tool removal**: No new tests — this is dead code removal (non-behavioral change for any tested path).

```
make check   # 108 passed, 10 deselected (API tests)
```

## Notes

- **Gemini reasoning compatibility** (the fourth v1.2 candidate) was assessed and scoped to docs-only — `reasoning_effort` maps correctly for Gemini 3 models, and Gemini 2.5 users who set it get a clear provider error consistent with the "capability-transparent" policy. Documentation will be addressed in a dedicated docs pass.
- Custom tool support can be re-added with proper tests and docs if downstream demand materializes.
- Upload cleanup is always-on with no opt-out flag. The alternative (an `Options` field) was considered unnecessary given the 24-hour TTL backstop and the fact that cross-call file reuse isn't supported today.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [ ] Docs updated (if this changes public API or user-facing behavior) — deferred to dedicated docs pass