### PR TITLE
refactor(api): use Sequence for read-only collection parameters

### DIFF
--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -35,6 +35,8 @@ from pollux.retry import RetryPolicy
 from pollux.source import Source
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pollux.providers.base import Provider
 
 try:
@@ -79,9 +81,9 @@ async def run(
 
 
 async def run_many(
-    prompts: str | list[str | None] | tuple[str | None, ...] | None = None,
+    prompts: str | Sequence[str | None] | None = None,
     *,
-    sources: tuple[Source, ...] | list[Source] = (),
+    sources: Sequence[Source] = (),
     config: Config,
     options: Options | None = None,
 ) -> ResultEnvelope:
@@ -160,7 +162,7 @@ async def continue_tool(
 
 
 async def create_cache(
-    sources: tuple[Source, ...] | list[Source],
+    sources: Sequence[Source],
     *,
     config: Config,
     system_instruction: str | None = None,

--- a/src/pollux/cache.py
+++ b/src/pollux/cache.py
@@ -15,6 +15,8 @@ from pollux.errors import ConfigurationError, InternalError
 from pollux.retry import RetryPolicy, retry_async, should_retry_side_effect
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pollux.config import Config
     from pollux.providers.base import Provider
     from pollux.source import Source
@@ -209,7 +211,7 @@ async def _resolve_file_parts(
 
 
 async def create_cache_impl(
-    sources: tuple[Source, ...] | list[Source],
+    sources: Sequence[Source],
     *,
     provider: Provider,
     config: Config,

--- a/src/pollux/request.py
+++ b/src/pollux/request.py
@@ -10,6 +10,8 @@ from pollux.options import Options
 from pollux.source import Source
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pollux.config import Config
 
 
@@ -24,8 +26,8 @@ class Request:
 
 
 def normalize_request(
-    prompts: tuple[str | None, ...] | list[str | None] | str | None,
-    sources: tuple[Source, ...] | list[Source],
+    prompts: str | Sequence[str | None] | None,
+    sources: Sequence[Source],
     config: Config,
     *,
     options: Options | None = None,


### PR DESCRIPTION
## Summary

Replace concrete `list[...] | tuple[...]` unions with `collections.abc.Sequence` in public API signatures (`run_many`, `create_cache`, `normalize_request`, `create_cache_impl`). These functions only iterate - `Sequence` accurately reflects the contract and eliminates mypy invariance errors for callers passing `list[str]` where `list[str | None]` was expected.

## Related issue

None

## Test plan

No new tests - **non-behavioral change**. Type annotations only; no runtime code altered.

- `just check` passes (lint + mypy strict + 176 tests)
- Verified empirically that mypy rejects `list[str]` → `list[str | None]` but accepts `list[str]` → `Sequence[str | None]`