### PR TITLE
feat(openrouter): validate model capabilities from OpenRouter metadata

### DIFF
--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -90,6 +90,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 
 - OpenRouter is a routed provider: Pollux sends requests to OpenRouter, and the
   selected model slug determines the upstream model family.
+- Pollux validates OpenRouter model availability and model-level capabilities
+  against the OpenRouter models API metadata.
 - The current Pollux OpenRouter support is intentionally narrow:
   text generation plus text-history conversation only.
 - Pollux does not expose OpenRouter routing controls in the public API.

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
+from dataclasses import dataclass
+import time
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
@@ -18,9 +21,19 @@ from pollux.providers.models import (
 )
 
 _OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+_OPENROUTER_METADATA_TTL_S = 300.0
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+@dataclass(frozen=True)
+class _OpenRouterModelMetadata:
+    """Subset of model metadata used for capability checks."""
+
+    input_modalities: frozenset[str]
+    output_modalities: frozenset[str]
+    supported_parameters: frozenset[str]
 
 
 class OpenRouterProvider:
@@ -30,6 +43,9 @@ class OpenRouterProvider:
         """Initialize with an API key."""
         self.api_key = api_key
         self._client: Any = None
+        self._metadata_by_model: dict[str, _OpenRouterModelMetadata] = {}
+        self._metadata_expires_at = 0.0
+        self._metadata_lock = asyncio.Lock()
 
     @property
     def capabilities(self) -> ProviderCapabilities:
@@ -61,11 +77,7 @@ class OpenRouterProvider:
         request: ProviderRequest,
     ) -> ProviderResponse:
         """Generate a response using OpenRouter chat completions."""
-        if request.tools is not None or request.tool_choice is not None:
-            raise ConfigurationError(
-                "OpenRouter tool calling is not supported yet",
-                hint="Remove tools/tool_choice for now. OpenRouter tool support is planned for a later release.",
-            )
+        await self.validate_request(request)
 
         _ = (
             request.previous_response_id
@@ -113,6 +125,53 @@ class OpenRouterProvider:
 
         return _parse_response(data)
 
+    async def validate_request(self, request: ProviderRequest) -> None:
+        """Validate model-dependent OpenRouter behavior before dispatch."""
+        metadata = await self._get_model_metadata(request.model)
+        _require_text_io(metadata, model=request.model)
+
+        if request.tools is not None or request.tool_choice is not None:
+            _validate_deferred_feature(
+                metadata=metadata,
+                model=request.model,
+                feature_name="tool calling",
+                required_parameters={"tools", "tool_choice"},
+                planned_hint=(
+                    "Remove tools/tool_choice for now. OpenRouter tool support "
+                    "is planned for a later release."
+                ),
+            )
+
+        if request.response_schema is not None:
+            _validate_deferred_feature(
+                metadata=metadata,
+                model=request.model,
+                feature_name="structured outputs",
+                required_parameters={"structured_outputs", "response_format"},
+                planned_hint=(
+                    "Remove response_schema for now. OpenRouter structured "
+                    "output support is planned for a later release."
+                ),
+            )
+
+        if request.reasoning_effort is not None:
+            _validate_deferred_feature(
+                metadata=metadata,
+                model=request.model,
+                feature_name="reasoning controls",
+                required_parameters={"reasoning"},
+                planned_hint=(
+                    "Remove reasoning_effort for now. OpenRouter reasoning "
+                    "support is planned for a later release."
+                ),
+            )
+
+        _validate_input_modalities(
+            metadata=metadata,
+            model=request.model,
+            parts=request.parts,
+        )
+
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
         """Raise because OpenRouter uploads are not supported yet."""
         _ = path, mime_type
@@ -138,6 +197,70 @@ class OpenRouterProvider:
             return
         self._client = None
         await client.aclose()
+
+    async def _get_model_metadata(self, model: str) -> _OpenRouterModelMetadata:
+        """Return cached metadata for *model*, refreshing from OpenRouter as needed."""
+        cached = self._metadata_by_model.get(model)
+        if cached is not None and time.monotonic() < self._metadata_expires_at:
+            return cached
+
+        async with self._metadata_lock:
+            cached = self._metadata_by_model.get(model)
+            if cached is not None and time.monotonic() < self._metadata_expires_at:
+                return cached
+
+            metadata_by_model = await self._fetch_models()
+            self._metadata_by_model = metadata_by_model
+            self._metadata_expires_at = time.monotonic() + _OPENROUTER_METADATA_TTL_S
+
+            refreshed = metadata_by_model.get(model)
+            if refreshed is None:
+                raise ConfigurationError(
+                    f"OpenRouter model not found: {model!r}",
+                    hint="Choose a valid OpenRouter model slug, for example 'openai/gpt-4.1-mini'.",
+                )
+            return refreshed
+
+    async def _fetch_models(self) -> dict[str, _OpenRouterModelMetadata]:
+        """Fetch and normalize the OpenRouter models catalog."""
+        client = self._get_client()
+        try:
+            response = await client.get("/models")
+            if response.is_error:
+                raise httpx.HTTPStatusError(
+                    _extract_error_message(response),
+                    request=response.request,
+                    response=response,
+                )
+            payload = response.json()
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="openrouter",
+                phase="metadata",
+                allow_network_errors=True,
+                message="OpenRouter model metadata lookup failed",
+            ) from e
+
+        if not isinstance(payload, Mapping):
+            raise APIError("OpenRouter models lookup returned a non-object response")
+
+        data = payload.get("data")
+        if not isinstance(data, list):
+            raise APIError("OpenRouter models lookup returned an invalid payload")
+
+        metadata_by_model: dict[str, _OpenRouterModelMetadata] = {}
+        for item in data:
+            if not isinstance(item, Mapping):
+                continue
+            model_id = item.get("id")
+            if not isinstance(model_id, str) or not model_id:
+                continue
+            metadata_by_model[model_id] = _parse_model_metadata(item)
+
+        return metadata_by_model
 
 
 def _build_messages(
@@ -214,6 +337,108 @@ def _normalize_input_part(part: Any) -> str | None:
         f"Unsupported OpenRouter input part: {type(part).__name__}",
         hint="Use plain text sources for now. OpenRouter multimodal input support is planned for a later release.",
     )
+
+
+def _parse_model_metadata(item: Mapping[str, Any]) -> _OpenRouterModelMetadata:
+    """Normalize a models API entry into a compact metadata object."""
+    architecture = item.get("architecture")
+    if not isinstance(architecture, Mapping):
+        architecture = {}
+
+    input_modalities = architecture.get("input_modalities")
+    output_modalities = architecture.get("output_modalities")
+    supported_parameters = item.get("supported_parameters")
+
+    return _OpenRouterModelMetadata(
+        input_modalities=_normalize_str_set(input_modalities),
+        output_modalities=_normalize_str_set(output_modalities),
+        supported_parameters=_normalize_str_set(supported_parameters),
+    )
+
+
+def _normalize_str_set(value: Any) -> frozenset[str]:
+    """Coerce a list-like metadata field into a lowercase string set."""
+    if not isinstance(value, list):
+        return frozenset()
+    return frozenset(
+        item.strip().lower() for item in value if isinstance(item, str) and item.strip()
+    )
+
+
+def _require_text_io(metadata: _OpenRouterModelMetadata, *, model: str) -> None:
+    """Ensure a model can satisfy Pollux's current text-only result contract."""
+    if "text" not in metadata.input_modalities:
+        raise ConfigurationError(
+            f"OpenRouter model {model!r} does not support text input",
+            hint="Choose an OpenRouter chat model that accepts text input.",
+        )
+    if "text" not in metadata.output_modalities:
+        raise ConfigurationError(
+            f"OpenRouter model {model!r} does not support text output",
+            hint="Choose an OpenRouter model with text output for Pollux's current result contract.",
+        )
+
+
+def _validate_deferred_feature(
+    *,
+    metadata: _OpenRouterModelMetadata,
+    model: str,
+    feature_name: str,
+    required_parameters: set[str],
+    planned_hint: str,
+) -> None:
+    """Differentiate unsupported-by-model vs unsupported-by-Pollux."""
+    if metadata.supported_parameters.isdisjoint(required_parameters):
+        raise ConfigurationError(
+            f"OpenRouter model {model!r} does not support {feature_name}",
+            hint=f"Choose an OpenRouter model that supports {feature_name}.",
+        )
+    raise ConfigurationError(
+        f"OpenRouter {feature_name} is not supported yet",
+        hint=planned_hint,
+    )
+
+
+def _validate_input_modalities(
+    *,
+    metadata: _OpenRouterModelMetadata,
+    model: str,
+    parts: list[Any],
+) -> None:
+    """Differentiate unsupported-by-model vs unsupported-by-Pollux multimodal input."""
+    for part in parts:
+        modality = _requested_input_modality(part)
+        if modality is None:
+            continue
+        if modality not in metadata.input_modalities:
+            raise ConfigurationError(
+                f"OpenRouter model {model!r} does not support {modality} input",
+                hint=f"Choose an OpenRouter model that supports {modality} input.",
+            )
+        raise ConfigurationError(
+            "OpenRouter multimodal input is not supported yet",
+            hint=(
+                "Use text sources for now. OpenRouter multimodal input support "
+                "is planned for a later release."
+            ),
+        )
+
+
+def _requested_input_modality(part: Any) -> str | None:
+    """Infer the requested input modality for unsupported non-text parts."""
+    mime_type: Any
+    if isinstance(part, ProviderFileAsset):
+        mime_type = part.mime_type
+    elif isinstance(part, Mapping):
+        mime_type = part.get("mime_type")
+    else:
+        return None
+
+    if not isinstance(mime_type, str):
+        return "file"
+    if mime_type.startswith("image/"):
+        return "image"
+    return "file"
 
 
 def _parse_response(data: Mapping[str, Any]) -> ProviderResponse:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2394,8 +2394,14 @@ def test_openai_parse_response_extracts_tool_calls() -> None:
 class _FakeOpenRouterClient:
     """Captures payloads passed to OpenRouter chat completions."""
 
-    def __init__(self, payload: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        payload: dict[str, Any] | None = None,
+        models_payload: dict[str, Any] | None = None,
+    ) -> None:
         self.last_json: dict[str, Any] | None = None
+        self.get_calls = 0
         self.closed = False
         self._payload = payload or {
             "id": "gen_123",
@@ -2411,11 +2417,60 @@ class _FakeOpenRouterClient:
                 "total_tokens": 15,
             },
         }
+        self._models_payload = models_payload or {
+            "data": [
+                {
+                    "id": OPENROUTER_MODEL,
+                    "architecture": {
+                        "input_modalities": ["text"],
+                        "output_modalities": ["text"],
+                    },
+                    "supported_parameters": [
+                        "max_tokens",
+                        "temperature",
+                        "top_p",
+                    ],
+                },
+                {
+                    "id": "openai/gpt-4.1-mini",
+                    "architecture": {
+                        "input_modalities": ["text", "image", "file"],
+                        "output_modalities": ["text"],
+                    },
+                    "supported_parameters": [
+                        "max_tokens",
+                        "response_format",
+                        "structured_outputs",
+                        "temperature",
+                        "tool_choice",
+                        "tools",
+                        "top_p",
+                    ],
+                },
+                {
+                    "id": "meta-llama/llama-3.2-11b-vision-instruct",
+                    "architecture": {
+                        "input_modalities": ["text", "image"],
+                        "output_modalities": ["text"],
+                    },
+                    "supported_parameters": [
+                        "max_tokens",
+                        "temperature",
+                        "top_p",
+                    ],
+                },
+            ]
+        }
 
     async def post(self, path: str, json: dict[str, Any]) -> Any:
         self.last_json = json
         request = httpx.Request("POST", f"https://openrouter.ai/api/v1{path}")
         return httpx.Response(200, json=self._payload, request=request)
+
+    async def get(self, path: str) -> Any:
+        self.get_calls += 1
+        request = httpx.Request("GET", f"https://openrouter.ai/api/v1{path}")
+        return httpx.Response(200, json=self._models_payload, request=request)
 
     async def aclose(self) -> None:
         self.closed = True
@@ -2464,14 +2519,17 @@ async def test_openrouter_generate_builds_text_and_history_messages() -> None:
         "output_tokens": 5,
         "total_tokens": 15,
     }
+    assert fake_client.get_calls == 1
 
 
 @pytest.mark.asyncio
-async def test_openrouter_generate_rejects_tools_for_now() -> None:
-    """OpenRouter PR 1 should fail fast on unsupported tool definitions."""
+async def test_openrouter_generate_rejects_tools_when_model_lacks_support() -> None:
+    """Metadata should distinguish unsupported-by-model tool calls."""
+    fake_client = _FakeOpenRouterClient()
     provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
 
-    with pytest.raises(ConfigurationError, match="tool calling is not supported"):
+    with pytest.raises(ConfigurationError, match="does not support tool calling"):
         await provider.generate(
             ProviderRequest(
                 model=OPENROUTER_MODEL,
@@ -2482,22 +2540,73 @@ async def test_openrouter_generate_rejects_tools_for_now() -> None:
 
 
 @pytest.mark.asyncio
-async def test_openrouter_generate_rejects_url_inputs_for_now() -> None:
-    """OpenRouter PR 1 should fail fast on multimodal inputs."""
+async def test_openrouter_generate_rejects_tools_when_pollux_support_is_deferred() -> (
+    None
+):
+    """Metadata should distinguish deferred Pollux support from model support."""
+    fake_client = _FakeOpenRouterClient()
     provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
 
-    with pytest.raises(ConfigurationError, match="URL inputs are not supported"):
+    with pytest.raises(ConfigurationError, match="tool calling is not supported yet"):
         await provider.generate(
             ProviderRequest(
-                model=OPENROUTER_MODEL,
+                model="openai/gpt-4.1-mini",
+                parts=["Hello"],
+                tools=[{"name": "get_weather"}],
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_generate_rejects_image_inputs_when_pollux_support_is_deferred() -> (
+    None
+):
+    """Image-capable models should still fail clearly until multimodal lands."""
+    fake_client = _FakeOpenRouterClient()
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    with pytest.raises(
+        ConfigurationError, match="multimodal input is not supported yet"
+    ):
+        await provider.generate(
+            ProviderRequest(
+                model="meta-llama/llama-3.2-11b-vision-instruct",
                 parts=[
                     {
-                        "uri": "https://example.com/report.pdf",
-                        "mime_type": "application/pdf",
+                        "uri": "https://example.com/photo.jpg",
+                        "mime_type": "image/jpeg",
                     }
                 ],
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_validate_request_rejects_unknown_model() -> None:
+    """Unknown OpenRouter model slugs should fail before dispatch."""
+    fake_client = _FakeOpenRouterClient(models_payload={"data": []})
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    with pytest.raises(ConfigurationError, match="model not found"):
+        await provider.validate_request(
+            ProviderRequest(model="missing/model", parts=["Hello"])
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_validate_request_reuses_cached_metadata() -> None:
+    """Metadata lookup should be cached across validations within the TTL."""
+    fake_client = _FakeOpenRouterClient()
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    await provider.validate_request(ProviderRequest(model=OPENROUTER_MODEL, parts=[]))
+    await provider.validate_request(ProviderRequest(model=OPENROUTER_MODEL, parts=[]))
+
+    assert fake_client.get_calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Validate OpenRouter models against the OpenRouter models API before dispatch. This keeps the OpenRouter provider honest about model availability and lets Pollux distinguish between features a model does not support and features Pollux has intentionally deferred to later OpenRouter PRs.

## Related issue

None

## Test plan

- `uv run pytest tests/test_providers.py -q -k openrouter`
- `just check`

## Notes

- Adds an internal metadata cache with TTL and a lock to avoid duplicate `/models` fetches across concurrent validations.
- Keeps the change local to the OpenRouter provider; this PR does not widen Pollux's core capability abstraction.
- Improves errors for unsupported-by-model vs not-yet-implemented-in-Pollux OpenRouter features.
