### PR TITLE
feat(openai): add deferred delivery backend

### DIFF
--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -14,6 +14,7 @@ from pollux.options import (
 from pollux.providers.base import (
     DeferredProvider,
     Provider,
+    ProviderDeferredHandle,
     ProviderDeferredItem,
     ProviderDeferredSnapshot,
 )
@@ -50,6 +51,7 @@ class DeferredHandle:
     request_count: int
     submitted_at: float
     schema_hash: str | None = None
+    provider_state: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the handle for persistence."""
@@ -68,6 +70,11 @@ class DeferredHandle:
                 None
                 if data.get("schema_hash") is None
                 else str(data.get("schema_hash"))
+            ),
+            provider_state=(
+                dict(data["provider_state"])
+                if isinstance(data.get("provider_state"), dict)
+                else None
             ),
         )
 
@@ -111,6 +118,19 @@ def _get_deferred_provider(provider: Provider) -> DeferredProvider:
 
 def _request_ids(count: int) -> list[str]:
     return [f"pollux-{idx:06d}" for idx in range(count)]
+
+
+def _provider_handle_from_handle(handle: DeferredHandle) -> ProviderDeferredHandle:
+    """Rebuild the provider-facing deferred handle from the public Pollux handle."""
+    return ProviderDeferredHandle(
+        job_id=handle.job_id,
+        submitted_at=handle.submitted_at,
+        provider_state=(
+            dict(handle.provider_state)
+            if isinstance(handle.provider_state, dict)
+            else None
+        ),
+    )
 
 
 def _validate_deferred_plan(plan: Plan, provider: Provider) -> None:
@@ -210,6 +230,11 @@ async def submit_deferred(plan: Plan, provider: Provider) -> DeferredHandle:
         request_count=len(plan.request.prompts),
         submitted_at=submitted_at,
         schema_hash=plan.request.options.response_schema_hash(),
+        provider_state=(
+            dict(provider_handle.provider_state)
+            if isinstance(provider_handle.provider_state, dict)
+            else None
+        ),
     )
 
 
@@ -247,7 +272,7 @@ async def inspect_deferred_handle(
     deferred_provider = _get_deferred_provider(provider)
     return _snapshot_from_provider(
         handle,
-        await deferred_provider.inspect_deferred(handle.job_id),
+        await deferred_provider.inspect_deferred(_provider_handle_from_handle(handle)),
     )
 
 
@@ -317,7 +342,9 @@ async def collect_deferred_handle(
     if not snapshot.is_terminal:
         raise DeferredNotReadyError(snapshot)
 
-    items = await deferred_provider.collect_deferred(handle.job_id)
+    items = await deferred_provider.collect_deferred(
+        _provider_handle_from_handle(handle)
+    )
     items_by_id: dict[str, ProviderDeferredItem] = {}
     for item in items:
         if item.request_id in items_by_id:
@@ -384,4 +411,4 @@ async def collect_deferred_handle(
 async def cancel_deferred_handle(handle: DeferredHandle, provider: Provider) -> None:
     """Request provider-side cancellation for a deferred job."""
     deferred_provider = _get_deferred_provider(provider)
-    await deferred_provider.cancel_deferred(handle.job_id)
+    await deferred_provider.cancel_deferred(_provider_handle_from_handle(handle))

--- a/src/pollux/providers/base.py
+++ b/src/pollux/providers/base.py
@@ -36,6 +36,7 @@ class ProviderDeferredHandle:
 
     job_id: str
     submitted_at: float | None = None
+    provider_state: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -111,14 +112,18 @@ class DeferredProvider(Protocol):
         """Submit deferred work and return a provider-owned handle."""
         ...
 
-    async def inspect_deferred(self, job_id: str) -> ProviderDeferredSnapshot:
+    async def inspect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> ProviderDeferredSnapshot:
         """Inspect deferred job state."""
         ...
 
-    async def collect_deferred(self, job_id: str) -> list[ProviderDeferredItem]:
+    async def collect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> list[ProviderDeferredItem]:
         """Collect terminal deferred results."""
         ...
 
-    async def cancel_deferred(self, job_id: str) -> None:
+    async def cancel_deferred(self, handle: ProviderDeferredHandle) -> None:
         """Request provider-side cancellation."""
         ...

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -4,23 +4,28 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import io
 import json
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from pollux.errors import APIError
 from pollux.providers._errors import wrap_provider_error
 from pollux.providers._utils import to_strict_schema
-from pollux.providers.base import ProviderCapabilities
+from pollux.providers.base import (
+    DeferredItemStatus,
+    ProviderCapabilities,
+    ProviderDeferredHandle,
+    ProviderDeferredItem,
+    ProviderDeferredSnapshot,
+)
 from pollux.providers.models import (
     ProviderFileAsset,
     ProviderRequest,
     ProviderResponse,
     ToolCall,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class OpenAIProvider:
@@ -52,7 +57,7 @@ class OpenAIProvider:
             uploads=True,
             structured_outputs=True,
             reasoning=True,
-            deferred_delivery=False,
+            deferred_delivery=True,
             conversation=True,
         )
 
@@ -173,49 +178,58 @@ class OpenAIProvider:
 
     @staticmethod
     def _parse_response(
-        response: Any, *, response_schema: dict[str, Any] | None
+        response: Any,
+        *,
+        response_schema: dict[str, Any] | None,
+        parse_structured_json: bool = False,
     ) -> ProviderResponse:
         """Parse an OpenAI response into ProviderResponse."""
-        text = getattr(response, "output_text", "") or ""
-        response_id = getattr(response, "id", None)
+        text = _extract_output_text(response)
+        response_id = _field(response, "id")
         finish_reason = _extract_finish_reason(response)
 
         structured: Any = None
-        if response_schema is not None and text:
+        if (response_schema is not None or parse_structured_json) and text:
             try:
                 structured = json.loads(text)
             except Exception:
                 structured = None
 
-        usage_raw = getattr(response, "usage", None)
+        usage_raw = _field(response, "usage")
         usage: dict[str, int] = {}
         if usage_raw is not None:
-            usage = {
-                "input_tokens": int(getattr(usage_raw, "input_tokens", 0)),
-                "output_tokens": int(getattr(usage_raw, "output_tokens", 0)),
-                "total_tokens": int(getattr(usage_raw, "total_tokens", 0)),
-            }
-            out_details = getattr(usage_raw, "output_tokens_details", None)
+            input_tokens = _field(usage_raw, "input_tokens")
+            output_tokens = _field(usage_raw, "output_tokens")
+            total_tokens = _field(usage_raw, "total_tokens")
+            if isinstance(input_tokens, int):
+                usage["input_tokens"] = input_tokens
+            if isinstance(output_tokens, int):
+                usage["output_tokens"] = output_tokens
+            if isinstance(total_tokens, int):
+                usage["total_tokens"] = total_tokens
+            out_details = _field(usage_raw, "output_tokens_details")
             if out_details:
-                reasoning_toks = getattr(out_details, "reasoning_tokens", None)
+                reasoning_toks = _field(out_details, "reasoning_tokens")
                 if reasoning_toks is not None:
                     usage["reasoning_tokens"] = int(reasoning_toks)
 
         tool_calls: list[ToolCall] = []
         reasoning_parts: list[str] = []
-        for item in getattr(response, "output", []):
-            if item.type == "function_call":
+        for item in _field(response, "output", []) or []:
+            item_type = _field(item, "type")
+            if item_type == "function_call":
                 tool_calls.append(
                     ToolCall(
-                        id=item.call_id,
-                        name=item.name,
-                        arguments=item.arguments or "{}",
+                        id=str(_field(item, "call_id", "")),
+                        name=str(_field(item, "name", "")),
+                        arguments=str(_field(item, "arguments", "{}") or "{}"),
                     )
                 )
-            elif item.type == "reasoning":
-                for summary_item in item.summary or []:
-                    if summary_item.text:
-                        reasoning_parts.append(summary_item.text)
+            elif item_type == "reasoning":
+                for summary_item in _field(item, "summary", []) or []:
+                    summary_text = _field(summary_item, "text")
+                    if isinstance(summary_text, str) and summary_text:
+                        reasoning_parts.append(summary_text)
 
         return ProviderResponse(
             text=text,
@@ -229,6 +243,150 @@ class OpenAIProvider:
             finish_reason=finish_reason,
         )
 
+    async def submit_deferred(
+        self,
+        requests: list[ProviderRequest],
+        *,
+        request_ids: list[str],
+    ) -> ProviderDeferredHandle:
+        """Submit deferred work through the OpenAI Batch API."""
+        client = self._get_client()
+
+        try:
+            lines: list[str] = []
+            for request_id, request in zip(request_ids, requests, strict=True):
+                body = await self._build_batch_request_body(request)
+                lines.append(
+                    json.dumps(
+                        {
+                            "custom_id": request_id,
+                            "method": "POST",
+                            "url": "/v1/responses",
+                            "body": body,
+                        },
+                        separators=(",", ":"),
+                    )
+                )
+
+            payload = ("\n".join(lines) + "\n").encode("utf-8")
+            upload = io.BytesIO(payload)
+            upload.name = "pollux-batch.jsonl"
+
+            batch_file = await client.files.create(
+                file=upload,
+                purpose="batch",
+            )
+            batch = await client.batches.create(
+                input_file_id=batch_file.id,
+                endpoint="/v1/responses",
+                completion_window="24h",
+                metadata={"pollux_request_count": str(len(requests))},
+            )
+            return ProviderDeferredHandle(
+                job_id=batch.id,
+                submitted_at=float(batch.created_at),
+            )
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="openai",
+                phase="batch_submit",
+                allow_network_errors=False,
+                message="OpenAI batch submit failed",
+            ) from e
+
+    async def inspect_deferred(self, job_id: str) -> ProviderDeferredSnapshot:
+        """Inspect an OpenAI batch and normalize status/counts."""
+        client = self._get_client()
+
+        try:
+            batch = await client.batches.retrieve(job_id)
+            total = _batch_total_requests(batch)
+            completed = _batch_completed_requests(batch)
+            failed = _batch_failed_requests(batch)
+            pending = max(total - completed - failed, 0)
+            status = _normalize_batch_status(
+                _field(batch, "status"),
+                completed=completed,
+                failed=failed,
+            )
+            return ProviderDeferredSnapshot(
+                status=status,
+                provider_status=str(_field(batch, "status", "")),
+                request_count=total,
+                succeeded=completed,
+                failed=failed,
+                pending=pending,
+                submitted_at=_timestamp_or_none(_field(batch, "created_at")),
+                completed_at=_batch_terminal_timestamp(batch),
+                expires_at=_timestamp_or_none(_field(batch, "expires_at")),
+            )
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="openai",
+                phase="batch_inspect",
+                allow_network_errors=True,
+                message="OpenAI batch inspect failed",
+            ) from e
+
+    async def collect_deferred(self, job_id: str) -> list[ProviderDeferredItem]:
+        """Collect OpenAI batch output and error files into deferred items."""
+        client = self._get_client()
+
+        try:
+            batch = await client.batches.retrieve(job_id)
+            items: list[ProviderDeferredItem] = []
+            output_file_id = _field(batch, "output_file_id")
+            if isinstance(output_file_id, str) and output_file_id:
+                content = await client.files.retrieve_content(output_file_id)
+                items.extend(self._parse_batch_output_file(content))
+
+            error_file_id = _field(batch, "error_file_id")
+            if isinstance(error_file_id, str) and error_file_id:
+                content = await client.files.retrieve_content(error_file_id)
+                items.extend(self._parse_batch_error_file(content))
+
+            return items
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="openai",
+                phase="batch_collect",
+                allow_network_errors=True,
+                message="OpenAI batch collect failed",
+            ) from e
+
+    async def cancel_deferred(self, job_id: str) -> None:
+        """Cancel an OpenAI batch."""
+        client = self._get_client()
+        try:
+            await client.batches.cancel(job_id)
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="openai",
+                phase="batch_cancel",
+                allow_network_errors=True,
+                message="OpenAI batch cancel failed",
+            ) from e
+
     async def generate(
         self,
         request: ProviderRequest,
@@ -236,45 +394,7 @@ class OpenAIProvider:
         """Generate a response using OpenAI's responses endpoint."""
         _ = request.cache_name
         client = self._get_client()
-
-        input_messages = self._build_input(
-            request.parts, request.history, request.previous_response_id
-        )
-
-        create_kwargs: dict[str, Any] = {
-            "model": request.model,
-            "input": input_messages,
-        }
-        if request.temperature is not None:
-            create_kwargs["temperature"] = request.temperature
-        if request.top_p is not None:
-            create_kwargs["top_p"] = request.top_p
-
-        if request.tools is not None:
-            create_kwargs["tools"] = self._normalize_tools(request.tools)
-            mapped = self._map_tool_choice(request.tool_choice)
-            if mapped is not None:
-                create_kwargs["tool_choice"] = mapped
-
-        if request.system_instruction:
-            create_kwargs["instructions"] = request.system_instruction
-        if request.previous_response_id:
-            create_kwargs["previous_response_id"] = request.previous_response_id
-        if request.reasoning_effort is not None:
-            create_kwargs["reasoning"] = {
-                "effort": request.reasoning_effort,
-                "summary": "auto",
-            }
-        if request.response_schema is not None:
-            strict_schema = to_strict_schema(request.response_schema)
-            create_kwargs["text"] = {
-                "format": {
-                    "type": "json_schema",
-                    "name": "pollux_structured_output",
-                    "schema": strict_schema,
-                    "strict": True,
-                }
-            }
+        create_kwargs = self._build_responses_create_kwargs(request)
 
         response = await client.responses.create(**create_kwargs)
         return self._parse_response(response, response_schema=request.response_schema)
@@ -346,6 +466,159 @@ class OpenAIProvider:
         self._client = None
         await client.close()
 
+    def _build_responses_create_kwargs(
+        self, request: ProviderRequest
+    ) -> dict[str, Any]:
+        """Build the raw `/v1/responses` request body."""
+        input_messages = self._build_input(
+            request.parts, request.history, request.previous_response_id
+        )
+
+        create_kwargs: dict[str, Any] = {
+            "model": request.model,
+            "input": input_messages,
+        }
+        if request.temperature is not None:
+            create_kwargs["temperature"] = request.temperature
+        if request.top_p is not None:
+            create_kwargs["top_p"] = request.top_p
+        if request.max_tokens is not None:
+            create_kwargs["max_output_tokens"] = request.max_tokens
+
+        if request.tools is not None:
+            create_kwargs["tools"] = self._normalize_tools(request.tools)
+            mapped = self._map_tool_choice(request.tool_choice)
+            if mapped is not None:
+                create_kwargs["tool_choice"] = mapped
+
+        if request.system_instruction:
+            create_kwargs["instructions"] = request.system_instruction
+        if request.previous_response_id:
+            create_kwargs["previous_response_id"] = request.previous_response_id
+        if request.reasoning_effort is not None:
+            create_kwargs["reasoning"] = {
+                "effort": request.reasoning_effort,
+                "summary": "auto",
+            }
+        if request.response_schema is not None:
+            strict_schema = to_strict_schema(request.response_schema)
+            create_kwargs["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "name": "pollux_structured_output",
+                    "schema": strict_schema,
+                    "strict": True,
+                }
+            }
+
+        return create_kwargs
+
+    async def _build_batch_request_body(
+        self, request: ProviderRequest
+    ) -> dict[str, Any]:
+        """Build one OpenAI Batch API line body for `/v1/responses`."""
+        resolved_parts: list[Any] = []
+        for part in request.parts:
+            if (
+                isinstance(part, dict)
+                and isinstance(part.get("file_path"), str)
+                and isinstance(part.get("mime_type"), str)
+            ):
+                resolved_parts.append(
+                    await self.upload_file(Path(part["file_path"]), part["mime_type"])
+                )
+            else:
+                resolved_parts.append(part)
+
+        resolved_request = ProviderRequest(
+            model=request.model,
+            parts=resolved_parts,
+            system_instruction=request.system_instruction,
+            cache_name=request.cache_name,
+            response_schema=request.response_schema,
+            temperature=request.temperature,
+            top_p=request.top_p,
+            tools=request.tools,
+            tool_choice=request.tool_choice,
+            reasoning_effort=request.reasoning_effort,
+            history=request.history,
+            previous_response_id=request.previous_response_id,
+            provider_state=request.provider_state,
+            max_tokens=request.max_tokens,
+            implicit_caching=request.implicit_caching,
+        )
+        return self._build_responses_create_kwargs(resolved_request)
+
+    def _parse_batch_output_file(self, content: str) -> list[ProviderDeferredItem]:
+        """Parse a batch output JSONL file into succeeded/failed items."""
+        items: list[ProviderDeferredItem] = []
+        for line in content.splitlines():
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            request_id = str(payload["custom_id"])
+            response = payload.get("response")
+            error = payload.get("error")
+
+            if not isinstance(response, dict):
+                items.append(
+                    ProviderDeferredItem(
+                        request_id=request_id,
+                        status="failed",
+                        error=_error_message(error),
+                    )
+                )
+                continue
+
+            status_code = response.get("status_code")
+            body = response.get("body")
+            if status_code != 200 or not isinstance(body, dict):
+                items.append(
+                    ProviderDeferredItem(
+                        request_id=request_id,
+                        status="failed",
+                        error=_error_message(error) or _error_message(body),
+                    )
+                )
+                continue
+
+            parsed = self._parse_response(
+                body,
+                response_schema=None,
+                parse_structured_json=True,
+            )
+            items.append(
+                ProviderDeferredItem(
+                    request_id=request_id,
+                    status="succeeded",
+                    response=_provider_response_to_dict(parsed),
+                    provider_status="completed",
+                    finish_reason=parsed.finish_reason,
+                )
+            )
+        return items
+
+    def _parse_batch_error_file(self, content: str) -> list[ProviderDeferredItem]:
+        """Parse a batch error JSONL file into failed/cancelled/expired items."""
+        items: list[ProviderDeferredItem] = []
+        for line in content.splitlines():
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            request_id = str(payload["custom_id"])
+            error = payload.get("error")
+            code = error.get("code") if isinstance(error, dict) else None
+            status = _deferred_status_from_error_code(code)
+            items.append(
+                ProviderDeferredItem(
+                    request_id=request_id,
+                    status=status,
+                    error=_error_message(error),
+                    provider_status=str(code) if isinstance(code, str) else None,
+                )
+            )
+        return items
+
 
 def _extract_finish_reason(response: Any) -> str | None:
     """Extract OpenAI finish reason, preferring incomplete_details.reason.
@@ -355,18 +628,152 @@ def _extract_finish_reason(response: Any) -> str | None:
     ``.reason`` field ("max_output_tokens" or "content_filter").  We surface
     the specific reason when available so callers get the actionable root cause.
     """
-    status = getattr(response, "status", None)
+    status = _field(response, "status")
     if not isinstance(status, str):
         return None
 
     normalized_status = status.lower()
     if normalized_status == "incomplete":
-        details = getattr(response, "incomplete_details", None)
-        reason = getattr(details, "reason", None) if details is not None else None
+        details = _field(response, "incomplete_details")
+        reason = _field(details, "reason") if details is not None else None
         if isinstance(reason, str) and reason:
             return reason.lower()
 
     return normalized_status
+
+
+def _field(obj: Any, key: str, default: Any = None) -> Any:
+    """Read a field from either an SDK object or a raw JSON dict."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _extract_output_text(response: Any) -> str:
+    """Extract text from SDK responses and raw batch response bodies."""
+    text = _field(response, "output_text")
+    if isinstance(text, str) and text:
+        return text
+
+    parts: list[str] = []
+    for item in _field(response, "output", []) or []:
+        if _field(item, "type") != "message":
+            continue
+        for content in _field(item, "content", []) or []:
+            if _field(content, "type") == "output_text":
+                value = _field(content, "text")
+                if isinstance(value, str):
+                    parts.append(value)
+    return "".join(parts)
+
+
+def _timestamp_or_none(value: Any) -> float | None:
+    """Convert Unix timestamps to floats when present."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _batch_total_requests(batch: Any) -> int:
+    """Return the total request count, falling back to batch metadata."""
+    counts = _field(batch, "request_counts")
+    total = _field(counts, "total") if counts is not None else None
+    if isinstance(total, int) and total > 0:
+        return total
+    metadata = _field(batch, "metadata")
+    meta_total = (
+        _field(metadata, "pollux_request_count") if metadata is not None else None
+    )
+    if isinstance(meta_total, str) and meta_total.isdigit():
+        return int(meta_total)
+    return 0
+
+
+def _batch_completed_requests(batch: Any) -> int:
+    counts = _field(batch, "request_counts")
+    value = _field(counts, "completed") if counts is not None else None
+    return value if isinstance(value, int) else 0
+
+
+def _batch_failed_requests(batch: Any) -> int:
+    counts = _field(batch, "request_counts")
+    value = _field(counts, "failed") if counts is not None else None
+    return value if isinstance(value, int) else 0
+
+
+def _normalize_batch_status(status: Any, *, completed: int, failed: int) -> str:
+    """Map OpenAI batch status to Pollux deferred status."""
+    raw = str(status).lower() if isinstance(status, str) else ""
+    if raw == "validating":
+        return "queued"
+    if raw in {"in_progress", "finalizing"}:
+        return "running"
+    if raw == "cancelling":
+        return "cancelling"
+    if raw == "completed":
+        if completed > 0 and failed > 0:
+            return "partial"
+        if completed > 0:
+            return "completed"
+        return "failed"
+    if raw == "cancelled":
+        return "partial" if completed > 0 else "cancelled"
+    if raw == "expired":
+        return "partial" if completed > 0 else "expired"
+    if raw == "failed":
+        return "failed"
+    return "running"
+
+
+def _batch_terminal_timestamp(batch: Any) -> float | None:
+    """Return the most relevant terminal timestamp for a batch."""
+    for key in ("completed_at", "cancelled_at", "expired_at", "failed_at"):
+        value = _timestamp_or_none(_field(batch, key))
+        if value is not None:
+            return value
+    return None
+
+
+def _provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
+    """Convert ProviderResponse into the normalized response dict shape."""
+    payload: dict[str, Any] = {"text": response.text, "usage": response.usage}
+    if response.reasoning is not None:
+        payload["reasoning"] = response.reasoning
+    if response.structured is not None:
+        payload["structured"] = response.structured
+    if response.tool_calls is not None:
+        payload["tool_calls"] = [
+            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+            for tc in response.tool_calls
+        ]
+    if response.response_id is not None:
+        payload["response_id"] = response.response_id
+    if response.finish_reason is not None:
+        payload["finish_reason"] = response.finish_reason
+    return payload
+
+
+def _error_message(error: Any) -> str | None:
+    """Best-effort message extraction from OpenAI batch error payloads."""
+    if isinstance(error, dict):
+        message = error.get("message")
+        if isinstance(message, str) and message:
+            return message
+        code = error.get("code")
+        if isinstance(code, str) and code:
+            return code
+    return None
+
+
+def _deferred_status_from_error_code(code: Any) -> DeferredItemStatus:
+    """Map OpenAI batch error codes to normalized deferred item status."""
+    if not isinstance(code, str):
+        return "failed"
+    if code == "batch_expired":
+        return "expired"
+    if code in {"batch_cancelled", "batch_canceled"}:
+        return "cancelled"
+    return "failed"
 
 
 def _normalize_input_part(part: Any) -> dict[str, str] | None:

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import io
 import json
+import logging
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -26,6 +27,8 @@ from pollux.providers.models import (
     ProviderResponse,
     ToolCall,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAIProvider:
@@ -320,6 +323,7 @@ class OpenAIProvider:
         """Inspect an OpenAI batch and normalize status/counts."""
         client = self._get_client()
         job_id = handle.job_id
+        status: str | None = None
 
         try:
             batch = await client.batches.retrieve(job_id)
@@ -361,6 +365,9 @@ class OpenAIProvider:
                 allow_network_errors=True,
                 message="OpenAI batch inspect failed",
             ) from e
+        finally:
+            if status in {"completed", "partial", "failed", "cancelled", "expired"}:
+                await self._cleanup_deferred_owned_files(handle)
 
     async def collect_deferred(
         self, handle: ProviderDeferredHandle
@@ -394,10 +401,12 @@ class OpenAIProvider:
             synthesized = self._synthesize_terminal_batch_failure_items(
                 batch,
                 handle=handle,
+                existing_request_ids={item.request_id for item in items},
             )
             if synthesized is not None:
                 items.extend(synthesized)
 
+            await self._cleanup_deferred_owned_files(handle)
             return items
         except asyncio.CancelledError:
             raise
@@ -417,7 +426,14 @@ class OpenAIProvider:
         client = self._get_client()
         job_id = handle.job_id
         try:
-            await client.batches.cancel(job_id)
+            batch = await client.batches.cancel(job_id)
+            status = _normalize_batch_status(
+                _field(batch, "status"),
+                completed=0,
+                failed=0,
+            )
+            if status in {"completed", "partial", "failed", "cancelled", "expired"}:
+                await self._cleanup_deferred_owned_files(handle)
         except asyncio.CancelledError:
             raise
         except APIError:
@@ -509,6 +525,18 @@ class OpenAIProvider:
             return
         self._client = None
         await client.close()
+
+    async def _cleanup_deferred_owned_files(
+        self, handle: ProviderDeferredHandle
+    ) -> None:
+        """Best-effort cleanup for provider-owned input files after terminal batches."""
+        for file_id in _provider_handle_owned_file_ids(handle):
+            try:
+                await self.delete_file(file_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("OpenAI deferred cleanup failed for file_id=%s", file_id)
 
     def _build_responses_create_kwargs(
         self, request: ProviderRequest
@@ -681,17 +709,22 @@ class OpenAIProvider:
         batch: Any,
         *,
         handle: ProviderDeferredHandle,
+        existing_request_ids: set[str],
     ) -> list[ProviderDeferredItem] | None:
-        """Expand batch-level terminal failures into per-request deferred items."""
-        if _field(batch, "output_file_id") or _field(batch, "error_file_id"):
-            return None
-
+        """Expand missing terminal items into per-request deferred diagnostics."""
         item_status = _batch_level_item_status(_field(batch, "status"))
         if item_status is None:
             return None
 
         request_ids = _provider_handle_request_ids(handle) or _batch_request_ids(batch)
         if not request_ids:
+            return None
+        missing_request_ids = [
+            request_id
+            for request_id in request_ids
+            if request_id not in existing_request_ids
+        ]
+        if not missing_request_ids:
             return None
 
         error_message = _batch_error_message(batch)
@@ -703,7 +736,7 @@ class OpenAIProvider:
                 error=error_message,
                 provider_status=provider_status or None,
             )
-            for request_id in request_ids
+            for request_id in missing_request_ids
         ]
 
 
@@ -842,6 +875,22 @@ def _provider_handle_request_ids(handle: ProviderDeferredHandle) -> list[str] | 
     return request_ids
 
 
+def _provider_handle_owned_file_ids(handle: ProviderDeferredHandle) -> list[str]:
+    """Return provider-owned file ids stored on the deferred handle."""
+    provider_state = handle.provider_state
+    if not isinstance(provider_state, dict):
+        return []
+    raw_ids = provider_state.get("owned_file_ids")
+    if not isinstance(raw_ids, list):
+        return []
+
+    file_ids: list[str] = []
+    for value in raw_ids:
+        if isinstance(value, str) and value:
+            file_ids.append(value)
+    return file_ids
+
+
 def _batch_has_response_schema(requests: list[ProviderRequest]) -> str:
     """Persist whether this batch was submitted with structured outputs enabled."""
     return (
@@ -871,9 +920,9 @@ def _normalize_batch_status(status: Any, *, completed: int, failed: int) -> str:
             return "completed"
         return "failed"
     if raw == "cancelled":
-        return "partial" if completed > 0 else "cancelled"
+        return "partial" if completed > 0 or failed > 0 else "cancelled"
     if raw == "expired":
-        return "partial" if completed > 0 else "expired"
+        return "partial" if completed > 0 or failed > 0 else "expired"
     if raw == "failed":
         return "failed"
     return "running"

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -280,6 +280,7 @@ class OpenAIProvider:
                 file=upload,
                 purpose="batch",
             )
+            batch_file_id = _field(batch_file, "id")
             batch = await client.batches.create(
                 input_file_id=batch_file.id,
                 endpoint="/v1/responses",
@@ -292,6 +293,13 @@ class OpenAIProvider:
             return ProviderDeferredHandle(
                 job_id=batch.id,
                 submitted_at=float(batch.created_at),
+                provider_state={
+                    "request_ids": list(request_ids),
+                    "owned_file_ids": _owned_batch_file_ids(
+                        upload_cache,
+                        batch_file_id=batch_file_id,
+                    ),
+                },
             )
         except asyncio.CancelledError:
             raise
@@ -306,18 +314,27 @@ class OpenAIProvider:
                 message="OpenAI batch submit failed",
             ) from e
 
-    async def inspect_deferred(self, job_id: str) -> ProviderDeferredSnapshot:
+    async def inspect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> ProviderDeferredSnapshot:
         """Inspect an OpenAI batch and normalize status/counts."""
         client = self._get_client()
+        job_id = handle.job_id
 
         try:
             batch = await client.batches.retrieve(job_id)
+            raw_status = _field(batch, "status")
             total = _batch_total_requests(batch)
             completed = _batch_completed_requests(batch)
             failed = _batch_failed_requests(batch)
-            pending = max(total - completed - failed, 0)
             status = _normalize_batch_status(
-                _field(batch, "status"),
+                raw_status,
+                completed=completed,
+                failed=failed,
+            )
+            failed, pending = _normalize_terminal_batch_counts(
+                raw_status,
+                total=total,
                 completed=completed,
                 failed=failed,
             )
@@ -345,9 +362,12 @@ class OpenAIProvider:
                 message="OpenAI batch inspect failed",
             ) from e
 
-    async def collect_deferred(self, job_id: str) -> list[ProviderDeferredItem]:
+    async def collect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> list[ProviderDeferredItem]:
         """Collect OpenAI batch output and error files into deferred items."""
         client = self._get_client()
+        job_id = handle.job_id
 
         try:
             batch = await client.batches.retrieve(job_id)
@@ -371,6 +391,13 @@ class OpenAIProvider:
                 content = await client.files.retrieve_content(error_file_id)
                 items.extend(self._parse_batch_error_file(content))
 
+            synthesized = self._synthesize_terminal_batch_failure_items(
+                batch,
+                handle=handle,
+            )
+            if synthesized is not None:
+                items.extend(synthesized)
+
             return items
         except asyncio.CancelledError:
             raise
@@ -385,9 +412,10 @@ class OpenAIProvider:
                 message="OpenAI batch collect failed",
             ) from e
 
-    async def cancel_deferred(self, job_id: str) -> None:
+    async def cancel_deferred(self, handle: ProviderDeferredHandle) -> None:
         """Cancel an OpenAI batch."""
         client = self._get_client()
+        job_id = handle.job_id
         try:
             await client.batches.cancel(job_id)
         except asyncio.CancelledError:
@@ -621,7 +649,7 @@ class OpenAIProvider:
                     request_id=request_id,
                     status="succeeded",
                     response=_provider_response_to_dict(parsed),
-                    provider_status="completed",
+                    provider_status=_field(body, "status"),
                     finish_reason=parsed.finish_reason,
                 )
             )
@@ -647,6 +675,36 @@ class OpenAIProvider:
                 )
             )
         return items
+
+    def _synthesize_terminal_batch_failure_items(
+        self,
+        batch: Any,
+        *,
+        handle: ProviderDeferredHandle,
+    ) -> list[ProviderDeferredItem] | None:
+        """Expand batch-level terminal failures into per-request deferred items."""
+        if _field(batch, "output_file_id") or _field(batch, "error_file_id"):
+            return None
+
+        item_status = _batch_level_item_status(_field(batch, "status"))
+        if item_status is None:
+            return None
+
+        request_ids = _provider_handle_request_ids(handle) or _batch_request_ids(batch)
+        if not request_ids:
+            return None
+
+        error_message = _batch_error_message(batch)
+        provider_status = _batch_error_code(batch) or str(_field(batch, "status", ""))
+        return [
+            ProviderDeferredItem(
+                request_id=request_id,
+                status=item_status,
+                error=error_message,
+                provider_status=provider_status or None,
+            )
+            for request_id in request_ids
+        ]
 
 
 def _extract_finish_reason(response: Any) -> str | None:
@@ -730,6 +788,60 @@ def _batch_failed_requests(batch: Any) -> int:
     return value if isinstance(value, int) else 0
 
 
+def _normalize_terminal_batch_counts(
+    status: Any,
+    *,
+    total: int,
+    completed: int,
+    failed: int,
+) -> tuple[int, int]:
+    """Normalize terminal counts when OpenAI omits per-request failure totals."""
+    pending = max(total - completed - failed, 0)
+    if not isinstance(status, str):
+        return failed, pending
+    if status.lower() not in {"failed", "cancelled", "expired"}:
+        return failed, pending
+    return failed + pending, 0
+
+
+def _batch_request_ids(batch: Any) -> list[str]:
+    """Rebuild Pollux request ids from stored batch metadata."""
+    total = _batch_total_requests(batch)
+    return [f"pollux-{idx:06d}" for idx in range(total)]
+
+
+def _owned_batch_file_ids(
+    upload_cache: dict[tuple[str, str], ProviderFileAsset],
+    *,
+    batch_file_id: Any,
+) -> list[str]:
+    """Return provider-owned remote file ids created during batch submission."""
+    file_ids = {
+        asset.file_id
+        for asset in upload_cache.values()
+        if asset.file_id and not asset.is_inline_fallback
+    }
+    if isinstance(batch_file_id, str) and batch_file_id:
+        file_ids.add(batch_file_id)
+    return sorted(file_ids)
+
+
+def _provider_handle_request_ids(handle: ProviderDeferredHandle) -> list[str] | None:
+    """Return the authoritative submitted request ids stored in the handle."""
+    provider_state = handle.provider_state
+    if not isinstance(provider_state, dict):
+        return None
+    raw_ids = provider_state.get("request_ids")
+    if not isinstance(raw_ids, list):
+        return None
+    request_ids: list[str] = []
+    for value in raw_ids:
+        if not isinstance(value, str) or not value:
+            return None
+        request_ids.append(value)
+    return request_ids
+
+
 def _batch_has_response_schema(requests: list[ProviderRequest]) -> str:
     """Persist whether this batch was submitted with structured outputs enabled."""
     return (
@@ -795,9 +907,42 @@ def _provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
     return payload
 
 
+def _batch_error_entries(batch: Any) -> list[Any]:
+    """Return batch-level validation/runtime errors when present."""
+    errors = _field(batch, "errors")
+    data = _field(errors, "data") if errors is not None else None
+    return data if isinstance(data, list) else []
+
+
+def _batch_error_message(batch: Any) -> str | None:
+    """Return a readable message for batch-level failures without item files."""
+    messages: list[str] = []
+    for entry in _batch_error_entries(batch):
+        message = _field(entry, "message")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    if messages:
+        return "; ".join(messages)
+    return None
+
+
+def _batch_error_code(batch: Any) -> str | None:
+    """Return the first batch-level error code when present."""
+    for entry in _batch_error_entries(batch):
+        code = _field(entry, "code")
+        if isinstance(code, str) and code:
+            return code
+    return None
+
+
 def _error_message(error: Any) -> str | None:
     """Best-effort message extraction from OpenAI batch error payloads."""
     if isinstance(error, dict):
+        nested = error.get("error")
+        if isinstance(nested, dict):
+            nested_message = _error_message(nested)
+            if nested_message is not None:
+                return nested_message
         message = error.get("message")
         if isinstance(message, str) and message:
             return message
@@ -816,6 +961,19 @@ def _deferred_status_from_error_code(code: Any) -> DeferredItemStatus:
     if code in {"batch_cancelled", "batch_canceled"}:
         return "cancelled"
     return "failed"
+
+
+def _batch_level_item_status(status: Any) -> DeferredItemStatus | None:
+    """Map batch terminal status into a per-item fallback status."""
+    if not isinstance(status, str):
+        return None
+    if status == "failed":
+        return "failed"
+    if status == "cancelled":
+        return "cancelled"
+    if status == "expired":
+        return "expired"
+    return None
 
 
 def _normalize_input_part(part: Any) -> dict[str, str] | None:

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -254,8 +254,12 @@ class OpenAIProvider:
 
         try:
             lines: list[str] = []
+            upload_cache: dict[tuple[str, str], ProviderFileAsset] = {}
             for request_id, request in zip(request_ids, requests, strict=True):
-                body = await self._build_batch_request_body(request)
+                body = await self._build_batch_request_body(
+                    request,
+                    upload_cache=upload_cache,
+                )
                 lines.append(
                     json.dumps(
                         {
@@ -280,7 +284,10 @@ class OpenAIProvider:
                 input_file_id=batch_file.id,
                 endpoint="/v1/responses",
                 completion_window="24h",
-                metadata={"pollux_request_count": str(len(requests))},
+                metadata={
+                    "pollux_request_count": str(len(requests)),
+                    "pollux_has_response_schema": _batch_has_response_schema(requests),
+                },
             )
             return ProviderDeferredHandle(
                 job_id=batch.id,
@@ -345,10 +352,19 @@ class OpenAIProvider:
         try:
             batch = await client.batches.retrieve(job_id)
             items: list[ProviderDeferredItem] = []
+            parse_structured_json = _batch_metadata_flag(
+                _field(batch, "metadata"),
+                key="pollux_has_response_schema",
+            )
             output_file_id = _field(batch, "output_file_id")
             if isinstance(output_file_id, str) and output_file_id:
                 content = await client.files.retrieve_content(output_file_id)
-                items.extend(self._parse_batch_output_file(content))
+                items.extend(
+                    self._parse_batch_output_file(
+                        content,
+                        parse_structured_json=parse_structured_json,
+                    )
+                )
 
             error_file_id = _field(batch, "error_file_id")
             if isinstance(error_file_id, str) and error_file_id:
@@ -514,7 +530,10 @@ class OpenAIProvider:
         return create_kwargs
 
     async def _build_batch_request_body(
-        self, request: ProviderRequest
+        self,
+        request: ProviderRequest,
+        *,
+        upload_cache: dict[tuple[str, str], ProviderFileAsset],
     ) -> dict[str, Any]:
         """Build one OpenAI Batch API line body for `/v1/responses`."""
         resolved_parts: list[Any] = []
@@ -524,9 +543,14 @@ class OpenAIProvider:
                 and isinstance(part.get("file_path"), str)
                 and isinstance(part.get("mime_type"), str)
             ):
-                resolved_parts.append(
-                    await self.upload_file(Path(part["file_path"]), part["mime_type"])
-                )
+                file_path = part["file_path"]
+                mime_type = part["mime_type"]
+                cache_key = (file_path, mime_type)
+                asset = upload_cache.get(cache_key)
+                if asset is None:
+                    asset = await self.upload_file(Path(file_path), mime_type)
+                    upload_cache[cache_key] = asset
+                resolved_parts.append(asset)
             else:
                 resolved_parts.append(part)
 
@@ -549,7 +573,12 @@ class OpenAIProvider:
         )
         return self._build_responses_create_kwargs(resolved_request)
 
-    def _parse_batch_output_file(self, content: str) -> list[ProviderDeferredItem]:
+    def _parse_batch_output_file(
+        self,
+        content: str,
+        *,
+        parse_structured_json: bool,
+    ) -> list[ProviderDeferredItem]:
         """Parse a batch output JSONL file into succeeded/failed items."""
         items: list[ProviderDeferredItem] = []
         for line in content.splitlines():
@@ -585,7 +614,7 @@ class OpenAIProvider:
             parsed = self._parse_response(
                 body,
                 response_schema=None,
-                parse_structured_json=True,
+                parse_structured_json=parse_structured_json,
             )
             items.append(
                 ProviderDeferredItem(
@@ -699,6 +728,19 @@ def _batch_failed_requests(batch: Any) -> int:
     counts = _field(batch, "request_counts")
     value = _field(counts, "failed") if counts is not None else None
     return value if isinstance(value, int) else 0
+
+
+def _batch_has_response_schema(requests: list[ProviderRequest]) -> str:
+    """Persist whether this batch was submitted with structured outputs enabled."""
+    return (
+        "1" if any(request.response_schema is not None for request in requests) else "0"
+    )
+
+
+def _batch_metadata_flag(metadata: Any, *, key: str) -> bool:
+    """Return True when a Pollux-owned batch metadata flag is enabled."""
+    value = _field(metadata, key) if metadata is not None else None
+    return value == "1"
 
 
 def _normalize_batch_status(status: Any, *, completed: int, failed: int) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -497,7 +497,9 @@ async def test_openai_live_batch_validation_failure_shape_characterization(
         assert batch.errors.data
         assert batch.errors.data[0].code == "model_not_found"
         assert batch.errors.data[0].param == "body.model"
-        assert "not supported by the Batch API" in batch.errors.data[0].message
+        message = batch.errors.data[0].message
+        assert message is not None
+        assert "not supported by the Batch API" in message
     finally:
         if batch_id is not None and final_status not in {
             "failed",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,11 @@ The suite prioritizes high-signal end-to-end coverage with a small call budget.
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
+import io
 import json
+import time
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -423,6 +427,120 @@ async def test_openai_binary_upload_cleanup_roundtrip(
     assert "pdf_ok" in result["answers"][0].lower()
     assert deleted_file_ids
     assert all(isinstance(file_id, str) and file_id for file_id in deleted_file_ids)
+
+
+@pytest.mark.asyncio
+async def test_openai_live_batch_validation_failure_shape_characterization(
+    openai_api_key: str,
+    openai_test_model: str,
+) -> None:
+    """E2E: Batch validation failures surface on the batch object, not per-row output files."""
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(api_key=openai_api_key)
+    batch_id: str | None = None
+    final_status: str | None = None
+    file_ids_to_delete: set[str] = set()
+
+    try:
+        lines = [
+            {
+                "custom_id": "pollux-live-success",
+                "method": "POST",
+                "url": "/v1/responses",
+                "body": {
+                    "model": openai_test_model,
+                    "input": "Reply with exactly LIVE_BATCH_OK",
+                },
+            },
+            {
+                "custom_id": "pollux-live-invalid-model",
+                "method": "POST",
+                "url": "/v1/responses",
+                "body": {
+                    "model": "not-a-real-openai-model",
+                    "input": "Reply with exactly SHOULD_NOT_RUN",
+                },
+            },
+        ]
+
+        payload = (
+            "\n".join(json.dumps(line, separators=(",", ":")) for line in lines) + "\n"
+        ).encode("utf-8")
+        upload = io.BytesIO(payload)
+        upload.name = "pollux-live-batch.jsonl"
+
+        batch_file = await client.files.create(file=upload, purpose="batch")
+        file_ids_to_delete.add(batch_file.id)
+
+        batch = await client.batches.create(
+            input_file_id=batch_file.id,
+            endpoint="/v1/responses",
+            completion_window="24h",
+        )
+        batch_id = batch.id
+
+        deadline = time.monotonic() + 180
+        while True:
+            batch = await client.batches.retrieve(batch.id)
+            if batch.status in {"completed", "failed", "cancelled", "expired"}:
+                break
+            if time.monotonic() >= deadline:
+                pytest.fail(f"Timed out waiting for OpenAI batch {batch.id} to finish")
+            await asyncio.sleep(5)
+
+        final_status = batch.status
+        assert batch.status == "failed"
+        assert batch.output_file_id is None
+        assert batch.error_file_id is None
+        assert batch.errors is not None
+        assert batch.errors.data
+        assert batch.errors.data[0].code == "model_not_found"
+        assert batch.errors.data[0].param == "body.model"
+        assert "not supported by the Batch API" in batch.errors.data[0].message
+    finally:
+        if batch_id is not None and final_status not in {
+            "failed",
+            "cancelled",
+            "expired",
+            "completed",
+        }:
+            with suppress(Exception):
+                await client.batches.cancel(batch_id)
+        for file_id in file_ids_to_delete:
+            with suppress(Exception):
+                await client.files.delete(file_id)
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_live_response_incomplete_shape_characterization(
+    openai_api_key: str,
+    openai_test_model: str,
+) -> None:
+    """E2E: A live Responses API call exposes `status=incomplete` with reason details."""
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(api_key=openai_api_key)
+
+    try:
+        response = await client.responses.create(
+            model=openai_test_model,
+            input=(
+                "Reply with exactly the following 40 words, preserving order: "
+                "alpha bravo charlie delta echo foxtrot golf hotel india juliet "
+                "kilo lima mike november oscar papa quebec romeo sierra tango "
+                "uniform victor whiskey xray yankee zulu alpha bravo charlie "
+                "delta echo foxtrot golf hotel india juliet kilo lima mike."
+            ),
+            max_output_tokens=16,
+        )
+
+        assert response.status == "incomplete"
+        assert response.incomplete_details is not None
+        assert response.incomplete_details.reason == "max_output_tokens"
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1733,6 +1733,7 @@ async def test_openai_deferred_backend_integrates_with_public_api(
 
     class _Files:
         def __init__(self) -> None:
+            self.deleted_file_ids: list[str] = []
             self.contents = {
                 "file_out": "\n".join(
                     [
@@ -1785,7 +1786,7 @@ async def test_openai_deferred_backend_integrates_with_public_api(
             return self.contents[file_id]
 
         async def delete(self, file_id: str) -> None:
-            _ = file_id
+            self.deleted_file_ids.append(file_id)
 
         async def close(self) -> None:
             return None
@@ -1814,11 +1815,12 @@ async def test_openai_deferred_backend_integrates_with_public_api(
             return {"id": job_id}
 
     batches = _Batches()
+    files = _Files()
 
     def _make_provider(*_args: Any, **_kwargs: Any) -> OpenAIProvider:
         class _Client:
             def __init__(self) -> None:
-                self.files = _Files()
+                self.files = files
                 self.batches = batches
 
             async def close(self) -> None:
@@ -1859,6 +1861,115 @@ async def test_openai_deferred_backend_integrates_with_public_api(
         },
     ]
     assert batches.cancelled == "batch_123"
+    assert "file_batch_input" in files.deleted_file_ids
+
+
+@pytest.mark.asyncio
+async def test_openai_deferred_partial_cancel_returns_partial_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial cancelled batches should collect without missing-item errors."""
+
+    class _Files:
+        def __init__(self) -> None:
+            self.contents = {
+                "file_out": json.dumps(
+                    {
+                        "custom_id": "pollux-000000",
+                        "response": {
+                            "status_code": 200,
+                            "body": {
+                                "status": "completed",
+                                "output": [
+                                    {
+                                        "type": "message",
+                                        "content": [
+                                            {
+                                                "type": "output_text",
+                                                "text": "Answer 1",
+                                            }
+                                        ],
+                                    }
+                                ],
+                                "usage": {"total_tokens": 1},
+                            },
+                        },
+                        "error": None,
+                    }
+                )
+            }
+
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("File", (), {"id": "file_batch_input"})()
+
+        async def retrieve_content(self, file_id: str) -> str:
+            return self.contents[file_id]
+
+        async def delete(self, file_id: str) -> None:
+            _ = file_id
+
+    class _Batches:
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("Batch", (), {"id": "batch_123", "created_at": 100.0})()
+
+        async def retrieve(self, job_id: str) -> Any:
+            _ = job_id
+            return {
+                "status": "cancelled",
+                "request_counts": {"total": 2, "completed": 1, "failed": 0},
+                "created_at": 100,
+                "cancelled_at": 125,
+                "output_file_id": "file_out",
+            }
+
+        async def cancel(self, job_id: str) -> Any:
+            return {"id": job_id}
+
+    def _make_provider(*_args: Any, **_kwargs: Any) -> OpenAIProvider:
+        class _Client:
+            def __init__(self) -> None:
+                self.files = _Files()
+                self.batches = _Batches()
+
+            async def close(self) -> None:
+                return None
+
+        provider = OpenAIProvider("test-key")
+        provider._client = _Client()
+        return provider
+
+    monkeypatch.setattr(pollux, "_create_provider", _make_provider)
+    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+
+    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    snapshot = await pollux.inspect_deferred(job)
+    result = await pollux.collect_deferred(job)
+
+    assert snapshot.status == "partial"
+    assert snapshot.request_count == 2
+    assert snapshot.succeeded == 1
+    assert snapshot.failed == 1
+    assert snapshot.pending == 0
+    assert result["status"] == "partial"
+    assert result["answers"] == ["Answer 1", ""]
+    assert result["diagnostics"]["deferred"]["items"] == [
+        {
+            "request_id": "pollux-000000",
+            "status": "succeeded",
+            "error": None,
+            "provider_status": "completed",
+            "finish_reason": "completed",
+        },
+        {
+            "request_id": "pollux-000001",
+            "status": "cancelled",
+            "error": None,
+            "provider_status": "cancelled",
+            "finish_reason": None,
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1849,6 +1849,93 @@ async def test_openai_deferred_backend_integrates_with_public_api(
 
 
 @pytest.mark.asyncio
+async def test_openai_deferred_collection_does_not_invent_structured_without_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deferred collection should match realtime extraction when no schema was submitted."""
+
+    class _Files:
+        def __init__(self) -> None:
+            self.contents = {
+                "file_out": json.dumps(
+                    {
+                        "custom_id": "pollux-000000",
+                        "response": {
+                            "status_code": 200,
+                            "body": {
+                                "status": "completed",
+                                "output": [
+                                    {
+                                        "type": "message",
+                                        "content": [
+                                            {
+                                                "type": "output_text",
+                                                "text": '{"plain":true}',
+                                            }
+                                        ],
+                                    }
+                                ],
+                                "usage": {"total_tokens": 1},
+                            },
+                        },
+                        "error": None,
+                    }
+                )
+            }
+
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("File", (), {"id": "file_batch_input"})()
+
+        async def retrieve_content(self, file_id: str) -> str:
+            return self.contents[file_id]
+
+        async def delete(self, file_id: str) -> None:
+            _ = file_id
+
+    class _Batches:
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("Batch", (), {"id": "batch_123", "created_at": 100.0})()
+
+        async def retrieve(self, job_id: str) -> Any:
+            _ = job_id
+            return {
+                "status": "completed",
+                "request_counts": {"total": 1, "completed": 1, "failed": 0},
+                "created_at": 100,
+                "completed_at": 125,
+                "output_file_id": "file_out",
+                "metadata": {"pollux_has_response_schema": "0"},
+            }
+
+        async def cancel(self, job_id: str) -> Any:
+            return {"id": job_id}
+
+    def _make_provider(*_args: Any, **_kwargs: Any) -> OpenAIProvider:
+        class _Client:
+            def __init__(self) -> None:
+                self.files = _Files()
+                self.batches = _Batches()
+
+            async def close(self) -> None:
+                return None
+
+        provider = OpenAIProvider("test-key")
+        provider._client = _Client()
+        return provider
+
+    monkeypatch.setattr(pollux, "_create_provider", _make_provider)
+    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+
+    job = await pollux.defer('Return {"plain":true}', config=cfg)
+    result = await pollux.collect_deferred(job)
+
+    assert result["answers"] == ['{"plain":true}']
+    assert "structured" not in result
+
+
+@pytest.mark.asyncio
 async def test_structured_output_returns_pydantic_instances(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+import json
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -35,6 +36,7 @@ from pollux.providers.models import (
     ProviderResponse,
     ToolCall,
 )
+from pollux.providers.openai import OpenAIProvider
 from pollux.request import normalize_request
 from pollux.retry import RetryPolicy
 from pollux.source import Source
@@ -1708,6 +1710,142 @@ async def test_defer_rejects_out_of_scope_options(
 
     with pytest.raises(ConfigurationError, match=match):
         await pollux.defer("Q1?", config=cfg, options=options)
+
+
+@pytest.mark.asyncio
+async def test_openai_deferred_backend_integrates_with_public_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAI deferred provider should integrate cleanly through Pollux's public API."""
+
+    class _Files:
+        def __init__(self) -> None:
+            self.contents = {
+                "file_out": "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "custom_id": "pollux-000001",
+                                "response": {
+                                    "status_code": 200,
+                                    "body": {
+                                        "status": "completed",
+                                        "output": [
+                                            {
+                                                "type": "message",
+                                                "content": [
+                                                    {
+                                                        "type": "output_text",
+                                                        "text": "Answer 2",
+                                                    }
+                                                ],
+                                            }
+                                        ],
+                                        "usage": {"total_tokens": 1},
+                                    },
+                                },
+                                "error": None,
+                            }
+                        )
+                    ]
+                ),
+                "file_err": "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "custom_id": "pollux-000000",
+                                "error": {
+                                    "code": "server_error",
+                                    "message": "request failed",
+                                },
+                            }
+                        )
+                    ]
+                ),
+            }
+
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("File", (), {"id": "file_batch_input"})()
+
+        async def retrieve_content(self, file_id: str) -> str:
+            return self.contents[file_id]
+
+        async def delete(self, file_id: str) -> None:
+            _ = file_id
+
+        async def close(self) -> None:
+            return None
+
+    class _Batches:
+        def __init__(self) -> None:
+            self.cancelled: str | None = None
+
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("Batch", (), {"id": "batch_123", "created_at": 100.0})()
+
+        async def retrieve(self, job_id: str) -> Any:
+            _ = job_id
+            return {
+                "status": "completed",
+                "request_counts": {"total": 2, "completed": 1, "failed": 1},
+                "created_at": 100,
+                "completed_at": 125,
+                "output_file_id": "file_out",
+                "error_file_id": "file_err",
+            }
+
+        async def cancel(self, job_id: str) -> Any:
+            self.cancelled = job_id
+            return {"id": job_id}
+
+    batches = _Batches()
+
+    def _make_provider(*_args: Any, **_kwargs: Any) -> OpenAIProvider:
+        class _Client:
+            def __init__(self) -> None:
+                self.files = _Files()
+                self.batches = batches
+
+            async def close(self) -> None:
+                await _async_noop()
+
+        provider = OpenAIProvider("test-key")
+        provider._client = _Client()
+        return provider
+
+    async def _async_noop() -> None:
+        return None
+
+    monkeypatch.setattr(pollux, "_create_provider", _make_provider)
+    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+
+    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    snapshot = await pollux.inspect_deferred(job)
+    result = await pollux.collect_deferred(job)
+    await pollux.cancel_deferred(job)
+
+    assert snapshot.status == "partial"
+    assert result["status"] == "partial"
+    assert result["answers"] == ["", "Answer 2"]
+    assert result["diagnostics"]["deferred"]["items"] == [
+        {
+            "request_id": "pollux-000000",
+            "status": "failed",
+            "error": "request failed",
+            "provider_status": "server_error",
+            "finish_reason": None,
+        },
+        {
+            "request_id": "pollux-000001",
+            "status": "succeeded",
+            "error": None,
+            "provider_status": "completed",
+            "finish_reason": "completed",
+        },
+    ]
+    assert batches.cancelled == "batch_123"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,9 +88,16 @@ class InMemoryDeferredProvider(FakeProvider):
         job_id = f"job-{len(self.submitted_requests)}"
         self.submitted_requests[job_id] = list(requests)
         self.submitted_ids[job_id] = list(request_ids)
-        return ProviderDeferredHandle(job_id=job_id, submitted_at=self.submitted_at)
+        return ProviderDeferredHandle(
+            job_id=job_id,
+            submitted_at=self.submitted_at,
+            provider_state={"request_ids": list(request_ids)},
+        )
 
-    async def inspect_deferred(self, job_id: str) -> ProviderDeferredSnapshot:
+    async def inspect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> ProviderDeferredSnapshot:
+        job_id = handle.job_id
         request_ids = self.submitted_ids[job_id]
         items = self._collected_items(job_id)
         if self.inspect_status in {"queued", "running", "cancelling"}:
@@ -112,11 +119,13 @@ class InMemoryDeferredProvider(FakeProvider):
             completed_at=self.completed_at if pending == 0 else None,
         )
 
-    async def collect_deferred(self, job_id: str) -> list[ProviderDeferredItem]:
-        return self._collected_items(job_id)
+    async def collect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> list[ProviderDeferredItem]:
+        return self._collected_items(handle.job_id)
 
-    async def cancel_deferred(self, job_id: str) -> None:
-        self.cancelled_jobs.append(job_id)
+    async def cancel_deferred(self, handle: ProviderDeferredHandle) -> None:
+        self.cancelled_jobs.append(handle.job_id)
 
     def _collected_items(self, job_id: str) -> list[ProviderDeferredItem]:
         requests = self.submitted_requests[job_id]
@@ -1501,6 +1510,7 @@ def test_deferred_handle_round_trip_serialization() -> None:
         request_count=2,
         submitted_at=123.0,
         schema_hash="abc",
+        provider_state={"request_ids": ["pollux-000000", "pollux-000001"]},
     )
 
     assert DeferredHandle.from_dict(handle.to_dict()) == handle
@@ -1533,6 +1543,9 @@ async def test_defer_collect_smoke_without_lifecycle_config(
         sources=(Source.from_text("shared"),),
         config=cfg,
     )
+
+    assert job.provider_state == {"request_ids": ["pollux-000000", "pollux-000001"]}
+
     snapshot = await pollux.inspect_deferred(job)
     result = await pollux.collect_deferred(job)
 
@@ -1933,6 +1946,92 @@ async def test_openai_deferred_collection_does_not_invent_structured_without_sch
 
     assert result["answers"] == ['{"plain":true}']
     assert "structured" not in result
+
+
+@pytest.mark.asyncio
+async def test_openai_deferred_batch_level_failure_returns_error_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Batch-level validation failures should collect as a normal deferred error result."""
+
+    class _Files:
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("File", (), {"id": "file_batch_input"})()
+
+        async def retrieve_content(self, file_id: str) -> str:
+            raise AssertionError(f"unexpected retrieve_content({file_id})")
+
+        async def delete(self, file_id: str) -> None:
+            _ = file_id
+
+    class _Batches:
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("Batch", (), {"id": "batch_123", "created_at": 100.0})()
+
+        async def retrieve(self, job_id: str) -> Any:
+            _ = job_id
+            return {
+                "status": "failed",
+                "metadata": {"pollux_request_count": "2"},
+                "created_at": 100,
+                "failed_at": 125,
+                "errors": {
+                    "data": [
+                        {
+                            "code": "model_not_found",
+                            "message": "The provided model is not supported by the Batch API.",
+                        }
+                    ]
+                },
+            }
+
+        async def cancel(self, job_id: str) -> Any:
+            return {"id": job_id}
+
+    def _make_provider(*_args: Any, **_kwargs: Any) -> OpenAIProvider:
+        class _Client:
+            def __init__(self) -> None:
+                self.files = _Files()
+                self.batches = _Batches()
+
+            async def close(self) -> None:
+                return None
+
+        provider = OpenAIProvider("test-key")
+        provider._client = _Client()
+        return provider
+
+    monkeypatch.setattr(pollux, "_create_provider", _make_provider)
+    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+
+    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    snapshot = await pollux.inspect_deferred(job)
+    result = await pollux.collect_deferred(job)
+
+    assert snapshot.status == "failed"
+    assert snapshot.request_count == 2
+    assert snapshot.failed == 2
+    assert snapshot.pending == 0
+    assert result["status"] == "error"
+    assert result["answers"] == ["", ""]
+    assert result["diagnostics"]["deferred"]["items"] == [
+        {
+            "request_id": "pollux-000000",
+            "status": "failed",
+            "error": "The provided model is not supported by the Batch API.",
+            "provider_status": "model_not_found",
+            "finish_reason": None,
+        },
+        {
+            "request_id": "pollux-000001",
+            "status": "failed",
+            "error": "The provided model is not supported by the Batch API.",
+            "provider_status": "model_not_found",
+            "finish_reason": None,
+        },
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1247,8 +1247,56 @@ async def test_openai_submit_deferred_characterizes_batch_request(
         "input_file_id": "file_batch_input",
         "endpoint": "/v1/responses",
         "completion_window": "24h",
-        "metadata": {"pollux_request_count": "2"},
+        "metadata": {
+            "pollux_request_count": "2",
+            "pollux_has_response_schema": "1",
+        },
     }
+
+
+@pytest.mark.asyncio
+async def test_openai_submit_deferred_reuses_shared_file_uploads(
+    tmp_path: Path,
+) -> None:
+    """Deferred fan-out should upload a shared local file once per batch."""
+    pdf_path = tmp_path / "shared.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    await provider.submit_deferred(
+        [
+            ProviderRequest(
+                model=OPENAI_MODEL,
+                parts=[
+                    {"file_path": str(pdf_path), "mime_type": "application/pdf"},
+                    "Question 1",
+                ],
+            ),
+            ProviderRequest(
+                model=OPENAI_MODEL,
+                parts=[
+                    {"file_path": str(pdf_path), "mime_type": "application/pdf"},
+                    "Question 2",
+                ],
+            ),
+        ],
+        request_ids=["pollux-000000", "pollux-000001"],
+    )
+
+    assert len(files.create_calls) == 2
+    assert [call["purpose"] for call in files.create_calls] == ["user_data", "batch"]
+
+    batch_upload = files.create_calls[1]["file"]
+    lines = [json.loads(line) for line in batch_upload.getvalue().decode().splitlines()]
+
+    first_file = lines[0]["body"]["input"][0]["content"][0]["file_id"]
+    second_file = lines[1]["body"]["input"][0]["content"][0]["file_id"]
+    assert first_file == "file_uploaded_pdf"
+    assert second_file == first_file
 
 
 @pytest.mark.asyncio
@@ -1365,6 +1413,7 @@ async def test_openai_collect_deferred_parses_output_and_error_files() -> None:
     batches.retrieve_result = {
         "output_file_id": "file_out",
         "error_file_id": "file_err",
+        "metadata": {"pollux_has_response_schema": "1"},
     }
     provider = OpenAIProvider("test-key")
     provider._client = type("Client", (), {"files": files, "batches": batches})()
@@ -1386,6 +1435,49 @@ async def test_openai_collect_deferred_parses_output_and_error_files() -> None:
     assert success.response["reasoning"] == "Reasoned"
     assert success.response["usage"]["total_tokens"] == 3
     assert success.finish_reason == "completed"
+
+
+@pytest.mark.asyncio
+async def test_openai_collect_deferred_leaves_plain_json_text_unstructured() -> None:
+    """Deferred collection should only surface structured payloads for schema-backed jobs."""
+    files = _FakeBatchFilesClient()
+    files.contents["file_out"] = json.dumps(
+        {
+            "custom_id": "pollux-000000",
+            "response": {
+                "status_code": 200,
+                "body": {
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": '{"plain":true}',
+                                }
+                            ],
+                        }
+                    ],
+                    "usage": {"total_tokens": 1},
+                },
+            },
+            "error": None,
+        }
+    )
+
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {"output_file_id": "file_out", "metadata": {}}
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    items = await provider.collect_deferred("batch_123")
+
+    assert items[0].response == {
+        "text": '{"plain":true}',
+        "usage": {"total_tokens": 1},
+        "finish_reason": "completed",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1170,6 +1170,7 @@ class _FakeBatchesClient:
         self.create_kwargs: dict[str, Any] | None = None
         self.retrieve_result: Any = None
         self.cancelled_job_id: str | None = None
+        self.cancel_result: Any = None
 
     async def create(self, **kwargs: Any) -> Any:
         self.create_kwargs = kwargs
@@ -1185,7 +1186,9 @@ class _FakeBatchesClient:
 
     async def cancel(self, job_id: str) -> Any:
         self.cancelled_job_id = job_id
-        return type("Batch", (), {"id": job_id})()
+        if self.cancel_result is not None:
+            return self.cancel_result
+        return type("Batch", (), {"id": job_id, "status": "cancelling"})()
 
 
 @pytest.mark.asyncio
@@ -1431,6 +1434,55 @@ async def test_openai_inspect_deferred_terminal_failure_zeroes_pending() -> None
 
 
 @pytest.mark.asyncio
+async def test_openai_inspect_deferred_marks_cancelled_failed_mix_as_partial() -> None:
+    """Cancelled batches with failed rows should preserve the mixed terminal status."""
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {
+        "status": "cancelled",
+        "request_counts": {"total": 3, "completed": 0, "failed": 1},
+        "cancelled_at": 1_700_000_600,
+    }
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    snapshot = await provider.inspect_deferred(
+        ProviderDeferredHandle(job_id="batch_123")
+    )
+
+    assert snapshot.status == "partial"
+    assert snapshot.request_count == 3
+    assert snapshot.succeeded == 0
+    assert snapshot.failed == 3
+    assert snapshot.pending == 0
+
+
+@pytest.mark.asyncio
+async def test_openai_inspect_deferred_cleans_up_owned_files_when_terminal() -> None:
+    """Terminal inspection should cleanup provider-owned input files."""
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {
+        "status": "completed",
+        "request_counts": {"total": 1, "completed": 1, "failed": 0},
+        "completed_at": 1_700_000_600,
+    }
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    await provider.inspect_deferred(
+        ProviderDeferredHandle(
+            job_id="batch_123",
+            provider_state={
+                "owned_file_ids": ["file_batch_input", "file_uploaded_pdf"]
+            },
+        )
+    )
+
+    assert files.deleted_file_ids == ["file_batch_input", "file_uploaded_pdf"]
+
+
+@pytest.mark.asyncio
 async def test_openai_collect_deferred_parses_output_and_error_files() -> None:
     """Batch collection should merge output and error JSONL files by request id."""
     files = _FakeBatchFilesClient()
@@ -1557,6 +1609,56 @@ async def test_openai_collect_deferred_leaves_plain_json_text_unstructured() -> 
 
 
 @pytest.mark.asyncio
+async def test_openai_collect_deferred_cleans_up_owned_files() -> None:
+    """Direct collection should cleanup provider-owned input files after success."""
+    files = _FakeBatchFilesClient()
+    files.contents["file_out"] = json.dumps(
+        {
+            "custom_id": "pollux-000000",
+            "response": {
+                "status_code": 200,
+                "body": {
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "Answer 1",
+                                }
+                            ],
+                        }
+                    ],
+                    "usage": {"total_tokens": 1},
+                },
+            },
+            "error": None,
+        }
+    )
+
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {
+        "status": "completed",
+        "output_file_id": "file_out",
+        "metadata": {},
+    }
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    await provider.collect_deferred(
+        ProviderDeferredHandle(
+            job_id="batch_123",
+            provider_state={
+                "owned_file_ids": ["file_batch_input", "file_uploaded_pdf"]
+            },
+        )
+    )
+
+    assert files.deleted_file_ids == ["file_batch_input", "file_uploaded_pdf"]
+
+
+@pytest.mark.asyncio
 async def test_openai_collect_deferred_synthesizes_batch_level_failure_items() -> None:
     """Batch-level terminal failures should expand into per-request diagnostics."""
     files = _FakeBatchFilesClient()
@@ -1597,6 +1699,72 @@ async def test_openai_collect_deferred_synthesizes_batch_level_failure_items() -
             status="failed",
             error="The provided model is not supported by the Batch API.",
             provider_status="model_not_found",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_collect_deferred_synthesizes_missing_cancelled_items() -> None:
+    """Partial cancelled batches should fill in missing request ids."""
+    files = _FakeBatchFilesClient()
+    files.contents["file_out"] = json.dumps(
+        {
+            "custom_id": "pollux-000000",
+            "response": {
+                "status_code": 200,
+                "body": {
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "Answer 1",
+                                }
+                            ],
+                        }
+                    ],
+                    "usage": {"total_tokens": 1},
+                },
+            },
+            "error": None,
+        }
+    )
+
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {
+        "status": "cancelled",
+        "output_file_id": "file_out",
+        "metadata": {"pollux_request_count": "2"},
+    }
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    items = await provider.collect_deferred(
+        ProviderDeferredHandle(
+            job_id="batch_123",
+            provider_state={"request_ids": ["pollux-000000", "pollux-000001"]},
+        )
+    )
+
+    assert items == [
+        ProviderDeferredItem(
+            request_id="pollux-000000",
+            status="succeeded",
+            response={
+                "text": "Answer 1",
+                "usage": {"total_tokens": 1},
+                "finish_reason": "completed",
+            },
+            provider_status="completed",
+            finish_reason="completed",
+        ),
+        ProviderDeferredItem(
+            request_id="pollux-000001",
+            status="cancelled",
+            error=None,
+            provider_status="cancelled",
         ),
     ]
 
@@ -1700,6 +1868,29 @@ async def test_openai_cancel_deferred_calls_batches_cancel() -> None:
     await provider.cancel_deferred(ProviderDeferredHandle(job_id="batch_123"))
 
     assert batches.cancelled_job_id == "batch_123"
+
+
+@pytest.mark.asyncio
+async def test_openai_cancel_deferred_cleans_up_when_batch_is_terminal() -> None:
+    """Terminal cancel responses should cleanup owned input files."""
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    batches.cancel_result = type(
+        "Batch", (), {"id": "batch_123", "status": "cancelled"}
+    )()
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    await provider.cancel_deferred(
+        ProviderDeferredHandle(
+            job_id="batch_123",
+            provider_state={
+                "owned_file_ids": ["file_batch_input", "file_uploaded_pdf"]
+            },
+        )
+    )
+
+    assert files.deleted_file_ids == ["file_batch_input", "file_uploaded_pdf"]
 
 
 # =============================================================================

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,6 +11,7 @@ and drift is hard to detect.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -1132,6 +1133,272 @@ async def test_openai_extracts_finish_reason() -> None:
         )
 
         assert result.finish_reason == expected, f"status={status}"
+
+
+# =============================================================================
+# OpenAI Deferred Delivery (Characterization)
+# =============================================================================
+
+
+class _FakeBatchFilesClient:
+    """Captures OpenAI Files API interactions for batch tests."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+        self.contents: dict[str, str] = {}
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.create_calls.append(kwargs)
+        purpose = kwargs["purpose"]
+        if purpose == "user_data":
+            return type("File", (), {"id": "file_uploaded_pdf"})()
+        return type("File", (), {"id": "file_batch_input"})()
+
+    async def retrieve_content(self, file_id: str) -> str:
+        return self.contents[file_id]
+
+
+class _FakeBatchesClient:
+    """Captures OpenAI Batch API interactions for batch tests."""
+
+    def __init__(self) -> None:
+        self.create_kwargs: dict[str, Any] | None = None
+        self.retrieve_result: Any = None
+        self.cancelled_job_id: str | None = None
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.create_kwargs = kwargs
+        return type(
+            "Batch",
+            (),
+            {"id": "batch_123", "created_at": 1_700_000_000},
+        )()
+
+    async def retrieve(self, job_id: str) -> Any:
+        _ = job_id
+        return self.retrieve_result
+
+    async def cancel(self, job_id: str) -> Any:
+        self.cancelled_job_id = job_id
+        return type("Batch", (), {"id": job_id})()
+
+
+@pytest.mark.asyncio
+async def test_openai_submit_deferred_characterizes_batch_request(
+    tmp_path: Path,
+) -> None:
+    """Deferred submission should upload JSONL and create a `/v1/responses` batch."""
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    handle = await provider.submit_deferred(
+        [
+            ProviderRequest(
+                model=OPENAI_MODEL,
+                parts=["Summarize this"],
+                response_schema={
+                    "type": "object",
+                    "properties": {"summary": {"type": "string"}},
+                },
+            ),
+            ProviderRequest(
+                model=OPENAI_MODEL,
+                parts=[
+                    {"file_path": str(pdf_path), "mime_type": "application/pdf"},
+                    "Answer the question",
+                ],
+                reasoning_effort="high",
+            ),
+        ],
+        request_ids=["pollux-000000", "pollux-000001"],
+    )
+
+    assert handle.job_id == "batch_123"
+    assert handle.submitted_at == 1_700_000_000
+
+    assert len(files.create_calls) == 2
+    assert files.create_calls[0]["purpose"] == "user_data"
+    assert files.create_calls[1]["purpose"] == "batch"
+
+    batch_upload = files.create_calls[1]["file"]
+    payload = batch_upload.getvalue().decode("utf-8")
+    lines = [json.loads(line) for line in payload.splitlines()]
+    assert [line["custom_id"] for line in lines] == ["pollux-000000", "pollux-000001"]
+    assert all(line["method"] == "POST" for line in lines)
+    assert all(line["url"] == "/v1/responses" for line in lines)
+
+    first_body = lines[0]["body"]
+    assert first_body["model"] == OPENAI_MODEL
+    assert first_body["text"]["format"]["type"] == "json_schema"
+
+    second_body = lines[1]["body"]
+    assert second_body["reasoning"] == {"effort": "high", "summary": "auto"}
+    assert second_body["input"][0]["content"][0] == {
+        "type": "input_file",
+        "file_id": "file_uploaded_pdf",
+    }
+
+    assert batches.create_kwargs == {
+        "input_file_id": "file_batch_input",
+        "endpoint": "/v1/responses",
+        "completion_window": "24h",
+        "metadata": {"pollux_request_count": "2"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_openai_inspect_deferred_normalizes_status_and_counts() -> None:
+    """OpenAI batch status should map into Pollux deferred snapshot semantics."""
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = type(
+        "Batch",
+        (),
+        {
+            "status": "completed",
+            "request_counts": type(
+                "Counts", (), {"total": 3, "completed": 2, "failed": 1}
+            )(),
+            "created_at": 1_700_000_000,
+            "completed_at": 1_700_000_600,
+            "expires_at": 1_700_086_400,
+        },
+    )()
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    snapshot = await provider.inspect_deferred("batch_123")
+
+    assert snapshot.status == "partial"
+    assert snapshot.provider_status == "completed"
+    assert snapshot.request_count == 3
+    assert snapshot.succeeded == 2
+    assert snapshot.failed == 1
+    assert snapshot.pending == 0
+    assert snapshot.submitted_at == 1_700_000_000
+    assert snapshot.completed_at == 1_700_000_600
+    assert snapshot.expires_at == 1_700_086_400
+
+
+@pytest.mark.asyncio
+async def test_openai_inspect_deferred_falls_back_to_metadata_for_total() -> None:
+    """Early OpenAI batch states may need metadata to recover request count."""
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {
+        "status": "validating",
+        "request_counts": None,
+        "metadata": {"pollux_request_count": "4"},
+        "created_at": 1_700_000_000,
+    }
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    snapshot = await provider.inspect_deferred("batch_123")
+
+    assert snapshot.status == "queued"
+    assert snapshot.request_count == 4
+    assert snapshot.pending == 4
+
+
+@pytest.mark.asyncio
+async def test_openai_collect_deferred_parses_output_and_error_files() -> None:
+    """Batch collection should merge output and error JSONL files by request id."""
+    files = _FakeBatchFilesClient()
+    files.contents["file_out"] = "\n".join(
+        [
+            json.dumps(
+                {
+                    "custom_id": "pollux-000001",
+                    "response": {
+                        "status_code": 200,
+                        "body": {
+                            "id": "resp_1",
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "reasoning",
+                                    "summary": [{"text": "Reasoned"}],
+                                },
+                                {
+                                    "type": "message",
+                                    "content": [
+                                        {
+                                            "type": "output_text",
+                                            "text": '{"summary":"A"}',
+                                        }
+                                    ],
+                                },
+                            ],
+                            "usage": {
+                                "input_tokens": 1,
+                                "output_tokens": 2,
+                                "total_tokens": 3,
+                            },
+                        },
+                    },
+                    "error": None,
+                }
+            )
+        ]
+    )
+    files.contents["file_err"] = "\n".join(
+        [
+            json.dumps(
+                {
+                    "custom_id": "pollux-000000",
+                    "error": {
+                        "code": "batch_expired",
+                        "message": "Request expired before execution",
+                    },
+                }
+            )
+        ]
+    )
+
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {
+        "output_file_id": "file_out",
+        "error_file_id": "file_err",
+    }
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    items = await provider.collect_deferred("batch_123")
+
+    assert {item.request_id for item in items} == {"pollux-000000", "pollux-000001"}
+    expired = next(item for item in items if item.request_id == "pollux-000000")
+    success = next(item for item in items if item.request_id == "pollux-000001")
+
+    assert expired.status == "expired"
+    assert expired.error == "Request expired before execution"
+    assert expired.provider_status == "batch_expired"
+
+    assert success.status == "succeeded"
+    assert success.response is not None
+    assert success.response["text"] == '{"summary":"A"}'
+    assert success.response["structured"] == {"summary": "A"}
+    assert success.response["reasoning"] == "Reasoned"
+    assert success.response["usage"]["total_tokens"] == 3
+    assert success.finish_reason == "completed"
+
+
+@pytest.mark.asyncio
+async def test_openai_cancel_deferred_calls_batches_cancel() -> None:
+    """Deferred cancellation should delegate to the Batch API."""
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    await provider.cancel_deferred("batch_123")
+
+    assert batches.cancelled_job_id == "batch_123"
 
 
 # =============================================================================

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -23,6 +23,7 @@ from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import extract_retry_after_s, wrap_provider_error
 from pollux.providers._utils import to_strict_schema
 from pollux.providers.anthropic import AnthropicProvider
+from pollux.providers.base import ProviderDeferredHandle, ProviderDeferredItem
 from pollux.providers.gemini import GeminiProvider
 from pollux.providers.models import (
     Message,
@@ -1146,6 +1147,7 @@ class _FakeBatchFilesClient:
     def __init__(self) -> None:
         self.create_calls: list[dict[str, Any]] = []
         self.contents: dict[str, str] = {}
+        self.deleted_file_ids: list[str] = []
 
     async def create(self, **kwargs: Any) -> Any:
         self.create_calls.append(kwargs)
@@ -1156,6 +1158,9 @@ class _FakeBatchFilesClient:
 
     async def retrieve_content(self, file_id: str) -> str:
         return self.contents[file_id]
+
+    async def delete(self, file_id: str) -> None:
+        self.deleted_file_ids.append(file_id)
 
 
 class _FakeBatchesClient:
@@ -1220,6 +1225,10 @@ async def test_openai_submit_deferred_characterizes_batch_request(
 
     assert handle.job_id == "batch_123"
     assert handle.submitted_at == 1_700_000_000
+    assert handle.provider_state == {
+        "request_ids": ["pollux-000000", "pollux-000001"],
+        "owned_file_ids": ["file_batch_input", "file_uploaded_pdf"],
+    }
 
     assert len(files.create_calls) == 2
     assert files.create_calls[0]["purpose"] == "user_data"
@@ -1300,6 +1309,45 @@ async def test_openai_submit_deferred_reuses_shared_file_uploads(
 
 
 @pytest.mark.asyncio
+async def test_openai_submit_deferred_preserves_remote_artifacts_on_failure(
+    tmp_path: Path,
+) -> None:
+    """Submit failures should not assume rollback safety after remote side effects."""
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+
+    async def _fail_create(**kwargs: Any) -> Any:
+        batches.create_kwargs = kwargs
+        raise RuntimeError("batch create failed")
+
+    batches.create = _fail_create  # type: ignore[method-assign]
+
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    with pytest.raises(
+        APIError, match="OpenAI batch submit failed: batch create failed"
+    ):
+        await provider.submit_deferred(
+            [
+                ProviderRequest(
+                    model=OPENAI_MODEL,
+                    parts=[
+                        {"file_path": str(pdf_path), "mime_type": "application/pdf"},
+                        "Question",
+                    ],
+                )
+            ],
+            request_ids=["pollux-000000"],
+        )
+
+    assert files.deleted_file_ids == []
+
+
+@pytest.mark.asyncio
 async def test_openai_inspect_deferred_normalizes_status_and_counts() -> None:
     """OpenAI batch status should map into Pollux deferred snapshot semantics."""
     files = _FakeBatchFilesClient()
@@ -1320,7 +1368,9 @@ async def test_openai_inspect_deferred_normalizes_status_and_counts() -> None:
     provider = OpenAIProvider("test-key")
     provider._client = type("Client", (), {"files": files, "batches": batches})()
 
-    snapshot = await provider.inspect_deferred("batch_123")
+    snapshot = await provider.inspect_deferred(
+        ProviderDeferredHandle(job_id="batch_123")
+    )
 
     assert snapshot.status == "partial"
     assert snapshot.provider_status == "completed"
@@ -1347,11 +1397,37 @@ async def test_openai_inspect_deferred_falls_back_to_metadata_for_total() -> Non
     provider = OpenAIProvider("test-key")
     provider._client = type("Client", (), {"files": files, "batches": batches})()
 
-    snapshot = await provider.inspect_deferred("batch_123")
+    snapshot = await provider.inspect_deferred(
+        ProviderDeferredHandle(job_id="batch_123")
+    )
 
     assert snapshot.status == "queued"
     assert snapshot.request_count == 4
     assert snapshot.pending == 4
+
+
+@pytest.mark.asyncio
+async def test_openai_inspect_deferred_terminal_failure_zeroes_pending() -> None:
+    """Terminal batch failures should not leave requests counted as pending."""
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {
+        "status": "failed",
+        "request_counts": None,
+        "metadata": {"pollux_request_count": "2"},
+        "failed_at": 1_700_000_600,
+    }
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    snapshot = await provider.inspect_deferred(
+        ProviderDeferredHandle(job_id="batch_123")
+    )
+
+    assert snapshot.status == "failed"
+    assert snapshot.request_count == 2
+    assert snapshot.failed == 2
+    assert snapshot.pending == 0
 
 
 @pytest.mark.asyncio
@@ -1418,7 +1494,7 @@ async def test_openai_collect_deferred_parses_output_and_error_files() -> None:
     provider = OpenAIProvider("test-key")
     provider._client = type("Client", (), {"files": files, "batches": batches})()
 
-    items = await provider.collect_deferred("batch_123")
+    items = await provider.collect_deferred(ProviderDeferredHandle(job_id="batch_123"))
 
     assert {item.request_id for item in items} == {"pollux-000000", "pollux-000001"}
     expired = next(item for item in items if item.request_id == "pollux-000000")
@@ -1471,13 +1547,146 @@ async def test_openai_collect_deferred_leaves_plain_json_text_unstructured() -> 
     provider = OpenAIProvider("test-key")
     provider._client = type("Client", (), {"files": files, "batches": batches})()
 
-    items = await provider.collect_deferred("batch_123")
+    items = await provider.collect_deferred(ProviderDeferredHandle(job_id="batch_123"))
 
     assert items[0].response == {
         "text": '{"plain":true}',
         "usage": {"total_tokens": 1},
         "finish_reason": "completed",
     }
+
+
+@pytest.mark.asyncio
+async def test_openai_collect_deferred_synthesizes_batch_level_failure_items() -> None:
+    """Batch-level terminal failures should expand into per-request diagnostics."""
+    files = _FakeBatchFilesClient()
+
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {
+        "status": "failed",
+        "metadata": {"pollux_request_count": "2"},
+        "errors": {
+            "data": [
+                {
+                    "code": "model_not_found",
+                    "message": "The provided model is not supported by the Batch API.",
+                    "param": "body.model",
+                }
+            ]
+        },
+    }
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    items = await provider.collect_deferred(
+        ProviderDeferredHandle(
+            job_id="batch_123",
+            provider_state={"request_ids": ["custom-a", "custom-b"]},
+        )
+    )
+
+    assert items == [
+        ProviderDeferredItem(
+            request_id="custom-a",
+            status="failed",
+            error="The provided model is not supported by the Batch API.",
+            provider_status="model_not_found",
+        ),
+        ProviderDeferredItem(
+            request_id="custom-b",
+            status="failed",
+            error="The provided model is not supported by the Batch API.",
+            provider_status="model_not_found",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_collect_deferred_reads_nested_http_error_body() -> None:
+    """Batch HTTP failures should surface the nested OpenAI API error message."""
+    files = _FakeBatchFilesClient()
+    files.contents["file_out"] = json.dumps(
+        {
+            "custom_id": "pollux-000000",
+            "response": {
+                "status_code": 400,
+                "body": {
+                    "error": {
+                        "code": "invalid_request_error",
+                        "message": "schema invalid",
+                    }
+                },
+            },
+            "error": None,
+        }
+    )
+
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {"output_file_id": "file_out", "metadata": {}}
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    items = await provider.collect_deferred(ProviderDeferredHandle(job_id="batch_123"))
+
+    assert items == [
+        ProviderDeferredItem(
+            request_id="pollux-000000",
+            status="failed",
+            error="schema invalid",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_collect_deferred_preserves_incomplete_provider_status() -> None:
+    """Batch success items should report the actual Responses API body status."""
+    files = _FakeBatchFilesClient()
+    files.contents["file_out"] = json.dumps(
+        {
+            "custom_id": "pollux-000000",
+            "response": {
+                "status_code": 200,
+                "body": {
+                    "status": "incomplete",
+                    "incomplete_details": {"reason": "max_output_tokens"},
+                    "output": [
+                        {
+                            "type": "message",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "truncated",
+                                }
+                            ],
+                        }
+                    ],
+                    "usage": {"total_tokens": 1},
+                },
+            },
+            "error": None,
+        }
+    )
+
+    batches = _FakeBatchesClient()
+    batches.retrieve_result = {"output_file_id": "file_out", "metadata": {}}
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    items = await provider.collect_deferred(ProviderDeferredHandle(job_id="batch_123"))
+
+    assert items == [
+        ProviderDeferredItem(
+            request_id="pollux-000000",
+            status="succeeded",
+            response={
+                "text": "truncated",
+                "usage": {"total_tokens": 1},
+                "finish_reason": "max_output_tokens",
+            },
+            provider_status="incomplete",
+            finish_reason="max_output_tokens",
+        )
+    ]
 
 
 @pytest.mark.asyncio
@@ -1488,7 +1697,7 @@ async def test_openai_cancel_deferred_calls_batches_cancel() -> None:
     provider = OpenAIProvider("test-key")
     provider._client = type("Client", (), {"files": files, "batches": batches})()
 
-    await provider.cancel_deferred("batch_123")
+    await provider.cancel_deferred(ProviderDeferredHandle(job_id="batch_123"))
 
     assert batches.cancelled_job_id == "batch_123"
 


### PR DESCRIPTION
## Summary

Add the first real deferred delivery backend by implementing OpenAI Batch support behind the deferred provider protocol. This wires batch submit, inspect, collect, and cancel into Pollux's deferred public API without expanding the v1 contract beyond the already-merged API shape.

## Related issue

None

## Test plan

- `just check`
- Added OpenAI provider characterization coverage in `tests/test_providers.py` for:
  - batch JSONL submission shape
  - batch status/count normalization
  - metadata fallback for request counts
  - output/error file collection parsing
  - batch cancellation
- Added public API integration coverage in `tests/test_pipeline.py` for the OpenAI deferred backend path

## Notes

This PR is intentionally provider-specific. It reuses the deferred public contract from #157 and keeps transport-specific logic inside the OpenAI provider, including JSONL batch input construction and output/error file parsing.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [ ] Docs updated (if this changes public API or user-facing behavior)
