### PR TITLE
feat(cookbook): add projects tier and streamline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Multimodal orchestration for LLM APIs.
 > You describe what to analyze. Pollux handles source patterns, context caching, and multimodal complexity—so you don't.
 
 [Documentation](https://polluxlib.dev/) ·
-[Quickstart](https://polluxlib.dev/quickstart/) ·
-[Cookbook](https://polluxlib.dev/cookbook/)
+[Getting Started](https://polluxlib.dev/getting-started/) ·
+[Recipe Catalog](https://polluxlib.dev/reference/cli/)
 
 [![PyPI](https://img.shields.io/pypi/v/pollux-ai)](https://pypi.org/project/pollux-ai/)
 [![CI](https://github.com/seanbrar/pollux/actions/workflows/ci.yml/badge.svg)](https://github.com/seanbrar/pollux/actions/workflows/ci.yml)
@@ -42,8 +42,8 @@ To use OpenAI instead: `Config(provider="openai", model="gpt-5-nano")`.
 For Anthropic: `Config(provider="anthropic", model="claude-haiku-4-5")`.
 For OpenRouter: `Config(provider="openrouter", model="google/gemma-3-27b-it:free")`.
 
-For a full 2-minute walkthrough (install, key setup, success checks), see the
-[Quickstart](https://polluxlib.dev/quickstart/).
+For a full 2-minute walkthrough (install, key setup, success checks), see
+[Getting Started](https://polluxlib.dev/getting-started/).
 
 ## Why Pollux?
 
@@ -158,14 +158,12 @@ See the capability matrix: [Provider Capabilities](https://polluxlib.dev/referen
 
 ## Documentation
 
-- [Quickstart](https://polluxlib.dev/quickstart/) — First result in 2 minutes
-- [Concepts](https://polluxlib.dev/concepts/) — Mental model for source patterns and caching
-- [Sources and Patterns](https://polluxlib.dev/sources-and-patterns/) — Source constructors, run/run_many, ResultEnvelope
-- [Configuration](https://polluxlib.dev/configuration/) — Providers, models, retries, caching
-- [Caching and Efficiency](https://polluxlib.dev/caching-and-efficiency/) — TTL management, cache warming, cost savings
-- [Troubleshooting](https://polluxlib.dev/troubleshooting/) — Common issues and solutions
+- [Getting Started](https://polluxlib.dev/getting-started/) — First result in 2 minutes
+- [Core Concepts](https://polluxlib.dev/concepts/) — Mental model and vocabulary
+- [Recipe Catalog](https://polluxlib.dev/reference/cli/) — Runnable cookbook scripts
 - [API Reference](https://polluxlib.dev/reference/api/) — Entry points and types
-- [Cookbook](https://polluxlib.dev/cookbook/) — Scenario-driven, ready-to-run recipes
+
+Full documentation at [polluxlib.dev](https://polluxlib.dev/).
 
 ## Contributing
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -2,12 +2,16 @@
 
 Practical, problem-first recipes for multimodal analysis with Pollux.
 
-This folder contains the runnable recipe code. The canonical cookbook
-documentation (learning paths, recipe pages, and authoring guidance) lives under
-`docs/cookbook/` and is published on the documentation site.
+This folder contains runnable recipe code. The teaching layer lives in the
+published docs under `docs/`, where each concept has one authoritative page.
+Use the cookbook when you want a complete script you can run and modify after
+you understand the concept. Some recipes are compact on-ramps; others are small
+forkable applications under `cookbook/projects/`.
 
-- Start here: `docs/cookbook/index.md`
-- Recipe templates: `docs/cookbook/templates.md`
+- Learn the API and boundaries in `docs/getting-started.md`,
+  `docs/sending-content.md`, `docs/source-patterns.md`, and related topical pages
+- Find recipe specs and descriptions in `docs/reference/cli.md`
+- Start from a template in `cookbook/templates/`
 
 ## Setup
 
@@ -33,7 +37,11 @@ python -m cookbook --list
 python -m cookbook getting-started/analyze-single-paper \
   --input cookbook/data/demo/text-medium/input.txt
 
-# 3) Run against a real provider
+# 3) Run a project recipe
+python -m cookbook projects/paper-to-workshop-kit \
+  --input cookbook/data/demo/multimodal-basic/sample.pdf
+
+# 4) Run against a real provider
 python -m cookbook getting-started/analyze-single-paper \
   --input path/to/file.pdf --no-mock --provider gemini --model gemini-2.5-flash-lite
 ```

--- a/cookbook/projects/paper-to-workshop-kit.py
+++ b/cookbook/projects/paper-to-workshop-kit.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Recipe: Turn one paper into a workshop packet you can actually use.
+
+Problem:
+    A paper summary is not enough when you need to lead a discussion. You need
+    a compact packet that helps a group talk, question, and act.
+
+When to use:
+    - You are preparing a reading group, seminar, or journal club.
+    - You want one paper to produce several discussion-ready outputs.
+
+When not to use:
+    - You only need a quick summary (use analyze-single-paper).
+    - You need a deep research workflow across many papers.
+
+Run:
+    python -m cookbook projects/paper-to-workshop-kit --arxiv 2301.07041 --no-mock
+    python -m cookbook projects/paper-to-workshop-kit --input path/to/paper.pdf
+
+Success check:
+    - Output includes a hook, slide outline, questions, objections, and actions.
+    - Cache status is visible when the provider supports persistent caching.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+import re
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from cookbook.utils.demo_inputs import DEFAULT_MEDIA_DEMO_DIR, resolve_file_or_exit
+from cookbook.utils.presentation import (
+    print_header,
+    print_kv_rows,
+    print_learning_hints,
+    print_section,
+    print_usage,
+)
+from cookbook.utils.runtime import add_runtime_args, build_config_or_exit
+from pollux import Config, Options, Source, create_cache, run_many
+
+if TYPE_CHECKING:
+    from pollux.cache import CacheHandle
+    from pollux.result import ResultEnvelope
+
+DEFAULT_AUDIENCE = "reading group"
+
+
+class SkepticalObjection(BaseModel):
+    objection: str = Field(description="A concise skeptical objection.")
+    why_it_matters: str = Field(description="Why the group should take it seriously.")
+
+
+class WorkshopKit(BaseModel):
+    title: str = Field(description="A short, human-readable paper title.")
+    opening_hook: str = Field(
+        description="A 1-2 sentence opening to start the workshop."
+    )
+    slide_outline: list[str] = Field(
+        description="5-8 slide titles with brief speaker cues."
+    )
+    discussion_questions: list[str] = Field(
+        description="4-6 open discussion questions."
+    )
+    skeptical_objections: list[SkepticalObjection] = Field(
+        description="2-4 skeptical objections with why they matter."
+    )
+    action_items: list[str] = Field(
+        description="3-5 concrete follow-up ideas for the next week."
+    )
+
+
+def build_prompts(audience: str) -> list[tuple[str, str]]:
+    """Return the fixed section prompts for the workshop packet."""
+    return [
+        (
+            "Opening hook",
+            (
+                f"Write a 1-2 sentence opening hook for a {audience}. "
+                "Explain why this paper is worth discussing without hype."
+            ),
+        ),
+        (
+            "Slide outline",
+            (
+                f"Draft a 6-slide outline for a {audience}. "
+                "Keep each slide title concrete and add a short speaker cue."
+            ),
+        ),
+        (
+            "Discussion questions",
+            (
+                f"Write 5 discussion questions for a {audience}. "
+                "Prefer questions that expose assumptions, tradeoffs, or gaps."
+            ),
+        ),
+        (
+            "Skeptical objections",
+            (
+                "List 3 skeptical reviewer objections. "
+                "For each one, explain in one sentence why it matters."
+            ),
+        ),
+        (
+            "Next-week actions",
+            (
+                f"List 4 concrete follow-up actions a {audience} could try next week. "
+                "Keep them specific and realistically scoped."
+            ),
+        ),
+    ]
+
+
+def should_use_cache(config: Config, *, wants_cache: bool) -> tuple[bool, str]:
+    """Return whether to use persistent caching and how to describe the choice."""
+    if not wants_cache:
+        return False, "disabled"
+    if config.use_mock or config.provider == "gemini":
+        return True, "enabled"
+    return False, f"skipped (provider={config.provider} has no persistent cache)"
+
+
+def normalize_lines(text: str) -> list[str]:
+    """Turn model text into a compact list of display lines."""
+    items: list[str] = []
+    for raw in text.splitlines():
+        cleaned = re.sub(r"^\s*(?:[-*]|\d+[.)])\s*", "", raw).strip()
+        if cleaned:
+            items.append(cleaned)
+    if items:
+        return items
+    clipped = text.strip()
+    return [clipped] if clipped else []
+
+
+def build_notes(section_answers: list[tuple[str, str]]) -> str:
+    """Assemble section outputs into one draft note bundle."""
+    blocks: list[str] = []
+    for label, answer in section_answers:
+        blocks.append(f"{label}\n{answer.strip()}")
+    return "\n\n".join(blocks)
+
+
+def fallback_packet(
+    *, source_label: str, section_answers: list[tuple[str, str]]
+) -> WorkshopKit:
+    """Build a packet from raw section answers when structured output fails."""
+    by_label = dict(section_answers)
+    return WorkshopKit(
+        title=Path(source_label).stem.replace("-", " ").replace("_", " ").strip()
+        or source_label,
+        opening_hook=by_label.get("Opening hook", "").strip(),
+        slide_outline=normalize_lines(by_label.get("Slide outline", ""))[:6],
+        discussion_questions=normalize_lines(by_label.get("Discussion questions", ""))[
+            :5
+        ],
+        skeptical_objections=[
+            SkepticalObjection(objection=line, why_it_matters="")
+            for line in normalize_lines(by_label.get("Skeptical objections", ""))[:3]
+        ],
+        action_items=normalize_lines(by_label.get("Next-week actions", ""))[:4],
+    )
+
+
+def mock_packet(*, source_label: str, audience: str) -> WorkshopKit:
+    """Return a credible packet shape for mock-mode first runs."""
+    title = Path(source_label).stem.replace("-", " ").replace("_", " ").strip()
+    title = title or "sample paper"
+    return WorkshopKit(
+        title=title,
+        opening_hook=(
+            f"This paper gives a {audience} something concrete to test, debate, "
+            "and carry into the next session."
+        ),
+        slide_outline=[
+            "What problem is the paper trying to solve?",
+            "What did the authors actually build or test?",
+            "What evidence supports the main claim?",
+            "Where are the assumptions or blind spots?",
+            "What would change our mind?",
+            "What should we try next week?",
+        ],
+        discussion_questions=[
+            "Which claim feels strongest, and which feels most fragile?",
+            "What background knowledge does the paper assume?",
+            "What would a skeptical reader ask for next?",
+            "Which result is interesting enough to reproduce or extend?",
+            "Where does this paper fit into the broader conversation?",
+        ],
+        skeptical_objections=[
+            SkepticalObjection(
+                objection="The evidence may not justify the strongest framing.",
+                why_it_matters="A good workshop should separate what the paper proves from what it implies.",
+            ),
+            SkepticalObjection(
+                objection="The evaluation setup may be narrower than the claims.",
+                why_it_matters="If the test bed is narrow, the room should discuss how well the result travels.",
+            ),
+            SkepticalObjection(
+                objection="Important implementation details may be underspecified.",
+                why_it_matters="Missing details affect whether the group can trust or reproduce the work.",
+            ),
+        ],
+        action_items=[
+            "Pick one figure or result to reproduce locally.",
+            "List the paper's strongest assumption and how to test it.",
+            "Compare this paper to one adjacent baseline or prior work.",
+            "Write down one question to revisit after the workshop.",
+        ],
+    )
+
+
+def merged_usage(*envelopes: ResultEnvelope) -> ResultEnvelope:
+    """Merge usage blocks so the printed token summary reflects the whole flow."""
+    usage: dict[str, int] = {}
+    for envelope in envelopes:
+        raw = envelope.get("usage")
+        if not isinstance(raw, dict):
+            continue
+        for key, value in raw.items():
+            if isinstance(value, int):
+                usage[key] = usage.get(key, 0) + value
+    return {"usage": usage}
+
+
+def print_items(title: str, items: list[str]) -> None:
+    """Print a short bullet list section."""
+    if not items:
+        return
+    print_section(title)
+    for item in items:
+        print(f"- {item}")
+
+
+def print_objections(objections: list[SkepticalObjection]) -> None:
+    """Print skeptical objections in a compact workshop-friendly form."""
+    if not objections:
+        return
+    print_section("Skeptical objections")
+    for item in objections:
+        print(f"- {item.objection}")
+        print(f"  Why it matters: {item.why_it_matters}")
+
+
+async def build_packet(
+    source: Source,
+    *,
+    source_label: str,
+    audience: str,
+    config: Config,
+    ttl: int,
+    wants_cache: bool,
+) -> tuple[WorkshopKit, ResultEnvelope, ResultEnvelope, str]:
+    """Build the workshop packet from one paper source."""
+    prompts = build_prompts(audience)
+    use_cache, cache_label = should_use_cache(config, wants_cache=wants_cache)
+    cache_handle: CacheHandle | None = None
+
+    if use_cache:
+        cache_handle = await create_cache([source], config=config, ttl_seconds=ttl)
+        section_env = await run_many(
+            [prompt for _, prompt in prompts],
+            config=config,
+            options=Options(cache=cache_handle),
+        )
+    else:
+        section_env = await run_many(
+            [prompt for _, prompt in prompts],
+            sources=[source],
+            config=config,
+        )
+
+    section_answers = [
+        (label, str(answer))
+        for (label, _), answer in zip(
+            prompts, section_env.get("answers", []), strict=False
+        )
+    ]
+    notes = build_notes(section_answers)
+
+    if config.use_mock:
+        packet = mock_packet(source_label=source_label, audience=audience)
+        return packet, section_env, {"usage": {}}, cache_label
+
+    final_prompt = (
+        f"Build a compact workshop packet for a {audience}. "
+        "Use the paper faithfully, keep the tone practical, and avoid hype.\n\n"
+        "Draft notes:\n"
+        f"{notes}"
+    )
+
+    if cache_handle is not None:
+        packet_env = await run_many(
+            [final_prompt],
+            config=config,
+            options=Options(cache=cache_handle, response_schema=WorkshopKit),
+        )
+    else:
+        packet_env = await run_many(
+            [final_prompt],
+            sources=[
+                source,
+                Source.from_text(notes, identifier="draft-workshop-notes"),
+            ],
+            config=config,
+            options=Options(response_schema=WorkshopKit),
+        )
+
+    structured = packet_env.get("structured", [])
+    first = structured[0] if isinstance(structured, list) and structured else None
+    packet = (
+        first
+        if isinstance(first, WorkshopKit)
+        else fallback_packet(source_label=source_label, section_answers=section_answers)
+    )
+    return packet, section_env, packet_env, cache_label
+
+
+async def main_async(
+    source: Source,
+    *,
+    source_label: str,
+    audience: str,
+    config: Config,
+    ttl: int,
+    wants_cache: bool,
+) -> None:
+    packet, section_env, packet_env, cache_label = await build_packet(
+        source,
+        source_label=source_label,
+        audience=audience,
+        config=config,
+        ttl=ttl,
+        wants_cache=wants_cache,
+    )
+    slide_count = len(packet.slide_outline)
+    question_count = len(packet.discussion_questions)
+    objection_count = len(packet.skeptical_objections)
+    action_count = len(packet.action_items)
+
+    print_section("Workshop packet")
+    print_kv_rows(
+        [
+            ("Status", packet_env.get("status", section_env.get("status", "ok"))),
+            ("Source", source_label),
+            ("Audience", audience),
+            ("Cache", cache_label),
+            ("Slides", slide_count),
+            ("Questions", question_count),
+            ("Objections", objection_count),
+            ("Actions", action_count),
+        ]
+    )
+
+    print_section("Opening hook")
+    print(f"  {packet.opening_hook}")
+    print_items("Slide outline", packet.slide_outline)
+    print_items("Discussion questions", packet.discussion_questions)
+    print_objections(packet.skeptical_objections)
+    print_items("Next-week actions", packet.action_items)
+    print_usage(merged_usage(section_env, packet_env))
+    print_learning_hints(
+        [
+            "Next: swap the audience to see how the packet changes for a different room.",
+            "Next: trim or reorder the slide outline before using it live.",
+        ]
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Turn one paper into a workshop packet with slides, questions, objections, and actions.",
+    )
+    parser.add_argument(
+        "--input", type=Path, default=None, help="Path to a local paper file"
+    )
+    parser.add_argument(
+        "--arxiv",
+        default=None,
+        help="arXiv id or URL to analyze instead of a local file",
+    )
+    parser.add_argument(
+        "--audience",
+        default=DEFAULT_AUDIENCE,
+        help="Who the packet is for (for example: reading group, seminar, journal club).",
+    )
+    parser.add_argument(
+        "--ttl",
+        type=int,
+        default=3600,
+        help="Cache TTL in seconds when persistent caching is enabled.",
+    )
+    parser.add_argument(
+        "--cache",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use persistent caching when the provider supports it.",
+    )
+    add_runtime_args(parser)
+    args = parser.parse_args()
+
+    if args.input is not None and args.arxiv is not None:
+        raise SystemExit("Choose exactly one of --input or --arxiv.")
+
+    if args.arxiv:
+        source = Source.from_arxiv(args.arxiv)
+        source_label = args.arxiv
+    else:
+        path = resolve_file_or_exit(
+            args.input,
+            search_dir=DEFAULT_MEDIA_DEMO_DIR,
+            exts=[".pdf", ".txt", ".md"],
+            hint="No paper found. Run `just demo-data` or pass --input /path/to/paper.pdf.",
+        )
+        if path.suffix.lower() in {".txt", ".md"}:
+            source = Source.from_text(
+                path.read_text(encoding="utf-8"), identifier=path.name
+            )
+        else:
+            source = Source.from_file(path)
+        source_label = str(path)
+
+    config = build_config_or_exit(args)
+    print_header("Paper-to-Workshop Kit", config=config)
+    asyncio.run(
+        main_async(
+            source,
+            source_label=source_label,
+            audience=args.audience.strip() or DEFAULT_AUDIENCE,
+            config=config,
+            ttl=max(1, int(args.ttl)),
+            wants_cache=bool(args.cache),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbook/utils/runtime.py
+++ b/cookbook/utils/runtime.py
@@ -20,7 +20,7 @@ def add_runtime_args(parser: argparse.ArgumentParser) -> None:
     """Add common provider/model/runtime arguments to a recipe parser."""
     parser.add_argument(
         "--provider",
-        choices=("gemini", "openai"),
+        choices=("gemini", "openai", "anthropic", "openrouter"),
         default=DEFAULT_PROVIDER,
         help="Model provider to use.",
     )

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -79,9 +79,13 @@ Recipes live in `cookbook/`, organized by scenario. Each recipe should:
 - Be self-contained (no ambient CWD assumptions)
 - Support `--mock` and `--no-mock` modes
 
-Structure flows from the scenario — there's no rigid section template. That
-said, most good recipes cover: what you'll run, what you'll see, how to tune
-it, and where to go next. Look at existing recipes for examples.
+Recipes complement the docs. They are runnable starting points, not a second
+teaching layer. If a recipe introduces or depends on a user-facing concept,
+the authoritative explanation belongs on the matching page under `docs/`.
+
+Structure flows from the scenario — there's no rigid section template. Most
+good recipes cover: what you'll run, what you'll see, how to tune it, and
+where to go next. Look at existing recipes for examples.
 
 **Running recipes:**
 
@@ -92,4 +96,6 @@ python -m cookbook getting-started/analyze-single-paper --mock
 
 **Adding a recipe:** create the Python script in `cookbook/<category>/` and
 reuse shared runtime args from `cookbook.utils.runtime`. The recipe catalog
-in [CLI](reference/cli.md#recipe-catalog) lists all available recipes.
+in [CLI](reference/cli.md#recipe-catalog) lists all available recipes. Update
+the authoritative topical docs in the same PR when the recipe adds a new
+concept or changes user-facing behavior.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,8 +1,19 @@
 # CLI - Cookbook Runner
 
+Use cookbook recipes when you want a full runnable script you can execute,
+inspect, and modify. The docs pages teach Pollux concepts and boundaries; the
+cookbook gives you end-to-end starting points that apply those concepts in
+real workflows.
+
 Pollux currently ships one documented CLI surface:
 
 - `python -m cookbook`: run recipes under `cookbook/` without manual `PYTHONPATH` setup.
+
+## How Recipes Fit the Docs
+
+- Read the topical docs when you need to understand a concept, boundary, or API shape.
+- Run a cookbook recipe when you want a complete script with CLI flags, mock mode, and inspectable output.
+- Treat recipes as forkable starting points, not as the only place a concept is explained.
 
 ## Prerequisites
 
@@ -45,6 +56,9 @@ python -m cookbook
 
 # Run by cookbook-relative path
 python -m cookbook optimization/cache-warming-and-ttl --limit 2 --ttl 3600
+
+# Run a project recipe
+python -m cookbook projects/paper-to-workshop-kit --input path/to/paper.pdf
 
 # Run by dotted spec
 python -m cookbook production.resume_on_failure --limit 1
@@ -91,19 +105,20 @@ py -m cookbook production.resume_on_failure --limit 1
 
 All recipes support `--mock / --no-mock`, `--provider`, `--model`, and `--api-key` flags. Start in `--mock` to validate flow, switch to `--no-mock` when prompts are stable.
 
-| Recipe | Spec | Focus |
-|---|---|---|
-| Analyze Single Paper | `getting-started/analyze-single-paper` | Single-source baseline and output inspection |
-| Broadcast Process Files | `getting-started/broadcast-process-files` | Multi-file processing with shared prompts |
-| Structured Output Extraction | `getting-started/structured-output-extraction` | Schema-first typed extraction |
-| Extract Media Insights | `getting-started/extract-media-insights` | Image/audio/video analysis baseline |
-| Run vs RunMany | `optimization/run-vs-run-many` | Prompt batching and overhead comparison |
-| Cache Warming and TTL | `optimization/cache-warming-and-ttl` | Cache impact and TTL tuning |
-| Large-Scale Fan-Out | `optimization/large-scale-fan-out` | Bounded client-side concurrency |
-| Comparative Analysis | `research-workflows/comparative-analysis` | Structured source-to-source comparison |
-| Multi-Video Synthesis | `research-workflows/multi-video-synthesis` | Cross-video synthesis |
-| Rate Limits and Concurrency | `production/rate-limits-and-concurrency` | Throughput controls and concurrency tuning |
-| Resume on Failure | `production/resume-on-failure` | Durable manifest + retry/resume |
+| Recipe | Spec | Use it when you want to... | Learn the concept in docs |
+|---|---|---|---|
+| Analyze Single Paper | `getting-started/analyze-single-paper` | validate your install and inspect one result from one source | [Sending Content to Models](../sending-content.md) |
+| Broadcast Process Files | `getting-started/broadcast-process-files` | process a directory with the same analysis prompts per file | [Analyzing Collections with Source Patterns](../source-patterns.md) |
+| Structured Output Extraction | `getting-started/structured-output-extraction` | return typed objects instead of parsing JSON by hand | [Extracting Structured Data](../structured-data.md) |
+| Extract Media Insights | `getting-started/extract-media-insights` | analyze one image, audio file, or video with the same entry point | [Sending Content to Models](../sending-content.md) |
+| Paper-to-Workshop Kit | `projects/paper-to-workshop-kit` | turn one paper into a discussion-ready packet with slides, questions, objections, and actions | [Reducing Costs with Context Caching](../caching.md) |
+| Run vs RunMany | `optimization/run-vs-run-many` | compare prompt loops against one `run_many()` call | [Analyzing Collections with Source Patterns](../source-patterns.md) |
+| Cache Warming and TTL | `optimization/cache-warming-and-ttl` | measure cache reuse and choose a TTL for repeated prompts | [Reducing Costs with Context Caching](../caching.md) |
+| Large-Scale Fan-Out | `optimization/large-scale-fan-out` | fan out per-file work with bounded client-side concurrency | [Analyzing Collections with Source Patterns](../source-patterns.md) |
+| Comparative Analysis | `research-workflows/comparative-analysis` | compare two sources and emit structured JSON output | [Analyzing Collections with Source Patterns](../source-patterns.md) |
+| Multi-Video Synthesis | `research-workflows/multi-video-synthesis` | synthesize themes across multiple video sources | [Analyzing Collections with Source Patterns](../source-patterns.md) |
+| Rate Limits and Concurrency | `production/rate-limits-and-concurrency` | tune concurrency without overrunning provider limits | [Configuring Pollux](../configuration.md) |
+| Resume on Failure | `production/resume-on-failure` | checkpoint long-running work and resume failed items | [Handling Errors and Recovery](../error-handling.md) |
 
 ### Learning Paths
 
@@ -111,6 +126,8 @@ All recipes support `--mock / --no-mock`, `--provider`, `--model`, and `--api-ke
 `structured-output-extraction` → `comparative-analysis`
 
 **Efficiency and scale:** `run-vs-run-many` → `cache-warming-and-ttl` → `large-scale-fan-out`
+
+**Build something useful:** `analyze-single-paper` → `projects/paper-to-workshop-kit`
 
 **Production hardening:** `rate-limits-and-concurrency` → `resume-on-failure`
 

--- a/tests/test_cookbook_contract.py
+++ b/tests/test_cookbook_contract.py
@@ -28,6 +28,27 @@ def test_recipe_catalog_is_complete() -> None:
         )
 
 
+def test_no_stale_cookbook_doc_references() -> None:
+    """User-facing entry points should not reference the removed cookbook docs layer."""
+    stale_patterns = {
+        ROOT / "README.md": [
+            "https://polluxlib.dev/cookbook/",
+            "https://polluxlib.dev/quickstart/",
+            "https://polluxlib.dev/sources-and-patterns/",
+            "https://polluxlib.dev/caching-and-efficiency/",
+            "https://polluxlib.dev/troubleshooting/",
+        ],
+        ROOT / "cookbook" / "README.md": ["docs/cookbook/"],
+    }
+
+    for path, patterns in stale_patterns.items():
+        if not path.exists():
+            continue
+        text = path.read_text()
+        for pattern in patterns:
+            assert pattern not in text, f"stale reference {pattern!r} found in {path}"
+
+
 @pytest.mark.integration
 def test_all_recipes_run_in_mock_mode(tmp_path: Path) -> None:
     """Smoke test that each recipe runs successfully in mock mode.
@@ -66,6 +87,7 @@ def test_all_recipes_run_in_mock_mode(tmp_path: Path) -> None:
         f"python -m cookbook getting-started/extract-media-insights --input {image} --mock",
         f"python -m cookbook getting-started/extract-media-insights --input {video} --mock",
         f"python -m cookbook getting-started/extract-media-insights --input {audio} --mock",
+        f"python -m cookbook projects/paper-to-workshop-kit --input {input_txt} --mock",
         f"python -m cookbook optimization/cache-warming-and-ttl --input {text_dir} --limit 1 --ttl 300 --mock",
         f"python -m cookbook optimization/large-scale-fan-out --input {text_dir} --limit 1 --concurrency 1 --mock",
         f"python -m cookbook optimization/run-vs-run-many --input {input_txt} --mock",


### PR DESCRIPTION
## Summary

Introduce a `projects/` cookbook tier for cross-concept recipes that combine
multiple Pollux primitives into forkable applications. Streamline the README
Documentation section and align cookbook guidance across docs.

## Related issue

None

## Test plan

- `just check` passes (lint + typecheck + 205 tests)
- `test_no_stale_cookbook_doc_references` verifies no old cookbook/quickstart
  URLs survive in README or cookbook README
- `test_all_recipes_run_in_mock_mode` includes the new Paper-to-Workshop Kit
  recipe (`--input input.txt --mock`)
- `test_recipe_catalog_is_complete` confirms the new recipe appears in
  `docs/reference/cli.md`

## Notes

- The Paper-to-Workshop Kit is the first `projects/` recipe. It demonstrates
  the two-stage pattern (fan-out section prompts over a cached source, then
  synthesize into a structured `WorkshopKit` via `response_schema`). This
  crosses caching, fan-out, and structured output — three concept boundaries.
- README Documentation section trimmed from 13 links to 4 entry points
  plus a "full docs" link, per the principle that the docs site nav should
  be the canonical table of contents.
- `cookbook/utils/runtime.py` adds anthropic and openrouter to `--provider`
  choices so all four supported providers work from cookbook recipes.