### PR TITLE
chore(config): remove stale env vars from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,16 +2,11 @@
 # Never commit real secrets.
 
 # === Provider API Keys ===
-# Set the key for whichever provider(s) you use.
+# Runtime library authentication. Set the key for whichever provider(s) you use.
 GEMINI_API_KEY=
 OPENAI_API_KEY=
 
-# === Pollux Configuration ===
-
-# Optional: Force mock mode for testing (default: false/real API)
-# POLLUX_MOCK=1
-
-# Optional: Tune operational behavior
-# POLLUX_REQUEST_CONCURRENCY=6
-# POLLUX_ENABLE_CACHING=true
-# POLLUX_TTL_SECONDS=3600
+# === Test-Only Contributor Flags ===
+# Not used by the Pollux runtime library.
+# Only affects pytest API test collection (see tests/conftest.py).
+# ENABLE_API_TESTS=1


### PR DESCRIPTION
## Summary
Remove stale `POLLUX_*` variables from `.env.example` and add a clearly labeled, commented `ENABLE_API_TESTS=1` under test-only contributor flags.

## Related issue
None

## Test plan
- Verified `.env.example` reflects current runtime env usage in `src/pollux/config.py` (provider keys only)
- Confirmed `ENABLE_API_TESTS` is test-only via `tests/conftest.py`
- Non-behavioral change (docs/template only); no runtime code paths changed
