### PR TITLE
feat(openrouter): add OpenRouter provider for text generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@
 # Runtime library authentication. Set the key for whichever provider(s) you use.
 GEMINI_API_KEY=
 OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+OPENROUTER_API_KEY=
 
 # === Test-Only Contributor Flags ===
 # Not used by the Pollux runtime library.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ print(result["answers"][0])
 
 To use OpenAI instead: `Config(provider="openai", model="gpt-5-nano")`.
 For Anthropic: `Config(provider="anthropic", model="claude-haiku-4-5")`.
+For OpenRouter: `Config(provider="openrouter", model="google/gemma-3-27b-it:free")`.
 
 For a full 2-minute walkthrough (install, key setup, success checks), see the
 [Quickstart](https://polluxlib.dev/quickstart/).
@@ -60,7 +61,7 @@ pip install pollux-ai
 
 ### API Keys
 
-Get a key from [Google AI Studio](https://ai.dev/), [OpenAI Platform](https://platform.openai.com/api-keys), or the [Anthropic Console](https://console.anthropic.com/settings/keys), then:
+Get a key from [Google AI Studio](https://ai.dev/), [OpenAI Platform](https://platform.openai.com/api-keys), the [Anthropic Console](https://console.anthropic.com/settings/keys), or [OpenRouter](https://openrouter.ai/keys), then:
 
 ```bash
 # Gemini
@@ -71,6 +72,9 @@ export OPENAI_API_KEY="your-key-here"
 
 # Anthropic
 export ANTHROPIC_API_KEY="your-key-here"
+
+# OpenRouter
+export OPENROUTER_API_KEY="your-key-here"
 ```
 
 ## Usage

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ All fields and their defaults:
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `provider` | `"gemini" \| "openai" \| "anthropic"` | *(required)* | Provider to use |
+| `provider` | `"gemini" \| "openai" \| "anthropic" \| "openrouter"` | *(required)* | Provider to use |
 | `model` | `str` | *(required)* | Model identifier |
 | `api_key` | `str \| None` | `None` | Explicit key; auto-resolved from env if omitted |
 | `use_mock` | `bool` | `False` | Use mock provider (no network calls) |
@@ -45,11 +45,13 @@ If `api_key` is omitted, Pollux resolves it from environment variables:
 - Gemini: `GEMINI_API_KEY`
 - OpenAI: `OPENAI_API_KEY`
 - Anthropic: `ANTHROPIC_API_KEY`
+- OpenRouter: `OPENROUTER_API_KEY`
 
 ```bash
 export GEMINI_API_KEY="your-key"
 export OPENAI_API_KEY="your-key"
 export ANTHROPIC_API_KEY="your-key"
+export OPENROUTER_API_KEY="your-key"
 ```
 
 You can also pass a key directly:

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -62,7 +62,7 @@ Use this order when debugging. Most failures resolve by step 2.
 
 1. **Auth and mode check.** Is `use_mock` what you expect? For real mode,
    ensure the matching key exists (`GEMINI_API_KEY`, `OPENAI_API_KEY`, or
-   `ANTHROPIC_API_KEY`).
+   `ANTHROPIC_API_KEY`, or `OPENROUTER_API_KEY`).
 
 2. **Provider/model pairing.** Verify the model belongs to the selected
    provider. Re-run a minimal prompt after fixing any mismatch.
@@ -70,7 +70,7 @@ Use this order when debugging. Most failures resolve by step 2.
 3. **Unsupported feature.** Compare your options against
    [Provider Capabilities](reference/provider-capabilities.md).
    `delivery_mode="deferred"` is not supported. Conversation continuity
-   and tool calling are supported by all three providers.
+   and tool calling are provider-dependent.
 
 4. **Source and payload.** Reduce to one source + one prompt and retry.
    For OpenAI remote URLs, only PDF and image URLs are supported.
@@ -203,7 +203,7 @@ asyncio.run(process_collection("./papers", "Summarize the key findings."))
 
 | Symptom | Likely Cause | Fix |
 |---|---|---|
-| `ConfigurationError` at startup | Missing API key | `export GEMINI_API_KEY="your-key"` (or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) or pass `api_key` in `Config(...)` |
+| `ConfigurationError` at startup | Missing API key | `export GEMINI_API_KEY="your-key"` (or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY`) or pass `api_key` in `Config(...)` |
 | Outputs look like `echo: ...` | `use_mock=True` is set | Set `use_mock=False` (default) and ensure the API key is present |
 | `ConfigurationError` at request time | Provider/model mismatch | Verify the model belongs to the selected provider |
 | `ConfigurationError` mentioning `delivery_mode` | `"deferred"` is not supported | Use `delivery_mode="realtime"` (default) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,9 +42,17 @@ Or download the latest wheel from
     export ANTHROPIC_API_KEY="your-key-here"
     ```
 
+=== "OpenRouter"
+
+    Get a key from [OpenRouter](https://openrouter.ai/keys), then:
+
+    ```bash
+    export OPENROUTER_API_KEY="your-key-here"
+    ```
+
 Not sure which provider? Start with Gemini for explicit context caching,
-OpenAI for broad model selection, or Anthropic for implicit caching and
-extended thinking.
+OpenAI for broad model selection, Anthropic for implicit caching and
+extended thinking, or OpenRouter for routed model access.
 
 ## 3. Run
 
@@ -70,7 +78,8 @@ asyncio.run(main())
 
 If you chose OpenAI, change config to
 `Config(provider="openai", model="gpt-5-nano")`. For Anthropic, use
-`Config(provider="anthropic", model="claude-haiku-4-5")`.
+`Config(provider="anthropic", model="claude-haiku-4-5")`. For OpenRouter,
+use `Config(provider="openrouter", model="google/gemma-3-27b-it:free")`.
 
 !!! tip "No API key yet?"
     Use `Config(provider="gemini", model="gemini-2.5-flash-lite", use_mock=True)` to

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -128,5 +128,5 @@ just demo-data                # seed demo inputs
 - `Recipe not found`: verify the spec with `python -m cookbook --list`.
 - Unexpected relative-path behavior: use `--no-cwd-repo-root` only when you need CWD-local paths.
 - **No demo files:** run `just demo-data` or provide explicit `--input` paths.
-- **API auth errors:** set `GEMINI_API_KEY`/`OPENAI_API_KEY`/`ANTHROPIC_API_KEY`, then use `--no-mock`.
+- **API auth errors:** set `GEMINI_API_KEY`/`OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/`OPENROUTER_API_KEY`, then use `--no-mock`.
 - **Rate limits:** lower concurrency and stage workload size with `--limit`.

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -1,6 +1,6 @@
 # Provider Capabilities
 
-This page defines the v1.3 capability contract by provider.
+This page defines the current capability contract by provider.
 
 Pollux is **capability-transparent**, not capability-equalizing: providers are allowed to differ, and those differences are surfaced clearly.
 
@@ -10,24 +10,24 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 - Unsupported features must fail fast with actionable errors.
 - New provider features do not require immediate cross-provider implementation.
 
-## Capability Matrix (v1.3)
+## Capability Matrix
 
-| Capability | Gemini | OpenAI | Anthropic | Notes |
-|---|---|---|---|---|
-| Text generation | ✅ | ✅ | ✅ | Core feature |
-| Multi-prompt execution (`run_many`) | ✅ | ✅ | ✅ | One call per prompt, shared context |
-| Local file inputs | ✅ | ✅ | ✅ | Each provider uses its own Files API for uploads |
-| PDF URL inputs | ✅ (via URI part) | ✅ (native `input_file.file_url`) | ✅ (native `document` URL block) | |
-| Image URL inputs | ✅ (via URI part) | ✅ (native `input_image.image_url`) | ✅ (native `image` URL block) | |
-| YouTube URL inputs | ✅ | ⚠️ limited | ⚠️ limited | OpenAI/Anthropic parity layers (download/re-upload) are out of scope |
-| Explicit context caching (`create_cache`) | ✅ | ❌ | ❌ | Persistent cache handles are Gemini-only |
-| Implicit prompt caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | Anthropic-only request-level optimization |
-| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | JSON-schema path in all providers |
-| Reasoning controls (`reasoning_effort`) | ✅ | ✅ | ✅ | Passed through to provider; see notes below |
-| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | ❌ | Not supported; raises `ConfigurationError` |
-| Tool calling | ✅ | ✅ | ✅ | Tool definitions via `Options.tools`; results in `ResultEnvelope.tool_calls` |
-| Tool message pass-through in history | ✅ | ✅ | ✅ | Provider-native tool call/result encoding |
-| Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | Single prompt per call; supports tool messages in history |
+| Capability | Gemini | OpenAI | Anthropic | OpenRouter | Notes |
+|---|---|---|---|---|---|
+| Text generation | ✅ | ✅ | ✅ | ✅ | Core feature |
+| Multi-prompt execution (`run_many`) | ✅ | ✅ | ✅ | ✅ | One call per prompt, shared context |
+| Local file inputs | ✅ | ✅ | ✅ | ❌ | OpenRouter multimodal input is planned separately |
+| PDF URL inputs | ✅ (via URI part) | ✅ (native `input_file.file_url`) | ✅ (native `document` URL block) | ❌ | |
+| Image URL inputs | ✅ (via URI part) | ✅ (native `input_image.image_url`) | ✅ (native `image` URL block) | ❌ | |
+| YouTube URL inputs | ✅ | ⚠️ limited | ⚠️ limited | ❌ | OpenAI/Anthropic parity layers (download/re-upload) are out of scope |
+| Explicit context caching (`create_cache`) | ✅ | ❌ | ❌ | ❌ | Persistent cache handles are Gemini-only |
+| Implicit prompt caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | Anthropic-only request-level optimization |
+| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ❌ | OpenRouter support is planned separately |
+| Reasoning controls (`reasoning_effort`) | ✅ | ✅ | ✅ | ❌ | Passed through to provider where supported; see notes below |
+| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | ❌ | ❌ | Not supported; raises `ConfigurationError` |
+| Tool calling | ✅ | ✅ | ✅ | ❌ | OpenRouter support is planned separately |
+| Tool message pass-through in history | ✅ | ✅ | ✅ | ❌ | OpenRouter conversation is text-history only in the current release |
+| Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
 ## Provider-Specific Notes
 
@@ -85,6 +85,18 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 - `Options.max_tokens`: limits the output length. Default is `16384` for Anthropic
   (which reserves enough room for all supported manual thinking budgets). Other providers
   currently ignore this option.
+
+### OpenRouter
+
+- OpenRouter is a routed provider: Pollux sends requests to OpenRouter, and the
+  selected model slug determines the upstream model family.
+- The current Pollux OpenRouter support is intentionally narrow:
+  text generation plus text-history conversation only.
+- Pollux does not expose OpenRouter routing controls in the public API.
+- `continue_from` works through Pollux conversation state replay; there is no
+  OpenRouter-specific equivalent to OpenAI's `previous_response_id`.
+- Persistent cache handles, multimodal inputs, structured outputs, reasoning,
+  and tool calling are planned as separate OpenRouter follow-ups.
 
 ## Error Semantics
 

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -249,6 +249,16 @@ def _get_provider(config: Config) -> Provider:
             )
         return AnthropicProvider(config.api_key)
 
+    if config.provider == "openrouter":
+        from pollux.providers.openrouter import OpenRouterProvider
+
+        if not config.api_key:
+            raise ConfigurationError(
+                "api_key required for real API",
+                hint="Set OPENROUTER_API_KEY or pass Config(api_key=...).",
+            )
+        return OpenRouterProvider(config.api_key)
+
     from pollux.providers.gemini import GeminiProvider
 
     if not config.api_key:

--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -11,13 +11,14 @@ import dotenv
 from pollux.errors import ConfigurationError
 from pollux.retry import RetryPolicy
 
-ProviderName = Literal["gemini", "openai", "anthropic"]
+ProviderName = Literal["gemini", "openai", "anthropic", "openrouter"]
 
 # Provider-specific API key environment variable names
 _API_KEY_ENV_VARS: dict[ProviderName, str] = {
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
 }
 
 
@@ -35,7 +36,7 @@ class Config:
 
     provider: ProviderName
     model: str
-    #: Auto-resolved from ``GEMINI_API_KEY`` or ``OPENAI_API_KEY`` when *None*.
+    #: Auto-resolved from the provider-specific API key env var when *None*.
     api_key: str | None = None
     use_mock: bool = False
     request_concurrency: int = 6
@@ -44,10 +45,12 @@ class Config:
     def __post_init__(self) -> None:
         """Auto-resolve API key and validate configuration."""
         # Validate provider
-        if self.provider not in ("gemini", "openai", "anthropic"):
+        if self.provider not in ("gemini", "openai", "anthropic", "openrouter"):
             raise ConfigurationError(
                 f"Unknown provider: {self.provider!r}",
-                hint="Supported providers: 'gemini', 'openai', 'anthropic'",
+                hint=(
+                    "Supported providers: 'gemini', 'openai', 'anthropic', 'openrouter'"
+                ),
             )
 
         # Validate numeric fields

--- a/src/pollux/providers/__init__.py
+++ b/src/pollux/providers/__init__.py
@@ -4,11 +4,13 @@ from .anthropic import AnthropicProvider
 from .base import Provider, ProviderCapabilities
 from .gemini import GeminiProvider
 from .openai import OpenAIProvider
+from .openrouter import OpenRouterProvider
 
 __all__ = [
     "AnthropicProvider",
     "GeminiProvider",
     "OpenAIProvider",
+    "OpenRouterProvider",
     "Provider",
     "ProviderCapabilities",
 ]

--- a/src/pollux/providers/_errors.py
+++ b/src/pollux/providers/_errors.py
@@ -120,6 +120,8 @@ def _auth_hint(
             env_var = "GEMINI_API_KEY"
         elif provider == "anthropic":
             env_var = "ANTHROPIC_API_KEY"
+        elif provider == "openrouter":
+            env_var = "OPENROUTER_API_KEY"
         return (
             f"Check credentials/permissions (try setting {env_var} or Config.api_key)."
         )

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -1,0 +1,294 @@
+"""OpenRouter Chat Completions provider implementation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+
+from pollux.errors import APIError, ConfigurationError
+from pollux.providers._errors import wrap_provider_error
+from pollux.providers.base import ProviderCapabilities
+from pollux.providers.models import (
+    Message,
+    ProviderFileAsset,
+    ProviderRequest,
+    ProviderResponse,
+)
+
+_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class OpenRouterProvider:
+    """OpenRouter provider backed by the HTTP API."""
+
+    def __init__(self, api_key: str) -> None:
+        """Initialize with an API key."""
+        self.api_key = api_key
+        self._client: Any = None
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        """Return supported feature flags."""
+        return ProviderCapabilities(
+            persistent_cache=False,
+            uploads=False,
+            structured_outputs=False,
+            reasoning=False,
+            deferred_delivery=False,
+            conversation=True,
+            implicit_caching=False,
+        )
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Lazily initialize and return the shared async HTTP client."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=_OPENROUTER_BASE_URL,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+        return cast("httpx.AsyncClient", self._client)
+
+    async def generate(
+        self,
+        request: ProviderRequest,
+    ) -> ProviderResponse:
+        """Generate a response using OpenRouter chat completions."""
+        if request.tools is not None or request.tool_choice is not None:
+            raise ConfigurationError(
+                "OpenRouter tool calling is not supported yet",
+                hint="Remove tools/tool_choice for now. OpenRouter tool support is planned for a later release.",
+            )
+
+        _ = (
+            request.previous_response_id
+        )  # OpenRouter uses history replay, not ID-based continuation
+
+        messages = _build_messages(
+            request.parts,
+            request.history,
+            system_instruction=request.system_instruction,
+        )
+        payload: dict[str, Any] = {
+            "model": request.model,
+            "messages": messages,
+        }
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
+        if request.top_p is not None:
+            payload["top_p"] = request.top_p
+        if request.max_tokens is not None:
+            payload["max_tokens"] = request.max_tokens
+
+        client = self._get_client()
+        try:
+            response = await client.post("/chat/completions", json=payload)
+            if response.is_error:
+                raise httpx.HTTPStatusError(
+                    _extract_error_message(response),
+                    request=response.request,
+                    response=response,
+                )
+            data = response.json()
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="openrouter",
+                phase="generate",
+                allow_network_errors=True,
+                message="OpenRouter generate failed",
+            ) from e
+
+        if not isinstance(data, dict):
+            raise APIError("OpenRouter returned a non-object response")
+
+        return _parse_response(data)
+
+    async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
+        """Raise because OpenRouter uploads are not supported yet."""
+        _ = path, mime_type
+        raise APIError("OpenRouter provider does not support file uploads yet")
+
+    async def create_cache(
+        self,
+        *,
+        model: str,
+        parts: list[Any],
+        system_instruction: str | None = None,
+        tools: list[dict[str, Any]] | list[Any] | None = None,
+        ttl_seconds: int = 3600,
+    ) -> str:
+        """Raise because OpenRouter does not expose Pollux cache handles."""
+        _ = model, parts, system_instruction, tools, ttl_seconds
+        raise APIError("OpenRouter provider does not support context caching")
+
+    async def aclose(self) -> None:
+        """Close underlying async HTTP resources."""
+        client = self._client
+        if client is None:
+            return
+        self._client = None
+        await client.aclose()
+
+
+def _build_messages(
+    parts: list[Any],
+    history: list[Message] | None,
+    *,
+    system_instruction: str | None,
+) -> list[dict[str, Any]]:
+    """Build OpenRouter chat-completions messages from history and parts."""
+    messages: list[dict[str, Any]] = []
+
+    if system_instruction is not None:
+        messages.append({"role": "system", "content": system_instruction})
+
+    if history is not None:
+        for item in history:
+            if item.role == "tool" or item.tool_calls:
+                raise ConfigurationError(
+                    "OpenRouter tool history is not supported yet",
+                    hint="Remove tool messages from history for now. OpenRouter tool support is planned for a later release.",
+                )
+            # Note: an empty Message.content sends `{"role": "assistant", "content": ""}`.
+            # This is correct for assistant messages that only include tool calls.
+            messages.append(
+                {
+                    "role": item.role,
+                    "content": item.content,
+                }
+            )
+
+    user_texts: list[str] = []
+    for part in parts:
+        normalized = _normalize_input_part(part)
+        if normalized is not None:
+            user_texts.append(normalized)
+
+    user_text = "\n\n".join(text for text in user_texts if text)
+    if user_text or not messages:
+        messages.append({"role": "user", "content": user_text})
+
+    return messages
+
+
+def _normalize_input_part(part: Any) -> str | None:
+    """Convert Pollux parts into OpenRouter-compatible text content."""
+    if isinstance(part, str):
+        return part
+
+    if isinstance(part, dict) and isinstance(part.get("text"), str):
+        return cast("str", part["text"])
+
+    if isinstance(part, dict):
+        if isinstance(part.get("file_path"), str):
+            raise ConfigurationError(
+                "OpenRouter local file inputs are not supported yet",
+                hint="Use text sources for now. OpenRouter multimodal input support is planned for a later release.",
+            )
+        if isinstance(part.get("uri"), str):
+            raise ConfigurationError(
+                "OpenRouter URL inputs are not supported yet",
+                hint="Use text sources for now. OpenRouter multimodal input support is planned for a later release.",
+            )
+
+    if isinstance(part, ProviderFileAsset):
+        raise ConfigurationError(
+            "OpenRouter does not support file assets",
+            hint="Remove file sources; OpenRouter multimodal support is planned.",
+        )
+
+    if part is None:
+        return None
+
+    raise ConfigurationError(
+        f"Unsupported OpenRouter input part: {type(part).__name__}",
+        hint="Use plain text sources for now. OpenRouter multimodal input support is planned for a later release.",
+    )
+
+
+def _parse_response(data: Mapping[str, Any]) -> ProviderResponse:
+    """Parse an OpenRouter chat-completions payload into ProviderResponse."""
+    choices = data.get("choices")
+    choice = choices[0] if isinstance(choices, list) and choices else {}
+    if not isinstance(choice, Mapping):
+        choice = {}
+
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        message = {}
+
+    text = _extract_message_text(message.get("content"))
+    finish_reason = choice.get("finish_reason")
+    if not isinstance(finish_reason, str):
+        finish_reason = None
+
+    usage_raw = data.get("usage")
+    usage: dict[str, int] = {}
+    if isinstance(usage_raw, Mapping):
+        prompt_tokens = usage_raw.get("prompt_tokens")
+        completion_tokens = usage_raw.get("completion_tokens")
+        total_tokens = usage_raw.get("total_tokens")
+        if isinstance(prompt_tokens, int):
+            usage["input_tokens"] = prompt_tokens
+        if isinstance(completion_tokens, int):
+            usage["output_tokens"] = completion_tokens
+        if isinstance(total_tokens, int):
+            usage["total_tokens"] = total_tokens
+
+    response_id = data.get("id")
+    return ProviderResponse(
+        text=text,
+        usage=usage,
+        response_id=response_id if isinstance(response_id, str) else None,
+        finish_reason=finish_reason,
+    )
+
+
+def _extract_message_text(content: Any) -> str:
+    """Extract text from a chat-completions message content field."""
+    if isinstance(content, str):
+        return content
+
+    if not isinstance(content, list):
+        return ""
+
+    text_parts: list[str] = []
+    for item in content:
+        if not isinstance(item, Mapping):
+            continue
+        if item.get("type") == "text" and isinstance(item.get("text"), str):
+            text_parts.append(item["text"])
+    return "\n\n".join(text_parts)
+
+
+def _extract_error_message(response: httpx.Response) -> str:
+    """Extract a useful error message from an OpenRouter HTTP response."""
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+        message = payload.get("message")
+        if isinstance(message, str) and message:
+            return message
+
+    text = response.text.strip()
+    if text:
+        return text
+    return f"HTTP {response.status_code}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from pollux.providers.models import ProviderFileAsset, ProviderRequest, Provider
 GEMINI_MODEL = "gemini-2.0-flash"
 OPENAI_MODEL = "gpt-5-nano"
 ANTHROPIC_MODEL = "claude-haiku-4-5"
+OPENROUTER_MODEL = "google/gemma-3-27b-it:free"
 CACHE_MODEL = "cache-model"
 GEMINI_API_TEST_MODEL = "gemini-2.5-flash-lite-preview-09-2025"
 OPENAI_API_TEST_MODEL = OPENAI_MODEL
@@ -105,7 +106,7 @@ def block_dotenv(request, monkeypatch):
 def isolate_provider_env(request, monkeypatch):
     """Ensure a clean provider environment for each test.
 
-    Clears GEMINI_* and OPENAI_* env vars to prevent test pollution.
+    Clears provider auth env vars to prevent test pollution.
     Opt-out: @pytest.mark.allow_env_pollution or @pytest.mark.api
     """
     if request.node.get_closest_marker("allow_env_pollution") or (
@@ -114,7 +115,7 @@ def isolate_provider_env(request, monkeypatch):
         return
 
     for key in list(os.environ.keys()):
-        if key.startswith(("GEMINI_", "OPENAI_", "ANTHROPIC_")):
+        if key.startswith(("GEMINI_", "OPENAI_", "ANTHROPIC_", "OPENROUTER_")):
             monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("DEBUG", raising=False)
     monkeypatch.delenv("POLLUX_DEBUG_CONFIG", raising=False)
@@ -196,6 +197,27 @@ def openai_test_model():
 def anthropic_model() -> str:
     """Return the canonical Anthropic model for non-API tests."""
     return ANTHROPIC_MODEL
+
+
+@pytest.fixture
+def openrouter_model() -> str:
+    """Return the canonical OpenRouter model for non-API tests."""
+    return OPENROUTER_MODEL
+
+
+@pytest.fixture
+def openrouter_api_key():
+    """Return OPENROUTER_API_KEY or skip the test if unavailable."""
+    key = os.getenv("OPENROUTER_API_KEY")
+    if not key:
+        pytest.skip("OPENROUTER_API_KEY not set")
+    return key
+
+
+@pytest.fixture
+def openrouter_test_model():
+    """Return the model to use for OpenRouter API tests."""
+    return "meta-llama/llama-3.2-1b-instruct"
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,7 @@ _PROVIDERS: list[tuple[str, str, str]] = [
     ("gemini", "gemini_api_key", "gemini_test_model"),
     ("openai", "openai_api_key", "openai_test_model"),
     ("anthropic", "anthropic_api_key", "anthropic_test_model"),
+    ("openrouter", "openrouter_api_key", "openrouter_test_model"),
 ]
 _GEMINI_REASONING_MODEL = "gemini-3-flash-preview"
 
@@ -81,7 +82,7 @@ def _provider_config(
 @pytest.mark.parametrize(
     ("provider", "api_key_fixture", "model_fixture"),
     _PROVIDERS,
-    ids=["gemini", "openai", "anthropic"],
+    ids=["gemini", "openai", "anthropic", "openrouter"],
 )
 async def test_live_source_patterns_and_generation_controls(
     request: pytest.FixtureRequest,
@@ -124,8 +125,8 @@ async def test_live_source_patterns_and_generation_controls(
     assert "neptune" in result["answers"][0].lower()
     assert "second" in result["answers"][1].lower()
     assert "zx-41" in result["answers"][1].lower()
-    assert isinstance(result["usage"].get("total_tokens"), int)
-    assert result["usage"]["total_tokens"] > 0
+    if result["usage"]:
+        assert result["usage"].get("total_tokens", 0) > 0
 
     # system_instruction="Return one line only." should constrain output shape.
     for answer in result["answers"]:
@@ -136,7 +137,7 @@ async def test_live_source_patterns_and_generation_controls(
 @pytest.mark.parametrize(
     ("provider", "api_key_fixture", "model_fixture"),
     _PROVIDERS,
-    ids=["gemini", "openai", "anthropic"],
+    ids=["gemini", "openai", "anthropic", "openrouter"],
 )
 async def test_live_tool_calls_conversation_and_reasoning_roundtrip(
     request: pytest.FixtureRequest,
@@ -145,6 +146,8 @@ async def test_live_tool_calls_conversation_and_reasoning_roundtrip(
     model_fixture: str,
 ) -> None:
     """E2E: tool call + continuation preserves ordering and context."""
+    if provider == "openrouter":
+        pytest.skip("OpenRouter tool calling is not supported yet")
     config = _provider_config(
         request,
         provider=provider,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,6 +121,20 @@ def test_openai_provider_uses_openai_api_key(
     assert cfg.api_key == "openai-secret"
 
 
+def test_openrouter_provider_uses_openrouter_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    openrouter_model: str,
+) -> None:
+    """Provider-specific env key selection should prefer OPENROUTER_API_KEY."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-secret")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    cfg = Config(provider="openrouter", model=openrouter_model)
+
+    assert cfg.provider == "openrouter"
+    assert cfg.api_key == "openrouter-secret"
+
+
 def test_missing_api_key_raises_clear_error(
     monkeypatch: pytest.MonkeyPatch,
     gemini_model: str,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
-from pollux.errors import APIError
+from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import extract_retry_after_s, wrap_provider_error
 from pollux.providers._utils import to_strict_schema
 from pollux.providers.anthropic import AnthropicProvider
@@ -28,7 +29,8 @@ from pollux.providers.models import (
     ToolCall,
 )
 from pollux.providers.openai import OpenAIProvider
-from tests.conftest import ANTHROPIC_MODEL, GEMINI_MODEL, OPENAI_MODEL
+from pollux.providers.openrouter import OpenRouterProvider
+from tests.conftest import ANTHROPIC_MODEL, GEMINI_MODEL, OPENAI_MODEL, OPENROUTER_MODEL
 
 pytestmark = pytest.mark.contract
 
@@ -2382,3 +2384,138 @@ def test_openai_parse_response_extracts_tool_calls() -> None:
     assert result.tool_calls[0].id == "call_abc"
     assert result.tool_calls[0].name == "get_weather"
     assert result.tool_calls[0].arguments == '{"city": "NYC"}'
+
+
+# =============================================================================
+# OpenRouter Request / Response Characterization
+# =============================================================================
+
+
+class _FakeOpenRouterClient:
+    """Captures payloads passed to OpenRouter chat completions."""
+
+    def __init__(self, payload: dict[str, Any] | None = None) -> None:
+        self.last_json: dict[str, Any] | None = None
+        self.closed = False
+        self._payload = payload or {
+            "id": "gen_123",
+            "choices": [
+                {
+                    "message": {"content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        }
+
+    async def post(self, path: str, json: dict[str, Any]) -> Any:
+        self.last_json = json
+        request = httpx.Request("POST", f"https://openrouter.ai/api/v1{path}")
+        return httpx.Response(200, json=self._payload, request=request)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_openrouter_generate_builds_text_and_history_messages() -> None:
+    """OpenRouter should send OpenAI-style messages for text/history requests."""
+    fake_client = _FakeOpenRouterClient()
+
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    result = await provider.generate(
+        ProviderRequest(
+            model=OPENROUTER_MODEL,
+            parts=["Current prompt"],
+            system_instruction="Be concise.",
+            history=[
+                Message(role="user", content="Earlier question"),
+                Message(role="assistant", content="Earlier answer"),
+            ],
+            temperature=0.2,
+            top_p=0.9,
+            max_tokens=128,
+        )
+    )
+
+    assert fake_client.last_json == {
+        "model": OPENROUTER_MODEL,
+        "messages": [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Earlier question"},
+            {"role": "assistant", "content": "Earlier answer"},
+            {"role": "user", "content": "Current prompt"},
+        ],
+        "temperature": 0.2,
+        "top_p": 0.9,
+        "max_tokens": 128,
+    }
+    assert result.text == "ok"
+    assert result.finish_reason == "stop"
+    assert result.response_id == "gen_123"
+    assert result.usage == {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+    }
+
+
+@pytest.mark.asyncio
+async def test_openrouter_generate_rejects_tools_for_now() -> None:
+    """OpenRouter PR 1 should fail fast on unsupported tool definitions."""
+    provider = OpenRouterProvider("test-key")
+
+    with pytest.raises(ConfigurationError, match="tool calling is not supported"):
+        await provider.generate(
+            ProviderRequest(
+                model=OPENROUTER_MODEL,
+                parts=["Hello"],
+                tools=[{"name": "get_weather"}],
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_generate_rejects_url_inputs_for_now() -> None:
+    """OpenRouter PR 1 should fail fast on multimodal inputs."""
+    provider = OpenRouterProvider("test-key")
+
+    with pytest.raises(ConfigurationError, match="URL inputs are not supported"):
+        await provider.generate(
+            ProviderRequest(
+                model=OPENROUTER_MODEL,
+                parts=[
+                    {
+                        "uri": "https://example.com/report.pdf",
+                        "mime_type": "application/pdf",
+                    }
+                ],
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_cache_raises() -> None:
+    """create_cache should raise APIError: not supported."""
+    provider = OpenRouterProvider("test-key")
+
+    with pytest.raises(APIError, match="does not support context caching"):
+        await provider.create_cache(model=OPENROUTER_MODEL, parts=["test"])
+
+
+@pytest.mark.asyncio
+async def test_openrouter_aclose_closes_http_client() -> None:
+    """OpenRouter should close its shared HTTP client cleanly."""
+    fake_client = _FakeOpenRouterClient()
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    await provider.aclose()
+
+    assert fake_client.closed is True


### PR DESCRIPTION
## Summary

Add the first OpenRouter provider slice to Pollux using the direct HTTP API. This PR intentionally keeps the surface narrow: text generation plus history-based conversation, with explicit failure for OpenRouter features that are planned for later PRs.

## Related issue

None

## Test plan

- `uv run pytest tests/test_config.py tests/test_providers.py -q`
- `just check`

## Notes

- Uses direct `httpx` integration instead of the OpenRouter Python SDK.
- Keeps OpenRouter text-output-only in this slice.
- Fails fast on tools, uploads, URL/file inputs, caching, and other not-yet-supported OpenRouter features rather than degrading silently.
