### PR TITLE
feat(api): add Anthropic provider with E2E tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [{ name = "Sean Brar", email = "hello@seanbrar.com" }]
 license = { text = "MIT" }
 requires-python = ">=3.10, <3.15"
 dependencies = [
+    "anthropic>=0.83",
     "google-genai>=1.61",
     "httpx>=0.24",
     "openai>=2.16.0",
@@ -132,7 +133,7 @@ markers = [
     "contract: Architectural invariant tests spanning modules",
     "unit: Fast, isolated unit tests",
     "integration: Cross-component integration tests with mocked APIs",
-    "api: External API tests (requires GEMINI_API_KEY, auto-skipped otherwise)",
+    "api: External API tests (requires provider API key, auto-skipped otherwise)",
     # Secondary attributes (stackable with primary type)
     "security: Security-sensitive tests",
     "slow: Tests taking >1s (for CI optimization)",

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -186,6 +186,16 @@ def _get_provider(config: Config) -> Provider:
             )
         return OpenAIProvider(config.api_key)
 
+    if config.provider == "anthropic":
+        from pollux.providers.anthropic import AnthropicProvider
+
+        if not config.api_key:
+            raise ConfigurationError(
+                "api_key required for real API",
+                hint="Set ANTHROPIC_API_KEY or pass Config(api_key=...).",
+            )
+        return AnthropicProvider(config.api_key)
+
     from pollux.providers.gemini import GeminiProvider
 
     if not config.api_key:

--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -11,12 +11,13 @@ import dotenv
 from pollux.errors import ConfigurationError
 from pollux.retry import RetryPolicy
 
-ProviderName = Literal["gemini", "openai"]
+ProviderName = Literal["gemini", "openai", "anthropic"]
 
 # Provider-specific API key environment variable names
 _API_KEY_ENV_VARS: dict[ProviderName, str] = {
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
 }
 
 
@@ -46,10 +47,10 @@ class Config:
     def __post_init__(self) -> None:
         """Auto-resolve API key and validate configuration."""
         # Validate provider
-        if self.provider not in ("gemini", "openai"):
+        if self.provider not in ("gemini", "openai", "anthropic"):
             raise ConfigurationError(
                 f"Unknown provider: {self.provider!r}",
-                hint="Supported providers: 'gemini', 'openai'",
+                hint="Supported providers: 'gemini', 'openai', 'anthropic'",
             )
 
         # Validate numeric fields

--- a/src/pollux/providers/__init__.py
+++ b/src/pollux/providers/__init__.py
@@ -1,7 +1,14 @@
 """Provider implementations."""
 
+from .anthropic import AnthropicProvider
 from .base import Provider, ProviderCapabilities
 from .gemini import GeminiProvider
 from .openai import OpenAIProvider
 
-__all__ = ["GeminiProvider", "OpenAIProvider", "Provider", "ProviderCapabilities"]
+__all__ = [
+    "AnthropicProvider",
+    "GeminiProvider",
+    "OpenAIProvider",
+    "Provider",
+    "ProviderCapabilities",
+]

--- a/src/pollux/providers/_errors.py
+++ b/src/pollux/providers/_errors.py
@@ -117,6 +117,8 @@ def _auth_hint(
             env_var = "OPENAI_API_KEY"
         elif provider == "gemini":
             env_var = "GEMINI_API_KEY"
+        elif provider == "anthropic":
+            env_var = "ANTHROPIC_API_KEY"
         return (
             f"Check credentials/permissions (try setting {env_var} or Config.api_key)."
         )

--- a/src/pollux/providers/_utils.py
+++ b/src/pollux/providers/_utils.py
@@ -1,0 +1,42 @@
+"""Shared utilities for provider implementations."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from pollux.errors import APIError
+
+
+def to_strict_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a JSON schema for strict structured-output requirements.
+
+    Ensures that for all 'object' types:
+    1. additionalProperties is False
+    2. All defined properties are listed in 'required'
+    """
+    normalized = deepcopy(schema)
+
+    def walk(node: Any) -> Any:
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        if not isinstance(node, dict):
+            return node
+
+        updated: dict[str, Any] = {}
+        for key, value in node.items():
+            updated[key] = walk(value)
+
+        if updated.get("type") == "object" or "properties" in updated:
+            properties = updated.get("properties", {})
+            if isinstance(properties, dict):
+                updated["additionalProperties"] = False
+                if "required" not in updated:
+                    updated["required"] = list(properties.keys())
+
+        return updated
+
+    result = walk(normalized)
+    if not isinstance(result, dict):
+        raise APIError("Invalid response_schema: expected object schema")
+    return result

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -1,0 +1,367 @@
+"""Anthropic Messages API provider."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+from pollux.errors import APIError
+from pollux.providers._errors import wrap_provider_error
+from pollux.providers._utils import to_strict_schema
+from pollux.providers.base import ProviderCapabilities
+from pollux.providers.models import ProviderRequest, ProviderResponse, ToolCall
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class AnthropicProvider:
+    """Anthropic Messages API provider."""
+
+    def __init__(self, api_key: str) -> None:
+        """Initialize with an API key."""
+        self.api_key = api_key
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        """Lazily initialize and return the async Anthropic client."""
+        if self._client is None:
+            try:
+                from anthropic import AsyncAnthropic
+            except ImportError as e:
+                raise APIError(
+                    "anthropic package not installed",
+                    hint="uv pip install anthropic",
+                ) from e
+            self._client = AsyncAnthropic(api_key=self.api_key)
+        return self._client
+
+    @property
+    def supports_caching(self) -> bool:
+        """Whether this provider supports context caching."""
+        return self.capabilities.caching
+
+    @property
+    def supports_uploads(self) -> bool:
+        """Whether this provider supports file uploads."""
+        return self.capabilities.uploads
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        """Return supported feature flags."""
+        return ProviderCapabilities(
+            caching=False,
+            uploads=False,
+            structured_outputs=True,
+            reasoning=False,
+            deferred_delivery=False,
+            conversation=True,
+        )
+
+    async def generate(
+        self,
+        request: ProviderRequest,
+    ) -> ProviderResponse:
+        """Generate a response using Anthropic's Messages API."""
+        client = self._get_client()
+
+        model = request.model
+        parts = request.parts
+        system_instruction = request.system_instruction
+        response_schema = request.response_schema
+        temperature = request.temperature
+        top_p = request.top_p
+        tools = request.tools
+        tool_choice = request.tool_choice
+        history = request.history
+
+        # No Anthropic equivalents or deferred features.
+        _ = request.cache_name
+        _ = request.reasoning_effort
+        _ = request.previous_response_id
+
+        # Build the messages list from history + current parts.
+        messages: list[dict[str, Any]] = []
+
+        if history:
+            for item in history:
+                if item.role == "tool":
+                    call_id = item.tool_call_id
+                    if not call_id:
+                        continue
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": call_id,
+                                    "content": item.content or "",
+                                }
+                            ],
+                        }
+                    )
+                elif item.role == "assistant":
+                    content_blocks: list[dict[str, Any]] = []
+                    if item.content:
+                        content_blocks.append(
+                            {
+                                "type": "text",
+                                "text": item.content,
+                            }
+                        )
+                    if item.tool_calls:
+                        for tc in item.tool_calls:
+                            try:
+                                args = json.loads(tc.arguments)
+                            except Exception:
+                                args = {}
+                            content_blocks.append(
+                                {
+                                    "type": "tool_use",
+                                    "id": tc.id,
+                                    "name": tc.name,
+                                    "input": args,
+                                }
+                            )
+                    if content_blocks:
+                        messages.append(
+                            {
+                                "role": "assistant",
+                                "content": content_blocks,
+                            }
+                        )
+                elif item.role == "user":
+                    if item.content:
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": item.content,
+                            }
+                        )
+
+        # Build user content from current parts.
+        user_content: list[dict[str, Any]] = []
+        for part in parts:
+            normalized = _normalize_input_part(part)
+            if normalized is not None:
+                user_content.append(normalized)
+
+        has_real_content = False
+        for c in user_content:
+            if c.get("type") != "text" or c.get("text"):
+                has_real_content = True
+                break
+
+        if not user_content:
+            user_content.append({"type": "text", "text": ""})
+
+        if has_real_content or not messages:
+            messages.append({"role": "user", "content": user_content})
+
+        # Build create kwargs.
+        create_kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": 8192,
+        }
+
+        if system_instruction:
+            create_kwargs["system"] = system_instruction
+        if temperature is not None:
+            create_kwargs["temperature"] = temperature
+        if top_p is not None:
+            create_kwargs["top_p"] = top_p
+
+        # Tool definitions.
+        if tools is not None:
+            anthropic_tools: list[dict[str, Any]] = []
+            for t in tools:
+                if "name" in t:
+                    tool_def: dict[str, Any] = {
+                        "name": t["name"],
+                        "input_schema": t.get("parameters", {"type": "object"}),
+                    }
+                    if "description" in t:
+                        tool_def["description"] = t["description"]
+                    anthropic_tools.append(tool_def)
+            if anthropic_tools:
+                create_kwargs["tools"] = anthropic_tools
+
+            if tool_choice is not None:
+                if isinstance(tool_choice, str):
+                    if tool_choice == "required":
+                        create_kwargs["tool_choice"] = {"type": "any"}
+                    elif tool_choice in ("auto", "none"):
+                        create_kwargs["tool_choice"] = {"type": tool_choice}
+                elif isinstance(tool_choice, dict) and "name" in tool_choice:
+                    create_kwargs["tool_choice"] = {
+                        "type": "tool",
+                        "name": tool_choice["name"],
+                    }
+
+        # Structured output via output_config.format.
+        if response_schema is not None:
+            strict_schema = to_strict_schema(response_schema)
+            create_kwargs["output_config"] = {
+                "format": {
+                    "type": "json_schema",
+                    "schema": strict_schema,
+                }
+            }
+
+        try:
+            response = await client.messages.create(**create_kwargs)
+            return _parse_response(response, response_schema=response_schema)
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="anthropic",
+                phase="generate",
+                allow_network_errors=True,
+                message="Anthropic generate failed",
+            ) from e
+
+    async def upload_file(self, path: Path, mime_type: str) -> str:
+        """Raise because Anthropic file uploads are not supported."""
+        _ = path, mime_type
+        raise APIError("Anthropic provider does not support file uploads")
+
+    async def create_cache(
+        self,
+        *,
+        model: str,
+        parts: list[Any],
+        system_instruction: str | None = None,
+        ttl_seconds: int = 3600,
+    ) -> str:
+        """Raise because Anthropic caching is deferred."""
+        _ = model, parts, system_instruction, ttl_seconds
+        raise APIError("Anthropic provider does not support context caching")
+
+    async def aclose(self) -> None:
+        """Close underlying async client resources."""
+        client = self._client
+        if client is None:
+            return
+        self._client = None
+        await client.close()
+
+
+def _parse_response(
+    response: Any, *, response_schema: dict[str, Any] | None
+) -> ProviderResponse:
+    """Parse an Anthropic Message response into ProviderResponse."""
+    text_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
+
+    for block in getattr(response, "content", []):
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            text_parts.append(getattr(block, "text", ""))
+        elif block_type == "tool_use":
+            tool_calls.append(
+                ToolCall(
+                    id=getattr(block, "id", ""),
+                    name=getattr(block, "name", ""),
+                    arguments=json.dumps(getattr(block, "input", {})),
+                )
+            )
+
+    text = "\n\n".join(text_parts) if text_parts else ""
+
+    # Usage extraction.
+    usage: dict[str, int] = {}
+    usage_raw = getattr(response, "usage", None)
+    if usage_raw is not None:
+        input_tokens = int(getattr(usage_raw, "input_tokens", 0))
+        output_tokens = int(getattr(usage_raw, "output_tokens", 0))
+        usage = {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        }
+
+    # Finish reason mapping.
+    stop_reason = getattr(response, "stop_reason", None)
+    finish_reason = _normalize_stop_reason(stop_reason)
+
+    # Response ID.
+    response_id = getattr(response, "id", None)
+
+    # Structured output extraction.
+    structured: Any = None
+    if response_schema is not None and text:
+        try:
+            structured = json.loads(text)
+        except Exception:
+            structured = None
+
+    return ProviderResponse(
+        text=text,
+        usage=usage,
+        reasoning=None,
+        structured=structured,
+        tool_calls=tool_calls if tool_calls else None,
+        response_id=response_id if isinstance(response_id, str) else None,
+        finish_reason=finish_reason,
+    )
+
+
+def _normalize_stop_reason(stop_reason: Any) -> str | None:
+    """Map Anthropic stop_reason to a normalized lowercase string."""
+    if stop_reason is None:
+        return None
+    reason = str(stop_reason).lower()
+
+    mapping: dict[str, str] = {
+        "end_turn": "stop",
+        "stop_sequence": "stop",
+        "max_tokens": "max_tokens",
+        "tool_use": "tool_calls",
+    }
+    return mapping.get(reason, reason)
+
+
+def _normalize_input_part(part: Any) -> dict[str, Any] | None:
+    """Convert Pollux parts into Anthropic content blocks."""
+    if isinstance(part, str):
+        return {"type": "text", "text": part}
+
+    if not isinstance(part, dict):
+        return None
+
+    uri = part.get("uri")
+    mime_type = part.get("mime_type")
+    if not isinstance(uri, str) or not isinstance(mime_type, str):
+        return None
+
+    # Image URL support.
+    if mime_type.startswith("image/"):
+        return {
+            "type": "image",
+            "source": {
+                "type": "url",
+                "url": uri,
+            },
+        }
+
+    # PDF support via document blocks.
+    if mime_type == "application/pdf":
+        return {
+            "type": "document",
+            "source": {
+                "type": "url",
+                "url": uri,
+            },
+        }
+
+    raise APIError(
+        f"Unsupported mime type for Anthropic provider: {mime_type}",
+        hint="Anthropic supports images and PDFs via URL.",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,11 @@ from pollux.providers.models import ProviderRequest, ProviderResponse
 
 GEMINI_MODEL = "gemini-2.0-flash"
 OPENAI_MODEL = "gpt-5-nano"
+ANTHROPIC_MODEL = "claude-haiku-4-5"
 CACHE_MODEL = "cache-model"
 GEMINI_API_TEST_MODEL = "gemini-2.5-flash-lite-preview-09-2025"
 OPENAI_API_TEST_MODEL = OPENAI_MODEL
+ANTHROPIC_API_TEST_MODEL = ANTHROPIC_MODEL
 
 
 @dataclass
@@ -116,7 +118,7 @@ def isolate_provider_env(request, monkeypatch):
         return
 
     for key in list(os.environ.keys()):
-        if key.startswith(("GEMINI_", "OPENAI_")):
+        if key.startswith(("GEMINI_", "OPENAI_", "ANTHROPIC_")):
             monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("DEBUG", raising=False)
     monkeypatch.delenv("POLLUX_DEBUG_CONFIG", raising=False)
@@ -192,3 +194,24 @@ def openai_api_key():
 def openai_test_model():
     """Return the model to use for OpenAI API tests."""
     return OPENAI_API_TEST_MODEL
+
+
+@pytest.fixture
+def anthropic_model() -> str:
+    """Return the canonical Anthropic model for non-API tests."""
+    return ANTHROPIC_MODEL
+
+
+@pytest.fixture
+def anthropic_api_key():
+    """Return ANTHROPIC_API_KEY or skip the test if unavailable."""
+    key = os.getenv("ANTHROPIC_API_KEY")
+    if not key:
+        pytest.skip("ANTHROPIC_API_KEY not set")
+    return key
+
+
+@pytest.fixture
+def anthropic_test_model():
+    """Return the model to use for Anthropic API tests."""
+    return ANTHROPIC_API_TEST_MODEL

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.84.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/ea/0869d6df9ef83dcf393aeefc12dd81677d091c6ffc86f783e51cf44062f2/anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37", size = 539457, upload-time = "2026-02-25T05:22:38.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ca/218fa25002a332c0aa149ba18ffc0543175998b1f65de63f6d106689a345/anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7", size = 455156, upload-time = "2026-02-25T05:22:40.468Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -496,6 +515,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
 ]
 
 [[package]]
@@ -1391,6 +1419,7 @@ name = "pollux-ai"
 version = "1.2.2"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "google-genai" },
     { name = "httpx" },
     { name = "openai" },
@@ -1447,6 +1476,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.83" },
     { name = "google-genai", specifier = ">=1.61" },
     { name = "httpx", specifier = ">=0.24" },
     { name = "openai", specifier = ">=2.16.0" },


### PR DESCRIPTION
## Summary

Add Anthropic as a third provider via the Messages API, with full support for text generation, tool calling, conversation history, and structured outputs. Extract `to_strict_schema` into shared `providers/_utils.py` for reuse by both OpenAI and Anthropic.

## Related issue

None

## Test plan

- **Characterization tests** (`test_providers.py`): 16 new Anthropic tests covering response parsing (text, structured, tool calls, finish reasons, empty/mixed content), generate config forwarding (basic, system instruction, tools, temperature, structured output, history), and capability gates (upload/cache raise).
- **E2E tests** (`test_api.py`): Anthropic added to both parametrized tests (`test_live_source_patterns_and_generation_controls`, `test_live_tool_calls_conversation_and_reasoning_roundtrip`) exercising `run_many` with JSON source fan-out and tool call + `continue_tool` roundtrip.
- **Shared schema normalization**: Updated existing `test_openai_strict_schema_*` tests to use `to_strict_schema` from `_utils`; updated Anthropic structured output characterization test to assert `additionalProperties: False` injection.
- `make check` passes (lint + typecheck + 144 tests).

## Notes

- **Dependency pin**: `anthropic>=0.83` — v0.83.0 (Feb 19, 2026) introduced automatic prompt caching. This sets the floor for upcoming caching work and ensures the `output_config` structured output API is available.
- **Model constant**: Fixed `ANTHROPIC_MODEL` from the invalid `"claude-haiku-3"` to `"claude-haiku-4-5"` ($1/$5 per MTok, cheapest active model). Claude 3 Haiku is deprecated and retiring April 19, 2026.
- **Structured output in E2E**: Both OpenAI and Anthropic now rely on `to_strict_schema` at the provider layer, so the test schema is shared across all three providers without per-provider fixup.
- **Deferred**: Anthropic caching (`capabilities.caching=False`), file uploads (`capabilities.uploads=False`), and reasoning effort forwarding are stubbed out for follow-up work.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [ ] Docs updated (if this changes public API or user-facing behavior)