### PR TITLE
chore(ci): sync uv.lock in release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-      # No uv sync needed; we build distributions later in this job.
+      # uv is used by build_command to update uv.lock and build distributions.
 
       # Main release step using PSR action
       - name: Create and Publish Release
@@ -60,12 +60,8 @@ jobs:
           prerelease_token: ${{ startsWith(github.ref, 'refs/heads/release/') && 'rc' || '' }}
           # Optional manual override for first major/prerelease cutovers.
           force: ${{ inputs.force }}
-          # Build distributions on the runner (with uv) after versioning/tagging.
-          build: false
-
-      - name: Build distributions
-        if: steps.release.outputs.released == 'true' && !inputs.dry_run
-        run: uv build
+          # Build distributions via build_command (also stages uv.lock into the release commit).
+          build: true
 
       - name: Publish to GitHub Release
         if: steps.release.outputs.released == 'true' && !inputs.dry_run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,11 @@ pytest_add_cli_args = [
 # --- Semantic Release ---
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-build_command = "uv build"
+build_command = """
+    uv lock --upgrade-package "$PACKAGE_NAME"
+    git add uv.lock
+    uv build
+"""
 tag_format = "v{version}"
 allow_zero_version = true
 major_on_zero = true

--- a/uv.lock
+++ b/uv.lock
@@ -1388,7 +1388,7 @@ wheels = [
 
 [[package]]
 name = "pollux-ai"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },


### PR DESCRIPTION
## Summary

Update the PSR `build_command` to run `uv lock --upgrade-package` and stage `uv.lock` before building, so the lock file version stays in sync with `pyproject.toml` in release commits. Removes the now-redundant separate build step from the workflow.

## Related issue

None

## Test plan

Boundary coverage: verified locally that `uv lock --upgrade-package pollux-ai` produces the expected one-line version diff and `uv build` succeeds. Workflow YAML validated structurally. Non-behavioral change to CI config; no library code affected.