### PR TITLE
fix(core): populate conversation state for tool-call responses

### DIFF
--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -364,7 +364,11 @@ async def execute_plan(
                 if isinstance(v, int):
                     total_usage[k] = total_usage.get(k, 0) + v
 
-        if wants_conversation and responses:
+        # Build conversation state when either (a) the caller opted in via
+        # history/continue_from, or (b) the response contains tool calls that
+        # the caller may need to continue via continue_tool/continue_from.
+        has_tool_calls = bool(responses and responses[0].get("tool_calls"))
+        if (wants_conversation or has_tool_calls) and responses:
             prompt = (
                 prompts[0]
                 if isinstance(prompts[0], str)


### PR DESCRIPTION
## Summary

`run()` with tools but without `history`/`continue_from` never populated `_conversation_state`, making `continue_tool` and `continue_from` unusable after an initial tool-call response. The execution layer now builds conversation state whenever the response contains tool calls, regardless of whether the caller explicitly opted into conversation support.

## Related issue

None

## Test plan

New test `test_tool_call_response_populates_conversation_state_without_history` verifies that:
- `_conversation_state` is present in the result envelope when `run()` returns tool calls (even without `history`/`continue_from`)
- The state contains the correct assistant message with `tool_calls`
- The `response_id` is preserved in the state
- The `tool_calls` field is populated in the envelope

## Notes

The root cause was the `wants_conversation` guard which only checked for explicit `history` or `continue_from` options. The fix widens the guard to also trigger when the first response contains tool calls. This is the minimal change; conversation state is still *not* built for responses without tool calls unless the caller opts in, keeping the default envelope lightweight.

---

- [x] PR title follows conventional commits
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [ ] Docs updated (if this changes public API or user-facing behavior)