### PR TITLE
fix(core): normalize tool parameter schemas per-provider

### DIFF
--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -172,12 +172,13 @@ class OpenAIProvider:
                     }
                     if "description" in t:
                         tool_def["description"] = t["description"]
+                    strict = t.get("strict", True)
                     if "parameters" in t:
-                        tool_def["parameters"] = t["parameters"]
-                    if "strict" in t:
-                        tool_def["strict"] = t["strict"]
-                    else:
-                        tool_def["strict"] = True
+                        params = t["parameters"]
+                        if strict and isinstance(params, dict):
+                            params = _to_openai_strict_schema(params)
+                        tool_def["parameters"] = params
+                    tool_def["strict"] = strict
                     create_kwargs["tools"].append(tool_def)
             if tool_choice is not None:
                 if isinstance(tool_choice, str):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -150,18 +150,15 @@ async def test_live_tool_calls_conversation_and_reasoning_roundtrip(
         api_key_fixture=api_key_fixture,
         model_fixture=model_fixture,
     )
-    parameters: dict[str, Any] = {
-        "type": "object",
-        "properties": {"topic": {"type": "string"}},
-        "required": ["topic"],
-    }
-    if provider == "openai":
-        parameters["additionalProperties"] = False
     tools = [
         {
             "name": "get_secret",
             "description": "Return a code for a given topic.",
-            "parameters": parameters,
+            "parameters": {
+                "type": "object",
+                "properties": {"topic": {"type": "string"}},
+                "required": ["topic"],
+            },
         },
     ]
 


### PR DESCRIPTION
## Summary

OpenAI with `strict: true` (the Pollux default) requires `additionalProperties: false` and `required` in tool parameter schemas. Gemini rejects `additionalProperties` entirely. Previously callers had to branch on provider to build compatible schemas. Now Pollux normalizes schemas at the provider boundary: OpenAI gets strict-compliance applied automatically, and Gemini gets the unsupported field stripped.

## Related issue

None 

## Test plan

**Provider-level tests** (3 new in `test_providers.py`):
- `test_openai_normalizes_tool_parameters_for_strict_mode`: verifies `additionalProperties: false` and `required` are added to tool params when strict is true
- `test_openai_skips_normalization_when_strict_is_false`: verifies normalization is skipped when the caller explicitly sets `strict: false`
- `test_gemini_strips_additional_properties_from_tool_schemas`: verifies `additionalProperties` is removed from tool params before passing to Gemini SDK

**API test cleanup**: Removed the provider-conditional `additionalProperties` workaround from `test_api.py` — the test now uses a single schema for both providers and passes against live APIs.

## Notes

The OpenAI normalization reuses the existing `_to_openai_strict_schema` function (already used for `response_schema`). The Gemini normalization is a new `_strip_additional_properties` helper that recursively removes the field via deep copy to avoid mutating the caller's schema dict.

The `strict` opt-out is preserved: callers who set `strict: false` on a tool definition bypass normalization entirely.

---

- [x] PR title follows conventional commits
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [ ] Docs updated (if this changes public API or user-facing behavior) 