### PR TITLE
docs(accuracy): fix stale references and document post-v1.2.0 behavior

### DIFF
--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -82,6 +82,8 @@ def execute_tool_calls(tool_calls: list[dict]) -> list[dict]:
 
 async def agent(user_prompt: str) -> str:
     """Run a tool-calling agent loop and return the final answer."""
+    # history=[] is optional — Pollux auto-populates conversation state when
+    # tool calls are present — but included here for explicitness.
     options = Options(tools=tools, tool_choice="auto", history=[])
     result = await run(user_prompt, config=config, options=options)
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -181,7 +181,7 @@ caching and enable it when you see repeated context in your workload.
 
 ## Provider Dependency
 
-Context caching is **Gemini-only** in v1.0. Enabling it with OpenAI raises
+Context caching is **Gemini-only**. Enabling it with OpenAI raises
 an actionable error. See
 [Provider Capabilities](reference/provider-capabilities.md) for the full
 matrix.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ pipeline logic, testing integrations, and CI.
 config = Config(
     provider="gemini",
     model="gemini-2.5-flash-lite",
-    enable_caching=True,       # Reuse uploaded context (Gemini-only in v1.0)
+    enable_caching=True,       # Reuse uploaded context (Gemini-only)
     ttl_seconds=3600,          # Cache lifetime
     request_concurrency=6,     # Concurrent API calls
 )
@@ -135,7 +135,7 @@ options = Options(
     tool_choice="auto",               # Tool calling mode ('auto', 'required', 'none', or dict)
     response_schema=MyPydanticModel,  # Structured output extraction
     reasoning_effort="medium",        # Controls model thinking depth
-    delivery_mode="realtime",         # "deferred" reserved for future provider batch APIs
+    delivery_mode="realtime",         # Only "realtime" is supported
 )
 ```
 
@@ -148,7 +148,7 @@ options = Options(
 | `tool_choice` | `str \| dict \| None` | `None` | Tool execution strategy. See [Building an Agent Loop](agent-loop.md) |
 | `response_schema` | `type[BaseModel] \| dict` | `None` | Expected JSON response format. See [Extracting Structured Data](structured-data.md) |
 | `reasoning_effort` | `str \| None` | `None` | Controls model thinking depth. See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints) |
-| `delivery_mode` | `str` | `"realtime"` | Reserved for future batch delivery |
+| `delivery_mode` | `str` | `"realtime"` | Only `"realtime"` is supported; `"deferred"` raises an error |
 | `history` | `list[dict] \| None` | `None` | Conversation history. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 | `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 

--- a/docs/conversations-and-agents.md
+++ b/docs/conversations-and-agents.md
@@ -146,6 +146,12 @@ options = Options(
 )
 ```
 
+Pollux normalizes tool parameter schemas at the provider boundary. For OpenAI
+(which defaults to strict mode), `additionalProperties: false` and `required`
+are injected automatically. For Gemini, unsupported fields like
+`additionalProperties` are stripped. You can define one schema and use it
+across both providers without modification.
+
 **Reading tool calls:** when the model invokes tools, the result envelope
 includes a `tool_calls` field:
 
@@ -193,6 +199,10 @@ round of `tool_calls` (if the model needs more data) or a final text answer.
   `result["tool_calls"][0]`.
 - **Conversation continuity requires one prompt.** Both `history` and
   `continue_from` work with single-prompt `run()` calls, not `run_many()`.
+- **Tool-call responses auto-populate conversation state.** When `run()`
+  returns tool calls, Pollux builds `_conversation_state` automatically, even
+  without explicit `history` or `continue_from`. This means `continue_tool()`
+  works on any result that contains tool calls.
 - **Provider differences exist.** Both Gemini and OpenAI support tool calling
   and tool messages in history. See
   [Provider Capabilities](reference/provider-capabilities.md) for details.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -68,11 +68,11 @@ Use this order when debugging. Most failures resolve by step 2.
 
 3. **Unsupported feature.** Compare your options against
    [Provider Capabilities](reference/provider-capabilities.md).
-   `delivery_mode="deferred"` is reserved. Conversation continuity
+   `delivery_mode="deferred"` is not supported. Conversation continuity
    and tool calling are supported by both Gemini and OpenAI.
 
 4. **Source and payload.** Reduce to one source + one prompt and retry.
-   For OpenAI remote URLs in v1.0, only PDF and image URLs are supported.
+   For OpenAI remote URLs, only PDF and image URLs are supported.
 
 ## Complete Production Example
 
@@ -205,9 +205,9 @@ asyncio.run(process_collection("./papers", "Summarize the key findings."))
 | `ConfigurationError` at startup | Missing API key | `export GEMINI_API_KEY="your-key"` or pass `api_key` in `Config(...)` |
 | Outputs look like `echo: ...` | `use_mock=True` is set | Set `use_mock=False` (default) and ensure the API key is present |
 | `ConfigurationError` at request time | Provider/model mismatch | Verify the model belongs to the selected provider |
-| `ConfigurationError` mentioning `delivery_mode` | `"deferred"` is reserved | Use `delivery_mode="realtime"` (default) |
+| `ConfigurationError` mentioning `delivery_mode` | `"deferred"` is not supported | Use `delivery_mode="realtime"` (default) |
 | `status: "partial"` | Some prompts returned empty answers | Check individual entries in `answers` to identify which prompts failed |
-| Remote source rejected | Unsupported MIME type on OpenAI | In v1.0, OpenAI remote URL support is limited to PDFs and images |
+| Remote source rejected | Unsupported MIME type on OpenAI | OpenAI remote URL support is limited to PDFs and images |
 | Keys show as `***redacted***` | Intentional redaction | Your key is still being used. `Config` hides it from string representations |
 | Import errors | Missing dependencies | Use Python `>=3.10,<3.15` with `uv sync --all-extras` |
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -23,7 +23,7 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Provider-side context caching | ✅ | ❌ | OpenAI provider returns unsupported for caching |
 | Structured outputs (`response_schema`) | ✅ | ✅ | JSON-schema path in both providers |
 | Reasoning controls (`reasoning_effort`) | ✅ | ✅ | Passed through to provider; see notes below |
-| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | Explicitly disabled |
+| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | Not supported; raises `ConfigurationError` |
 | Tool calling | ✅ | ✅ | Tool definitions via `Options.tools`; results in `ResultEnvelope.tool_calls` |
 | Tool message pass-through in history | ✅ | ✅ | Gemini maps to `Content`/`Part` types; OpenAI maps to `function_call`/`function_call_output` |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | Single prompt per call; supports tool messages in history |
@@ -37,6 +37,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
   `Part.from_function_call` / `Part.from_function_response` for tool turns.
 - Gemini does not support `previous_response_id`; conversation state is
   carried entirely via `history`.
+- Tool parameter schemas are normalized at the provider boundary:
+  `additionalProperties` is stripped because the Gemini API rejects it.
 - Reasoning: `reasoning_effort` maps to `ThinkingConfig(thinking_level=...)`.
   Full thinking text is returned in `ResultEnvelope.reasoning`. This maps
   cleanly on Gemini 3 models (for example `gemini-3-flash-preview`). Gemini
@@ -55,6 +57,9 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 - Sampling controls are model-specific: GPT-5 family models currently reject
   `temperature` and `top_p`, while older models (for example `gpt-4.1-nano`)
   accept them.
+- Tool parameter schemas are normalized for strict mode: `additionalProperties:
+  false` and `required` are injected automatically. Callers who set `strict:
+  false` on a tool definition bypass normalization.
 - Reasoning: `reasoning_effort` maps to `reasoning.effort` with automatic
   `summary: "auto"` to request reasoning summaries. Summaries appear in
   `ResultEnvelope.reasoning`; raw reasoning traces are not exposed by OpenAI.

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -23,7 +23,7 @@ a `Source`, which entry point to call, and how to read the result.
 |---|---|---|
 | `Source.from_text(text)` | Plain string | Identifier defaults to first 50 chars |
 | `Source.from_file(path)` | Local file path | Supports PDF, images, video, audio, text |
-| `Source.from_youtube(url)` | YouTube URL | URL reference (no download); Gemini-native, limited on OpenAI in v1.0 |
+| `Source.from_youtube(url)` | YouTube URL | URL reference (no download); Gemini-native, limited on OpenAI |
 | `Source.from_arxiv(ref)` | arXiv ID or URL | Normalizes to canonical PDF URL (no download at construction time) |
 | `Source.from_uri(uri, mime_type=...)` | Remote URI | Generic fallback for any hosted content |
 | `Source.from_json(data)` | Dict or Pydantic model instance | Serializes via `json.dumps()`; calls `model_dump()` on Pydantic objects |
@@ -182,9 +182,9 @@ a stable shape that works the same regardless of provider.
 | `reasoning` | `list[str \| None]` | No | Provider reasoning traces (when available) |
 | `tool_calls` | `list[list[dict]]` | Only with tool calling | Per-prompt list of tool-call requests. See [Conversations](conversations-and-agents.md) |
 | `confidence` | `float` | Yes | Heuristic: `0.9` for ok, `0.5` otherwise |
-| `extraction_method` | `str` | Yes | Always `"text"` in v1.0 |
+| `extraction_method` | `str` | Yes | Always `"text"` |
 | `usage` | `dict[str, int]` | Yes | Token counts (`input_tokens`, `output_tokens`, `total_tokens`) |
-| `metrics` | `dict[str, Any]` | Yes | `duration_s`, `n_calls`, `cache_used`, `finish_reasons` |
+| `metrics` | `dict[str, Any]` | Yes | `duration_s`, `n_calls`, `cache_used`, `finish_reasons` (per-prompt, e.g. `"stop"`, `"max_tokens"`) |
 
 Example of a complete envelope:
 
@@ -195,7 +195,7 @@ Example of a complete envelope:
     "confidence": 0.9,
     "extraction_method": "text",
     "usage": {"input_tokens": 1250, "output_tokens": 89, "total_tokens": 1339},
-    "metrics": {"duration_s": 1.42, "n_calls": 1, "cache_used": False},
+    "metrics": {"duration_s": 1.42, "n_calls": 1, "cache_used": False, "finish_reasons": ["stop"]},
 }
 ```
 
@@ -204,7 +204,7 @@ Example of a complete envelope:
 - Conversation continuity (`history`, `continue_from`) works with one
   prompt per call. See
   [Continuing Conversations Across Turns](conversations-and-agents.md).
-- `delivery_mode="deferred"` remains reserved and disabled.
+- `delivery_mode="deferred"` is not supported and raises an error.
 - Provider feature support varies. See
   [Provider Capabilities](reference/provider-capabilities.md).
 

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -84,6 +84,7 @@ async def execute_plan(
         options.history is not None or options.continue_from is not None
     )
 
+    # TODO: implement deferred delivery via provider batch APIs.
     if options.delivery_mode == "deferred":
         provider_name = type(provider).__name__
         raise ConfigurationError(

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -36,7 +36,7 @@ class Options:
 
     #: Controls model thinking depth; passed through to the provider.
     reasoning_effort: ReasoningEffort | None = None
-    #: ``"deferred"`` is reserved for future provider batch APIs.
+    # TODO: implement deferred delivery via provider batch APIs.
     delivery_mode: DeliveryMode = "realtime"
     #: Mutually exclusive with *continue_from*.
     history: list[dict[str, Any]] | None = None

--- a/src/pollux/result.py
+++ b/src/pollux/result.py
@@ -31,7 +31,7 @@ class ResultEnvelope(TypedDict, total=False):
     #: Keys: ``input_tokens``, ``output_tokens``, ``total_tokens``,
     #: and optionally ``reasoning_tokens``.
     usage: dict[str, int]
-    #: Keys: ``duration_s``, ``n_calls``, ``cache_used``.
+    #: Keys: ``duration_s``, ``n_calls``, ``cache_used``, ``finish_reasons``.
     metrics: dict[str, Any]
     diagnostics: dict[str, Any]
     _conversation_state: dict[str, Any]


### PR DESCRIPTION
## Summary

Fix documentation accuracy gaps introduced by commits #124–#127 (post-v1.2.0).

## Related issue

None — identified during documentation audit.

## Changes

- **Stale version pins:** removed 6 "v1.0" references across `sending-content.md`, `configuration.md`, `caching.md`, `error-handling.md`
- **`finish_reasons`:** documented in ResultEnvelope metrics table and example envelope (`sending-content.md`, `result.py`)
- **Tool schema normalization:** added note in `conversations-and-agents.md` and per-provider details in `provider-capabilities.md`
- **Conversation state auto-population:** added note in `conversations-and-agents.md` and clarifying comment in `agent-loop.md`
- **`delivery_mode` language:** replaced "reserved for future" with factual "not supported"; added `TODO` markers in `options.py` and `execute.py`

## Test plan

- `grep -rn "in v1.0" docs/` returns 0 matches
- `make docs-build` passes with no errors
- No behavioral code changes; documentation and comments only