### PR TITLE
chore(ci): make release build_command container-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,6 @@ jobs:
           fetch-depth: 0  # Full history needed for semantic-release
           token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-      # uv is used by build_command to update uv.lock and build distributions.
-
       # Main release step using PSR action
       - name: Create and Publish Release
         id: release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,6 +279,7 @@ pytest_add_cli_args = [
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 build_command = """
+    python -m pip install --disable-pip-version-check "uv==1.2.0"
     uv lock --upgrade-package "$PACKAGE_NAME"
     git add uv.lock
     uv build


### PR DESCRIPTION
## Summary

Install a pinned `uv` (`0.9.26`) inside python-semantic-release's container before running `build_command`, then keep `uv.lock` sync + build in the same step.

Remove the runner-level `Install uv` step from the release workflow because it is not visible inside the PSR Docker action.

## Related issue

None

## Test plan

- `python3 -m pip download --no-deps --dest /tmp uv==0.9.26`
- `make check`

## Notes

This fixes the `uv: command not found` / bad pin failure in the PSR step while preserving the `uv.lock` release-commit sync behavior introduced in #127.
