### PR TITLE
chore(openrouter): remove unused _validate_deferred_feature helper

### DIFF
--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -542,26 +542,6 @@ def _require_text_io(metadata: _OpenRouterModelMetadata, *, model: str) -> None:
         )
 
 
-def _validate_deferred_feature(
-    *,
-    metadata: _OpenRouterModelMetadata,
-    model: str,
-    feature_name: str,
-    required_parameters: set[str],
-    planned_hint: str,
-) -> None:
-    """Differentiate unsupported-by-model vs unsupported-by-Pollux."""
-    if metadata.supported_parameters.isdisjoint(required_parameters):
-        raise ConfigurationError(
-            f"OpenRouter model {model!r} does not support {feature_name}",
-            hint=f"Choose an OpenRouter model that supports {feature_name}.",
-        )
-    raise ConfigurationError(
-        f"OpenRouter {feature_name} is not supported yet",
-        hint=planned_hint,
-    )
-
-
 def _require_supported_parameter(
     *,
     metadata: _OpenRouterModelMetadata,


### PR DESCRIPTION
## Summary

Remove dead `_validate_deferred_feature()` from the OpenRouter provider. It was scaffolding for incremental feature rollout during #142–#145; all guarded features shipped, so the function was never called.

## Related issue

None

## Test plan

Non-behavioral change (dead code removal). `just check` passes — lint, typecheck, 211 tests.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)