### PR TITLE
feat(openrouter): add tools and structured outputs

### DIFF
--- a/docs/conversations-and-agents.md
+++ b/docs/conversations-and-agents.md
@@ -218,8 +218,9 @@ round of `tool_calls` (if the model needs more data) or a final text answer.
   returns tool calls, Pollux builds conversation state automatically, even
   without explicit `history` or `continue_from`. This means `continue_tool()`
   works on any result that contains tool calls — no opt-in needed.
-- **Provider differences exist.** Gemini, OpenAI, and Anthropic all support
-  tool calling and tool messages in history. See
+- **Provider differences exist.** Gemini, OpenAI, and Anthropic support tool
+  calling and tool messages in history. OpenRouter supports them on models
+  that advertise tool support. See
   [Provider Capabilities](reference/provider-capabilities.md) for details.
 
 ---

--- a/docs/portable-code.md
+++ b/docs/portable-code.md
@@ -14,8 +14,9 @@ This page shows the patterns that make that work.
 Pollux is capability-transparent, not capability-equalizing. All providers
 support the core text pipeline, but some features are provider-specific. For
 example, Gemini uses explicit cache handles (`create_cache()`), Anthropic uses
-implicit caching (`Options(implicit_caching=True)`), and OpenRouter currently
-does not support Pollux tool calling or structured outputs.
+implicit caching (`Options(implicit_caching=True)`), and OpenRouter exposes
+tool calling and structured outputs only on models that advertise those
+features.
 When you use an unsupported feature for a provider, Pollux raises a
 `ConfigurationError` or `APIError`. No silent degradation.
 This keeps behavior legible in both development and production.
@@ -66,6 +67,7 @@ PROVIDERS = {
     "gemini": ProviderConfig("gemini", "gemini-2.5-flash-lite"),
     "openai": ProviderConfig("openai", "gpt-5-nano"),
     "anthropic": ProviderConfig("anthropic", "claude-haiku-4-5"),
+    "openrouter": ProviderConfig("openrouter", "openai/gpt-5-nano"),
 }
 
 
@@ -98,7 +100,7 @@ async def main() -> None:
     prompt = "Summarize this document with key points and a word count estimate."
 
     # Same function, different providers
-    for provider in ["gemini", "openai"]:
+    for provider in ["gemini", "openai", "anthropic", "openrouter"]:
         try:
             summary = await analyze_document(
                 "report.pdf", prompt, provider_name=provider,
@@ -255,10 +257,11 @@ async def test_analyze_document_mock(provider: str) -> None:
 ## What to Watch For
 
 - **Keep the portable subset in mind.** Text generation and conversation
-  continuity work on all providers. Structured output and tool calling exclude
-  OpenRouter in the current release. Context caching has different paradigms
-  (explicit for Gemini, implicit for Anthropic). YouTube URLs have limited
-  OpenAI and Anthropic support. Check
+  continuity work on all providers. Structured output and tool calling are
+  portable across Gemini, OpenAI, and Anthropic; OpenRouter supports them only
+  on models that advertise the required parameters. Context caching has
+  different paradigms (explicit for Gemini, implicit for Anthropic). YouTube
+  URLs have limited OpenAI and Anthropic support. Check
   [Provider Capabilities](reference/provider-capabilities.md).
 - **Config errors are your portability signal.** A `ConfigurationError` for
   an unsupported feature marks the boundary of portability. Handle it at

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -28,11 +28,11 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | YouTube URL inputs | ✅ | ⚠️ limited | ⚠️ limited | ❌ | OpenAI/Anthropic parity layers (download/re-upload) are out of scope |
 | Explicit context caching (`create_cache`) | ✅ | ❌ | ❌ | ❌ | Persistent cache handles are Gemini-only |
 | Implicit prompt caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | Anthropic-only request-level optimization |
-| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ❌ | OpenRouter support is planned separately |
+| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that advertises `response_format` or `structured_outputs` |
 | Reasoning controls (`reasoning_effort`) | ✅ | ✅ | ✅ | ❌ | Passed through to provider where supported; see notes below |
 | Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | ❌ | ❌ | Not supported; raises `ConfigurationError` |
-| Tool calling | ✅ | ✅ | ✅ | ❌ | OpenRouter support is planned separately |
-| Tool message pass-through in history | ✅ | ✅ | ✅ | ❌ | OpenRouter conversation is text-history only in the current release |
+| Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that advertises `tools`; forced tool use may also require `tool_choice` |
+| Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | Works on OpenRouter models that support tool calling |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
 ## Provider-Specific Notes
@@ -98,11 +98,19 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
   selected model slug determines the upstream model family.
 - Pollux validates OpenRouter model availability and model-level capabilities
   against the OpenRouter models API metadata.
-- The current Pollux OpenRouter support is intentionally narrow:
-  text generation, text-history conversation, and verified image/PDF inputs.
+- The current Pollux OpenRouter support includes text generation, conversation
+  continuity, model-gated structured outputs, model-gated tool calling, and
+  verified image/PDF inputs.
 - Pollux does not expose OpenRouter routing controls in the public API.
 - `continue_from` works through Pollux conversation state replay; there is no
   OpenRouter-specific equivalent to OpenAI's `previous_response_id`.
+- `continue_tool()` works through the same replay path. Pollux carries prior
+  assistant tool calls and tool-result messages forward through history when
+  the selected OpenRouter model supports tool calling.
+- Structured outputs and tool calling are model-dependent on OpenRouter.
+  Pollux checks the OpenRouter models API metadata before dispatch and raises
+  `ConfigurationError` when a selected model does not advertise the required
+  parameters.
 - OpenRouter multimodal input currently supports:
   local image files, image URLs, local PDFs, and PDF URLs.
 - Image input is model-driven. If the selected OpenRouter model does not accept
@@ -124,8 +132,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
   downloading the PDF locally and sending it with `Source.from_file()`.
 - Unsupported OpenRouter file types fail fast. For example, local CSV uploads
   raise `ConfigurationError`.
-- Persistent cache handles, structured outputs, reasoning, and tool calling
-  are planned as separate OpenRouter follow-ups.
+- Persistent cache handles and reasoning controls remain unsupported on
+  OpenRouter in the current release.
 
 ## Error Semantics
 

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -218,8 +218,9 @@ decisions.
 - **Raw text is always available.** Even with `response_schema`, the raw
   model response is in `result["answers"]`. Useful for debugging when the
   structured output doesn't match expectations.
-- **All providers support structured output.** Gemini, OpenAI, and Anthropic
-  all support `response_schema`. See
+- **Structured output is provider- and model-dependent.** Gemini, OpenAI, and
+  Anthropic support `response_schema`. OpenRouter supports it on models that
+  advertise `response_format` or `structured_outputs`. See
   [Provider Capabilities](reference/provider-capabilities.md) for details.
 - **Pydantic v2 is required.** Pollux uses `model_json_schema()` for schema
   generation. Pydantic v2 is a dependency of Pollux.

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -16,16 +16,19 @@ import httpx
 
 from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import wrap_provider_error
+from pollux.providers._utils import to_strict_schema
 from pollux.providers.base import ProviderCapabilities
 from pollux.providers.models import (
     Message,
     ProviderFileAsset,
     ProviderRequest,
     ProviderResponse,
+    ToolCall,
 )
 
 _OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _OPENROUTER_METADATA_TTL_S = 300.0
+_OPENROUTER_REASONING_DETAILS_KEY = "openrouter_reasoning_details"
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -57,7 +60,7 @@ class OpenRouterProvider:
         return ProviderCapabilities(
             persistent_cache=False,
             uploads=True,
-            structured_outputs=False,
+            structured_outputs=True,
             reasoning=False,
             deferred_delivery=False,
             conversation=True,
@@ -90,6 +93,7 @@ class OpenRouterProvider:
         messages = _build_messages(
             request.parts,
             request.history,
+            request.provider_state,
             system_instruction=request.system_instruction,
         )
         payload: dict[str, Any] = {
@@ -102,6 +106,21 @@ class OpenRouterProvider:
             payload["top_p"] = request.top_p
         if request.max_tokens is not None:
             payload["max_tokens"] = request.max_tokens
+        if request.tools is not None:
+            payload["tools"] = self._normalize_tools(request.tools)
+            mapped_tool_choice = self._map_tool_choice(request.tool_choice)
+            if mapped_tool_choice is not None:
+                payload["tool_choice"] = mapped_tool_choice
+        if request.response_schema is not None:
+            strict_schema = to_strict_schema(request.response_schema)
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "pollux_structured_output",
+                    "strict": True,
+                    "schema": strict_schema,
+                },
+            }
 
         client = self._get_client()
         try:
@@ -130,35 +149,70 @@ class OpenRouterProvider:
                 phase="generate",
             )
 
-        return _parse_response(data)
+        return _parse_response(data, response_schema=request.response_schema)
+
+    @staticmethod
+    def _normalize_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Convert Pollux tool dicts to OpenRouter chat-completions format."""
+        result: list[dict[str, Any]] = []
+        for tool in tools:
+            name = tool.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+
+            function: dict[str, Any] = {"name": name}
+            description = tool.get("description")
+            if isinstance(description, str) and description:
+                function["description"] = description
+            parameters = tool.get("parameters")
+            if isinstance(parameters, dict):
+                function["parameters"] = to_strict_schema(parameters)
+
+            result.append({"type": "function", "function": function})
+        return result
+
+    @staticmethod
+    def _map_tool_choice(
+        tool_choice: str | dict[str, Any] | None,
+    ) -> str | dict[str, Any] | None:
+        """Map Pollux tool_choice to OpenRouter chat-completions shape."""
+        if tool_choice is None:
+            return None
+        if isinstance(tool_choice, str):
+            return tool_choice
+        if isinstance(tool_choice, dict) and isinstance(tool_choice.get("name"), str):
+            return {
+                "type": "function",
+                "function": {"name": tool_choice["name"]},
+            }
+        return None
 
     async def validate_request(self, request: ProviderRequest) -> None:
         """Validate model-dependent OpenRouter behavior before dispatch."""
         metadata = await self._get_model_metadata(request.model)
         _require_text_io(metadata, model=request.model)
 
-        if request.tools is not None or request.tool_choice is not None:
-            _validate_deferred_feature(
+        if request.tools is not None:
+            _require_supported_parameter(
                 metadata=metadata,
                 model=request.model,
                 feature_name="tool calling",
-                required_parameters={"tools", "tool_choice"},
-                planned_hint=(
-                    "Remove tools/tool_choice for now. OpenRouter tool support "
-                    "is planned for a later release."
-                ),
+                parameter="tools",
+            )
+        if request.tool_choice is not None:
+            _require_supported_parameter(
+                metadata=metadata,
+                model=request.model,
+                feature_name="tool choice",
+                parameter="tool_choice",
             )
 
         if request.response_schema is not None:
-            _validate_deferred_feature(
+            _require_supported_parameters_any(
                 metadata=metadata,
                 model=request.model,
                 feature_name="structured outputs",
-                required_parameters={"structured_outputs", "response_format"},
-                planned_hint=(
-                    "Remove response_schema for now. OpenRouter structured "
-                    "output support is planned for a later release."
-                ),
+                parameters={"structured_outputs", "response_format"},
             )
 
         if request.reasoning_effort is not None:
@@ -300,6 +354,7 @@ class OpenRouterProvider:
 def _build_messages(
     parts: list[Any],
     history: list[Message] | None,
+    provider_state: dict[str, Any] | None,
     *,
     system_instruction: str | None,
 ) -> list[dict[str, Any]]:
@@ -310,20 +365,11 @@ def _build_messages(
         messages.append({"role": "system", "content": system_instruction})
 
     if history is not None:
-        for item in history:
-            if item.role == "tool" or item.tool_calls:
-                raise ConfigurationError(
-                    "OpenRouter tool history is not supported yet",
-                    hint="Remove tool messages from history for now. OpenRouter tool support is planned for a later release.",
-                )
-            # Note: an empty Message.content sends `{"role": "assistant", "content": ""}`.
-            # This is correct for assistant messages that only include tool calls.
-            messages.append(
-                {
-                    "role": item.role,
-                    "content": item.content,
-                }
-            )
+        for idx, item in enumerate(history):
+            item_provider_state = _get_history_item_provider_state(provider_state, idx)
+            message = _history_message_to_openrouter(item, item_provider_state)
+            if message is not None:
+                messages.append(message)
 
     user_content: list[dict[str, Any]] = []
     for part in parts:
@@ -340,6 +386,40 @@ def _build_messages(
         )
 
     return messages
+
+
+def _history_message_to_openrouter(
+    item: Message,
+    item_provider_state: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Map a Pollux history message into OpenRouter chat-completions format."""
+    if item.role == "tool":
+        if not item.tool_call_id:
+            return None
+        return {
+            "role": "tool",
+            "tool_call_id": item.tool_call_id,
+            "content": item.content,
+        }
+
+    message: dict[str, Any] = {"role": item.role, "content": item.content}
+    tool_calls = _serialize_tool_calls(item.tool_calls)
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    reasoning_details = _extract_reasoning_details(item_provider_state)
+    if reasoning_details:
+        message["reasoning_details"] = reasoning_details
+
+    if (
+        item.role == "assistant"
+        and not item.content
+        and not tool_calls
+        and not reasoning_details
+    ):
+        return None
+
+    return message
 
 
 def _normalize_input_part(part: Any) -> dict[str, Any] | None:
@@ -404,7 +484,7 @@ def _normalize_input_part(part: Any) -> dict[str, Any] | None:
 
     raise ConfigurationError(
         f"Unsupported OpenRouter input part: {type(part).__name__}",
-        hint="Use plain text sources for now. OpenRouter multimodal input support is planned for a later release.",
+        hint="OpenRouter currently supports text, images, and PDFs only.",
     )
 
 
@@ -475,6 +555,38 @@ def _validate_deferred_feature(
     raise ConfigurationError(
         f"OpenRouter {feature_name} is not supported yet",
         hint=planned_hint,
+    )
+
+
+def _require_supported_parameter(
+    *,
+    metadata: _OpenRouterModelMetadata,
+    model: str,
+    feature_name: str,
+    parameter: str,
+) -> None:
+    """Require a specific supported parameter for a model-gated feature."""
+    if parameter in metadata.supported_parameters:
+        return
+    raise ConfigurationError(
+        f"OpenRouter model {model!r} does not support {feature_name}",
+        hint=f"Choose an OpenRouter model that supports {feature_name}.",
+    )
+
+
+def _require_supported_parameters_any(
+    *,
+    metadata: _OpenRouterModelMetadata,
+    model: str,
+    feature_name: str,
+    parameters: set[str],
+) -> None:
+    """Require that metadata exposes at least one compatible parameter."""
+    if not metadata.supported_parameters.isdisjoint(parameters):
+        return
+    raise ConfigurationError(
+        f"OpenRouter model {model!r} does not support {feature_name}",
+        hint=f"Choose an OpenRouter model that supports {feature_name}.",
     )
 
 
@@ -565,7 +677,11 @@ def _pdf_filename(*, uri: str, file_name: str | None = None) -> str:
     return "document.pdf"
 
 
-def _parse_response(data: Mapping[str, Any]) -> ProviderResponse:
+def _parse_response(
+    data: Mapping[str, Any],
+    *,
+    response_schema: dict[str, Any] | None,
+) -> ProviderResponse:
     """Parse an OpenRouter chat-completions payload into ProviderResponse."""
     choices = data.get("choices")
     choice = choices[0] if isinstance(choices, list) and choices else {}
@@ -577,6 +693,15 @@ def _parse_response(data: Mapping[str, Any]) -> ProviderResponse:
         message = {}
 
     text = _extract_message_text(message.get("content"))
+    structured: dict[str, Any] | None = None
+    if response_schema is not None and text:
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, dict):
+            structured = parsed
+
     finish_reason = choice.get("finish_reason")
     if not isinstance(finish_reason, str):
         finish_reason = None
@@ -595,11 +720,20 @@ def _parse_response(data: Mapping[str, Any]) -> ProviderResponse:
             usage["total_tokens"] = total_tokens
 
     response_id = data.get("id")
+    tool_calls = _parse_tool_calls(message.get("tool_calls"))
+    reasoning_details = _normalize_reasoning_details(message.get("reasoning_details"))
     return ProviderResponse(
         text=text,
         usage=usage,
+        structured=structured,
+        tool_calls=tool_calls if tool_calls else None,
         response_id=response_id if isinstance(response_id, str) else None,
         finish_reason=finish_reason,
+        provider_state=(
+            {_OPENROUTER_REASONING_DETAILS_KEY: reasoning_details}
+            if reasoning_details
+            else None
+        ),
     )
 
 
@@ -618,6 +752,97 @@ def _extract_message_text(content: Any) -> str:
         if item.get("type") == "text" and isinstance(item.get("text"), str):
             text_parts.append(item["text"])
     return "\n\n".join(text_parts)
+
+
+def _parse_tool_calls(value: Any) -> list[ToolCall]:
+    """Extract tool calls from an OpenRouter chat-completions assistant message."""
+    if not isinstance(value, list):
+        return []
+
+    tool_calls: list[ToolCall] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            continue
+        function = item.get("function")
+        if not isinstance(function, Mapping):
+            continue
+
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+
+        raw_arguments = function.get("arguments")
+        if isinstance(raw_arguments, str):
+            arguments = raw_arguments
+        else:
+            arguments = json.dumps(raw_arguments if raw_arguments is not None else {})
+
+        raw_id = item.get("id")
+        call_id = raw_id if isinstance(raw_id, str) and raw_id else f"call_{idx}"
+        tool_calls.append(ToolCall(id=call_id, name=name, arguments=arguments))
+
+    return tool_calls
+
+
+def _serialize_tool_calls(tool_calls: list[ToolCall] | None) -> list[dict[str, Any]]:
+    """Serialize Pollux tool calls into OpenRouter's OpenAI-compatible shape."""
+    if not tool_calls:
+        return []
+
+    serialized: list[dict[str, Any]] = []
+    for tool_call in tool_calls:
+        serialized.append(
+            {
+                "id": tool_call.id,
+                "type": "function",
+                "function": {
+                    "name": tool_call.name,
+                    "arguments": tool_call.arguments,
+                },
+            }
+        )
+    return serialized
+
+
+def _normalize_reasoning_details(value: Any) -> list[dict[str, Any]]:
+    """Return a JSON-serializable reasoning_details payload, if present."""
+    if not isinstance(value, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            normalized.append(dict(item))
+    return normalized
+
+
+def _extract_reasoning_details(
+    item_provider_state: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Return preserved OpenRouter reasoning details for a history item."""
+    if item_provider_state is None:
+        return []
+    return _normalize_reasoning_details(
+        item_provider_state.get(_OPENROUTER_REASONING_DETAILS_KEY)
+    )
+
+
+def _get_history_item_provider_state(
+    provider_state: dict[str, Any] | None, index: int
+) -> dict[str, Any] | None:
+    """Return provider_state for a specific history item."""
+    if provider_state is None:
+        return None
+
+    history_states = provider_state.get("history")
+    if not isinstance(history_states, list) or index >= len(history_states):
+        return None
+
+    item_provider_state = history_states[index]
+    if not isinstance(item_provider_state, dict):
+        return None
+
+    return item_provider_state
 
 
 def _extract_error_message(response: httpx.Response) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -194,8 +194,6 @@ async def test_live_tool_calls_conversation_and_reasoning_roundtrip(
     model_fixture: str,
 ) -> None:
     """E2E: tool call + continuation preserves ordering and context."""
-    if provider == "openrouter":
-        pytest.skip("OpenRouter tool calling is not supported yet")
     config = _provider_config(
         request,
         provider=provider,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2610,6 +2610,141 @@ async def test_openrouter_generate_characterizes_image_and_pdf_request_shape(
 
 
 @pytest.mark.asyncio
+async def test_openrouter_generate_characterizes_tool_history_and_schema_shape() -> (
+    None
+):
+    """OpenRouter should replay tool turns and map structured outputs."""
+    fake_client = _FakeOpenRouterClient()
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    await provider.generate(
+        ProviderRequest(
+            model="openai/gpt-4.1-mini",
+            parts=["Use the tool result to answer."],
+            history=[
+                Message(role="user", content="Need orbit code."),
+                Message(
+                    role="assistant",
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id="call_orbit",
+                            name="get_secret",
+                            arguments='{"topic":"orbit"}',
+                        )
+                    ],
+                ),
+                Message(
+                    role="tool",
+                    tool_call_id="call_orbit",
+                    content='{"code":"K9-ORBIT"}',
+                ),
+            ],
+            provider_state={
+                "history": [
+                    None,
+                    {
+                        "openrouter_reasoning_details": [
+                            {
+                                "type": "reasoning.text",
+                                "text": "Need the tool result before answering.",
+                            }
+                        ]
+                    },
+                    None,
+                ]
+            },
+            tools=[
+                {
+                    "name": "get_secret",
+                    "description": "Return a code for a topic.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"topic": {"type": "string"}},
+                        "required": ["topic"],
+                    },
+                }
+            ],
+            tool_choice={"name": "get_secret"},
+            response_schema={
+                "type": "object",
+                "properties": {"secret_code": {"type": "string"}},
+                "required": ["secret_code"],
+            },
+        )
+    )
+
+    assert fake_client.last_json == {
+        "model": "openai/gpt-4.1-mini",
+        "messages": [
+            {"role": "user", "content": "Need orbit code."},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_orbit",
+                        "type": "function",
+                        "function": {
+                            "name": "get_secret",
+                            "arguments": '{"topic":"orbit"}',
+                        },
+                    }
+                ],
+                "reasoning_details": [
+                    {
+                        "type": "reasoning.text",
+                        "text": "Need the tool result before answering.",
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_orbit",
+                "content": '{"code":"K9-ORBIT"}',
+            },
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Use the tool result to answer."}],
+            },
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_secret",
+                    "description": "Return a code for a topic.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"topic": {"type": "string"}},
+                        "required": ["topic"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        ],
+        "tool_choice": {
+            "type": "function",
+            "function": {"name": "get_secret"},
+        },
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "pollux_structured_output",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"secret_code": {"type": "string"}},
+                    "required": ["secret_code"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_openrouter_generate_rejects_tools_when_model_lacks_support() -> None:
     """Metadata should distinguish unsupported-by-model tool calls."""
     fake_client = _FakeOpenRouterClient()
@@ -2627,20 +2762,149 @@ async def test_openrouter_generate_rejects_tools_when_model_lacks_support() -> N
 
 
 @pytest.mark.asyncio
-async def test_openrouter_generate_rejects_tools_when_pollux_support_is_deferred() -> (
+async def test_openrouter_generate_rejects_structured_outputs_when_model_lacks_support() -> (
     None
 ):
-    """Metadata should distinguish deferred Pollux support from model support."""
+    """Metadata should reject schema mode on models without support."""
     fake_client = _FakeOpenRouterClient()
     provider = OpenRouterProvider("test-key")
     provider._client = fake_client
 
-    with pytest.raises(ConfigurationError, match="tool calling is not supported yet"):
+    with pytest.raises(ConfigurationError, match="does not support structured outputs"):
         await provider.generate(
             ProviderRequest(
-                model="openai/gpt-4.1-mini",
+                model=OPENROUTER_MODEL,
                 parts=["Hello"],
-                tools=[{"name": "get_weather"}],
+                response_schema={
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                },
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_parse_response_extracts_tool_calls_and_reasoning_state() -> (
+    None
+):
+    """Tool calls and reasoning_details should survive parsing for continuation."""
+    fake_client = _FakeOpenRouterClient(
+        payload={
+            "id": "gen_tool_123",
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_orbit",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_secret",
+                                    "arguments": '{"topic":"orbit"}',
+                                },
+                            }
+                        ],
+                        "reasoning_details": [
+                            {
+                                "type": "reasoning.text",
+                                "text": "Need the tool result before answering.",
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 11,
+                "completion_tokens": 4,
+                "total_tokens": 15,
+            },
+        }
+    )
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    result = await provider.generate(
+        ProviderRequest(
+            model="openai/gpt-4.1-mini",
+            parts=["Need orbit code."],
+            tools=[{"name": "get_secret"}],
+        )
+    )
+
+    assert result.text == ""
+    assert result.finish_reason == "tool_calls"
+    assert result.tool_calls is not None
+    assert result.tool_calls[0].id == "call_orbit"
+    assert result.tool_calls[0].name == "get_secret"
+    assert result.tool_calls[0].arguments == '{"topic":"orbit"}'
+    assert result.provider_state == {
+        "openrouter_reasoning_details": [
+            {
+                "type": "reasoning.text",
+                "text": "Need the tool result before answering.",
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_openrouter_parse_response_extracts_structured_output() -> None:
+    """Structured responses should parse from JSON text when schema mode is enabled."""
+    fake_client = _FakeOpenRouterClient(
+        payload={
+            "id": "gen_schema_123",
+            "choices": [
+                {
+                    "message": {
+                        "content": '{"secret_code":"K9-ORBIT"}',
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 12,
+                "completion_tokens": 5,
+                "total_tokens": 17,
+            },
+        }
+    )
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    result = await provider.generate(
+        ProviderRequest(
+            model="openai/gpt-4.1-mini",
+            parts=["Need orbit code."],
+            response_schema={
+                "type": "object",
+                "properties": {"secret_code": {"type": "string"}},
+                "required": ["secret_code"],
+            },
+        )
+    )
+
+    assert result.text == '{"secret_code":"K9-ORBIT"}'
+    assert result.structured == {"secret_code": "K9-ORBIT"}
+
+
+@pytest.mark.asyncio
+async def test_openrouter_generate_rejects_tool_choice_when_model_lacks_support() -> (
+    None
+):
+    """Metadata should validate tool_choice separately from tools."""
+    fake_client = _FakeOpenRouterClient()
+    provider = OpenRouterProvider("test-key")
+    provider._client = fake_client
+
+    with pytest.raises(ConfigurationError, match="does not support tool choice"):
+        await provider.generate(
+            ProviderRequest(
+                model=OPENROUTER_MODEL,
+                parts=["Hello"],
+                tool_choice="required",
             )
         )
 


### PR DESCRIPTION
## Summary

Add model-gated OpenRouter tool calling and structured outputs, including conversation-history replay for tool loops. Update the provider capability docs so the public contract matches the new OpenRouter behavior.

## Related issue

None

## Test plan

- `uv run pytest tests/test_providers.py -k openrouter -q`
- `uv run pytest tests/test_pipeline.py -k "tool_calls_preserved_in_conversation_state or continue_from_preserves_tool_history_items or continue_from_forwards_provider_state_with_history_items or continue_tool_mechanics" -q`
- `uv run mkdocs build`
- `uv run python scripts/tmp_openrouter_agent_loop.py --model openai/gpt-5-nano --model openai/gpt-4.1-mini --model google/gemma-3-27b-it:free`
- `uv run python scripts/tmp_openrouter_agent_loop.py --model google/gemma-3-4b-it`

## Notes

- OpenRouter support remains model-dependent; unsupported models fail fast from metadata gating, and some free routes can still fail at the OpenRouter policy layer.
- The temporary smoke script was used for validation only and is not included in this PR.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [ ] `make check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
