### PR TITLE
fix(providers): Anthropic model-specific max_tokens behavior

### DIFF
--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -222,13 +222,20 @@ class AnthropicProvider:
         )
 
         # Build create kwargs.
+        default_max_tokens = _ANTHROPIC_DEFAULT_MAX_TOKENS
+        if "claude-3-" in request.model:
+            # claude-3-haiku, claude-3-sonnet, claude-3-opus only support 4096
+            default_max_tokens = 4096
+            if "claude-3-5" in request.model:
+                default_max_tokens = 8192
+
         create_kwargs: dict[str, Any] = {
             "model": request.model,
             "messages": messages,
             "max_tokens": (
                 request.max_tokens
                 if request.max_tokens is not None
-                else _ANTHROPIC_DEFAULT_MAX_TOKENS
+                else default_max_tokens
             ),
         }
 


### PR DESCRIPTION
## Summary

Fixes Anthropic model-specific `max_tokens` behavior. Isolated model mapping was added to avoid unnecessarily limiting the `max_tokens` for "large" models (like Claude 3.5 Sonnet) to Anthropic's general default.

## Related issue

None

## Test plan

Boundary coverage. This is an isolated mapping for provider-specific default max_tokens configuration. Existing tests for Anthropic provider configuration will cover the boundary.

## Notes

Normally model mapping is avoided, but this is important for not unnecessarily limiting "large" model performance with Anthropic's API.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `make check` passes
- [ ] Tests cover the meaningful cases, not just the happy path
- [ ] Docs updated (if this changes public API or user-facing behavior)
