### PR TITLE
chore(ci): pin release container uv to 0.9.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,7 +279,7 @@ pytest_add_cli_args = [
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 build_command = """
-    python -m pip install --disable-pip-version-check "uv==1.2.0"
+    python -m pip install --disable-pip-version-check "uv==0.9.26"
     uv lock --upgrade-package "$PACKAGE_NAME"
     git add uv.lock
     uv build


### PR DESCRIPTION
## Summary

Fix the release workflow regression from #130 by changing the container-local `uv` pin in semantic-release `build_command` from an unavailable version (`1.2.0`) to a published one (`0.9.26`).

## Related issue

None

## Test plan

- `python3 -m pip download --no-deps --dest /tmp uv==0.9.26`
- `make check`
