### PR TITLE
feat(api): add deferred delivery backends and lifecycle docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ The public API is exposed through `src/pollux/__init__.py`:
 |--------|---------|
 | `config.py` | Immutable `Config` dataclass with API key resolution |
 | `source.py` | `Source` factory with `from_text()`, `from_file()`, `from_youtube()`, `from_arxiv()` |
-| `options.py` | Execution options: `response_schema`, `reasoning_effort`, `delivery_mode` (and reserved conversation inputs) |
+| `options.py` | Execution options: `response_schema`, `reasoning_effort`, legacy `delivery_mode` compatibility, and conversation inputs |
 | `cache.py` | `CacheRegistry` for TTL-based context cache management |
 | `errors.py` | Exception hierarchy with `.hint` attribute for actionable messages |
 | `retry.py` | `RetryPolicy` + bounded async retry used by execution and providers |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ This roadmap is intentionally scope-constrained: ship a stable, high-quality cor
 
 - Feature-parity layers that mask provider differences (example: automatic YouTube download/re-upload for OpenAI).
 - Conversation continuity (`history`, `continue_from`).
-- Deferred delivery (`delivery_mode="deferred"`).
+- Deferred delivery via dedicated entry points (`defer()` / `defer_many()`).
 
 ## Post-1.0 Candidates
 

--- a/docs/building-with-deferred-delivery.md
+++ b/docs/building-with-deferred-delivery.md
@@ -1,0 +1,171 @@
+<!-- Intent: Teach when deferred delivery is worth using and how to structure
+     application code around provider-side job lifecycles. Do NOT reteach the
+     deferred method signatures or every lifecycle state in detail. That lives
+     on the submission page. Assumes the reader already knows defer(),
+     inspect_deferred(), collect_deferred(), and ResultEnvelope. Register:
+     guided applied. -->
+
+# Building With Deferred Delivery
+
+You want deferred delivery to pay for itself. This page covers when to choose
+it, how to tell when work is done, and what your application should do next.
+
+Deferred delivery is not "slower `run()`." It is a remote job contract. You
+submit work now, persist the handle, and collect the result later when the
+provider says the job is done. That changes where your code waits and where
+your application stores progress.
+
+!!! info "Boundary"
+    **Pollux owns:** request normalization, provider submission, handle
+    serialization, normalized lifecycle snapshots, and terminal result
+    extraction.
+
+    **You own:** deciding that the work can wait, persisting handles, choosing
+    polling cadence, deciding what timeout means in your application, and
+    wiring collected results into downstream storage or alerts.
+
+## The Operating Pattern
+
+Teach your application three persistence states:
+
+1. `pending`: the job was submitted and the handle is stored durably.
+2. `collectable`: `inspect_deferred()` says the job reached a terminal state.
+3. `collected`: your code wrote the `ResultEnvelope` somewhere durable and
+   retired the pending handle.
+
+That answers the three important questions:
+
+- `inspect_deferred(handle)` tells you whether the provider is done.
+- `collect_deferred(handle)` gives you the final Pollux result once it is.
+- Your application decides how a pending handle becomes a collected record.
+
+Terminal does not mean successful. A collectable job can still produce
+`result["status"] == "partial"` or `result["status"] == "error"`, so branch on
+the collected envelope before you decide whether the workflow succeeded.
+
+This pattern fits cleanly inside a larger system. A cron job, worker queue,
+CLI, or web app can all use the same boundary. Pollux handles provider
+lifecycle calls. Your code owns scheduling and persistence.
+
+## Complete Example
+
+```python
+import asyncio
+import json
+from pathlib import Path
+
+from pollux import (
+    Config,
+    DeferredHandle,
+    Source,
+    collect_deferred,
+    defer,
+    inspect_deferred,
+)
+
+PENDING_DIR = Path("state/deferred/pending")
+RESULTS_DIR = Path("state/deferred/results")
+
+
+def pending_path(job_id: str) -> Path:
+    return PENDING_DIR / f"{job_id}.json"
+
+
+async def submit_reports(paths: list[Path]) -> None:
+    config = Config(provider="gemini", model="gemini-2.5-flash-lite")
+    PENDING_DIR.mkdir(parents=True, exist_ok=True)
+
+    for path in paths:
+        handle = await defer(
+            "Summarize the report in five bullets and list the three biggest execution risks.",
+            source=Source.from_file(path),
+            config=config,
+        )
+        record = {
+            "report_path": str(path),
+            "handle": handle.to_dict(),
+        }
+        # Persist each handle before moving on to the next submit.
+        pending_path(handle.job_id).write_text(
+            json.dumps(record, indent=2),
+            encoding="utf-8",
+        )
+
+
+async def harvest_ready_reports() -> None:
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    PENDING_DIR.mkdir(parents=True, exist_ok=True)
+
+    for record_path in PENDING_DIR.glob("*.json"):
+        record = json.loads(record_path.read_text(encoding="utf-8"))
+        report_path = Path(record["report_path"])
+        handle = DeferredHandle.from_dict(record["handle"])
+        snapshot = await inspect_deferred(handle)
+        if not snapshot.is_terminal:
+            continue
+
+        result = await collect_deferred(handle)
+        outcome_dir = RESULTS_DIR / result["status"]
+        outcome_dir.mkdir(parents=True, exist_ok=True)
+        result_path = outcome_dir / f"{handle.job_id}.json"
+        collected = {
+            "report_path": str(report_path),
+            "snapshot_status": snapshot.status,
+            "result": result,
+        }
+        # Store the collected outcome, then retire the pending handle.
+        result_path.write_text(json.dumps(collected, indent=2), encoding="utf-8")
+        record_path.unlink()
+
+
+reports = [Path("reports/q1.pdf"), Path("reports/q2.pdf")]
+asyncio.run(submit_reports(reports))
+# Later, from another process or scheduled run:
+# asyncio.run(harvest_ready_reports())
+```
+
+## Why This Shape Works
+
+1. Submission is fast. The interactive path stores a durable handle and exits.
+2. Readiness is explicit. `snapshot.is_terminal` is the only gate before
+   collection.
+3. Success is explicit. `result["status"]` decides whether the collected job
+   landed in `ok`, `partial`, or `error`.
+4. Collection happens once per pending record. After your code writes the
+   outcome, it retires the handle from the pending set.
+5. The result still lands in a normal `ResultEnvelope`, so downstream parsing
+   stays small.
+
+The directories here are placeholders for your real system boundary. Replace
+them with database rows, queue messages, or workflow records if that is how
+your application tracks background work.
+
+## When Deferred Is Worth It
+
+- Large fan-out or fan-in work where no person is waiting on the answer.
+- Scheduled analysis, backfills, and recurring report generation.
+- Provider pricing paths that reward batch-style execution.
+
+Deferred is a poor fit for chat, request-response APIs, or workflows that need
+an answer before the current process can continue.
+
+## What To Watch For
+
+- Completion time is provider-driven. A healthy job can stay queued or running
+  for much longer than a realtime call.
+- A polling timeout is your application's patience limit, not proof that the
+  deferred feature failed.
+- Cancellation is best-effort. A provider can stay in `cancelling` long after
+  you requested it.
+- If a process dies after remote acceptance but before it stores the handle,
+  treat that submit as ambiguous. Do not blindly resubmit when duplicate work
+  would be expensive or confusing.
+- Validate your exact provider, model, source type, and schema combination
+  before you commit a production workflow to it. Start with single-prompt text.
+
+---
+
+For the exact deferred lifecycle API, see
+[Submitting Work for Later Collection](submitting-work-for-later-collection.md).
+For recovery patterns when jobs stay active or fail, see
+[Handling Errors and Recovery](error-handling.md).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -3,7 +3,7 @@
      tool calling, multi-turn, caching, source patterns, reasoning) BEFORE
      showing any Pollux API. Then introduce Pollux's four-phase pipeline and
      the ownership boundary table. Do NOT include runnable code examples or
-     hands-on tutorials — those belong in subsequent pages. Assumes no prior
+     hands-on tutorials, those belong in subsequent pages. Assumes no prior
      LLM API experience. Register: conceptual/declarative. -->
 
 # Core Concepts
@@ -92,6 +92,14 @@ discounts repeated prefixes with no Pollux API surface). When you use explicit
 cache handles, cache identity is keyed to the content bundle rather than the
 file path.
 
+### Deferred Delivery
+
+Not all work needs an immediate answer. **Deferred delivery** submits requests
+to a provider's batch system, often at lower cost when batch pricing is
+available, and returns a serializable handle. Your code persists the handle and
+collects the `ResultEnvelope` later. See
+[Submitting Work for Later Collection](submitting-work-for-later-collection.md).
+
 ### Source Patterns
 
 When analysis scales beyond a single prompt and source, three structural
@@ -129,16 +137,16 @@ graph LR
     E --> X[Extract]
 ```
 
-**Request** — Validates and normalizes prompts, sources, config, and options
+**Request:** Validates and normalizes prompts, sources, config, and options
 into a canonical representation.
 
-**Plan** — Converts the request into deterministic API calls and computes
+**Plan:** Converts the request into deterministic API calls and computes
 cache keys from content hashes.
 
-**Execute** — Uploads content, reuses cached context where possible, and runs
+**Execute:** Uploads content, reuses cached context where possible, and runs
 provider calls concurrently.
 
-**Extract** — Transforms API responses into a stable
+**Extract:** Transforms API responses into a stable
 [`ResultEnvelope`](sending-content.md#resultenvelope-reference) with
 `answers`, optional `structured` data, and `usage` metadata.
 
@@ -203,6 +211,7 @@ leaves domain-level decisions and workflow orchestration to your code.
 | **Models** | Selecting the provider and model | Provider-specific API translation |
 | **Tool execution** | Implementing and calling tools | Surfacing tool-call requests and passing results back |
 | **Multi-turn loops** | Loop control, exit conditions, state | Single-turn request/response with conversation continuity |
+| **Deferred lifecycle** | Persistence, polling cadence, scheduling, cross-job orchestration | Provider submission, lifecycle normalization, ordered collection |
 | **Result aggregation** | Collecting, comparing, and storing answers | Normalizing each response into `ResultEnvelope` |
 | **Error recovery** | Deciding what to retry or skip at the workflow level | Retrying transient API failures within a single call |
 | **Concurrency** | Parallelizing across files or workflows | Concurrent API calls within a single `run_many()` |
@@ -216,5 +225,6 @@ in a library.
 ---
 
 Now that you have the mental model, see
-[Sending Content to Models](sending-content.md) to start using the API: create
-sources, call `run()`, and read results.
+[Sending Content to Models](sending-content.md) to start using the realtime
+API, then [Submitting Work for Later Collection](submitting-work-for-later-collection.md)
+when the job can run in the background.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -98,7 +98,10 @@ Not all work needs an immediate answer. **Deferred delivery** submits requests
 to a provider's batch system, often at lower cost when batch pricing is
 available, and returns a serializable handle. Your code persists the handle and
 collects the `ResultEnvelope` later. See
-[Submitting Work for Later Collection](submitting-work-for-later-collection.md).
+[Building With Deferred Delivery](building-with-deferred-delivery.md) for the
+operating model, then
+[Submitting Work for Later Collection](submitting-work-for-later-collection.md)
+for the lifecycle API.
 
 ### Source Patterns
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 <!-- Intent: Reference page for Config and Options fields. Cover API key
      resolution, mock mode, performance/cost controls, RetryPolicy, and Options
-     per-prompt overrides. Do NOT include tutorials or extended examples — link
-     to the relevant guide pages. Register: reference. -->
+     per-prompt overrides. Do NOT include tutorials or extended examples,
+     link to the relevant guide pages. Register: reference. -->
 
 # Configuring Pollux
 
@@ -135,7 +135,7 @@ options = Options(
     tool_choice="auto",               # Tool calling mode ('auto', 'required', 'none', or dict)
     response_schema=MyPydanticModel,  # Structured output extraction
     reasoning_effort="medium",        # Controls model thinking depth
-    delivery_mode="realtime",         # Only "realtime" is supported
+    delivery_mode="realtime",         # Realtime calls keep the default
     max_tokens=4096,                  # Provider-specific output cap
     implicit_caching=True,            # Auto-cache prefix (Anthropic only)
 )
@@ -150,7 +150,7 @@ options = Options(
 | `tool_choice` | `str \| dict \| None` | `None` | Tool execution strategy. See [Building an Agent Loop](agent-loop.md) |
 | `response_schema` | `type[BaseModel] \| dict` | `None` | Expected JSON response format. See [Extracting Structured Data](structured-data.md) |
 | `reasoning_effort` | `str \| None` | `None` | Controls model thinking depth. See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints) |
-| `delivery_mode` | `str` | `"realtime"` | Only `"realtime"` is supported; `"deferred"` raises an error |
+| `delivery_mode` | `str` | `"realtime"` | Keep the default for `run()` / `run_many()`. Background work uses `defer()` / `defer_many()`. Passing `"deferred"` to realtime entry points raises `ConfigurationError`. |
 | `max_tokens` | `int \| None` | `None` | Output-token cap with provider-specific semantics. Anthropic applies provider defaults when omitted; other providers may ignore it. See [Provider Capabilities](reference/provider-capabilities.md) |
 | `history` | `list[dict] \| None` | `None` | Conversation history. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 | `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
@@ -194,4 +194,5 @@ See [Contributing](contributing.md) for full development setup instructions.
 
 For the full provider feature matrix and model-specific constraints, see
 [Provider Capabilities](reference/provider-capabilities.md) and
-[Writing Portable Code Across Providers](portable-code.md).
+[Writing Portable Code Across Providers](portable-code.md). For the deferred
+workflow, see [Submitting Work for Later Collection](submitting-work-for-later-collection.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,7 +135,6 @@ options = Options(
     tool_choice="auto",               # Tool calling mode ('auto', 'required', 'none', or dict)
     response_schema=MyPydanticModel,  # Structured output extraction
     reasoning_effort="medium",        # Controls model thinking depth
-    delivery_mode="realtime",         # Realtime calls keep the default
     max_tokens=4096,                  # Provider-specific output cap
     implicit_caching=True,            # Auto-cache prefix (Anthropic only)
 )
@@ -150,7 +149,6 @@ options = Options(
 | `tool_choice` | `str \| dict \| None` | `None` | Tool execution strategy. See [Building an Agent Loop](agent-loop.md) |
 | `response_schema` | `type[BaseModel] \| dict` | `None` | Expected JSON response format. See [Extracting Structured Data](structured-data.md) |
 | `reasoning_effort` | `str \| None` | `None` | Controls model thinking depth. See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints) |
-| `delivery_mode` | `str` | `"realtime"` | Keep the default for `run()` / `run_many()`. Background work uses `defer()` / `defer_many()`. Passing `"deferred"` to realtime entry points raises `ConfigurationError`. |
 | `max_tokens` | `int \| None` | `None` | Output-token cap with provider-specific semantics. Anthropic applies provider defaults when omitted; other providers may ignore it. See [Provider Capabilities](reference/provider-capabilities.md) |
 | `history` | `list[dict] \| None` | `None` | Conversation history. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 | `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
@@ -169,6 +167,13 @@ options = Options(
     everywhere. Anthropic uses it as the total output budget and applies a
     provider default when you omit it. OpenRouter forwards it to the routed
     model. Other providers may ignore it in the current release.
+
+!!! note
+    `Options.delivery_mode` remains available only as a compatibility shim for
+    older code. New code should omit it.
+    Deferred work uses `defer()` / `defer_many()`. Legacy
+    `delivery_mode="deferred"` values still raise `ConfigurationError`, with
+    guidance that depends on which entry point you called.
 
 !!! warning "Cache handle restrictions"
     When `cache` is set, `system_instruction`, `tools`, and `tool_choice`

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -99,6 +99,10 @@ Use `snapshot.status` and `snapshot.is_terminal` to decide what your application
 does next. Pollux normalizes lifecycle state. Your code still owns polling
 cadence, backoff, scheduling, and any cross-job retry policy.
 
+Deferred timelines are provider-driven. A valid job can stay queued or running
+for minutes or hours. Treat your polling timeout as an application decision,
+not as proof that deferred submission failed.
+
 ## Complete Production Example
 
 A production wrapper that processes files with category-specific error

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -70,9 +70,9 @@ Use this order when debugging. Most failures resolve by step 2.
 
 3. **Unsupported feature.** Compare your options against
    [Provider Capabilities](reference/provider-capabilities.md).
-   `delivery_mode="deferred"` is not supported on `run()` / `run_many()`;
-   use the deferred API instead. Conversation continuity and tool
-   calling are provider-dependent.
+   Deferred work uses `defer()` / `defer_many()` rather than `run()` /
+   `run_many()`. Conversation continuity and tool calling are
+   provider-dependent.
 
 4. **Source and payload.** Reduce to one source + one prompt and retry.
    For OpenAI remote URLs, only PDF and image URLs are supported.
@@ -230,7 +230,7 @@ asyncio.run(process_collection("./papers", "Summarize the key findings."))
 | `ConfigurationError` at startup | Missing API key | `export GEMINI_API_KEY="your-key"` (or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY`) or pass `api_key` in `Config(...)` |
 | Outputs look like `echo: ...` | `use_mock=True` is set | Set `use_mock=False` (default) and ensure the API key is present |
 | `ConfigurationError` at request time | Provider/model mismatch | Verify the model belongs to the selected provider |
-| `ConfigurationError` mentioning `delivery_mode` | `"deferred"` was passed to a realtime call, or passed redundantly to deferred entry points | Use the default realtime mode for `run()` / `run_many()`, or switch to `defer()` / `defer_many()` |
+| `ConfigurationError` mentioning `delivery_mode` | Legacy `Options(delivery_mode="deferred")` was passed | On `run()` / `run_many()`, switch to `defer()` / `defer_many()`. On deferred entry points, remove `delivery_mode`. |
 | `status: "partial"` | Some prompts returned empty answers | Check individual entries in `answers` to identify which prompts failed |
 | Remote source rejected | Unsupported MIME type on OpenAI | OpenAI remote URL support is limited to PDFs and images |
 | Keys show as `***redacted***` | Intentional redaction | Your key is still being used. `Config` hides it from string representations |

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -69,8 +69,9 @@ Use this order when debugging. Most failures resolve by step 2.
 
 3. **Unsupported feature.** Compare your options against
    [Provider Capabilities](reference/provider-capabilities.md).
-   `delivery_mode="deferred"` is not supported. Conversation continuity
-   and tool calling are provider-dependent.
+   `delivery_mode="deferred"` is not supported on `run()` / `run_many()`;
+   use the sibling deferred API instead. Conversation continuity and tool
+   calling are provider-dependent.
 
 4. **Source and payload.** Reduce to one source + one prompt and retry.
    For OpenAI remote URLs, only PDF and image URLs are supported.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -27,6 +27,7 @@ PolluxError
 ├── SourceError          # File not found, invalid arXiv reference
 ├── PlanningError        # Execution plan could not be built
 ├── InternalError        # Bug or invariant violation inside Pollux
+├── DeferredNotReadyError # Deferred job is still active
 └── APIError             # Provider call failed
     ├── RateLimitError   # HTTP 429 (always retryable)
     └── CacheError       # Cache operation failed
@@ -70,11 +71,33 @@ Use this order when debugging. Most failures resolve by step 2.
 3. **Unsupported feature.** Compare your options against
    [Provider Capabilities](reference/provider-capabilities.md).
    `delivery_mode="deferred"` is not supported on `run()` / `run_many()`;
-   use the sibling deferred API instead. Conversation continuity and tool
+   use the deferred API instead. Conversation continuity and tool
    calling are provider-dependent.
 
 4. **Source and payload.** Reduce to one source + one prompt and retry.
    For OpenAI remote URLs, only PDF and image URLs are supported.
+
+## Deferred Collection State
+
+`collect_deferred()` is not a polling helper. If the job is still active, it
+raises `DeferredNotReadyError` and attaches the latest `DeferredSnapshot` on
+`exc.snapshot`.
+
+```python
+from pollux import DeferredNotReadyError, collect_deferred
+
+try:
+    result = await collect_deferred(handle)
+except DeferredNotReadyError as exc:
+    snapshot = exc.snapshot
+    print(snapshot.status)       # queued, running, or cancelling
+    print(snapshot.pending)      # Requests still in flight
+    print(snapshot.is_terminal)  # False
+```
+
+Use `snapshot.status` and `snapshot.is_terminal` to decide what your application
+does next. Pollux normalizes lifecycle state. Your code still owns polling
+cadence, backoff, scheduling, and any cross-job retry policy.
 
 ## Complete Production Example
 
@@ -207,7 +230,7 @@ asyncio.run(process_collection("./papers", "Summarize the key findings."))
 | `ConfigurationError` at startup | Missing API key | `export GEMINI_API_KEY="your-key"` (or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY`) or pass `api_key` in `Config(...)` |
 | Outputs look like `echo: ...` | `use_mock=True` is set | Set `use_mock=False` (default) and ensure the API key is present |
 | `ConfigurationError` at request time | Provider/model mismatch | Verify the model belongs to the selected provider |
-| `ConfigurationError` mentioning `delivery_mode` | `"deferred"` is not supported | Use `delivery_mode="realtime"` (default) |
+| `ConfigurationError` mentioning `delivery_mode` | `"deferred"` was passed to a realtime call, or passed redundantly to deferred entry points | Use the default realtime mode for `run()` / `run_many()`, or switch to `defer()` / `defer_many()` |
 | `status: "partial"` | Some prompts returned empty answers | Check individual entries in `answers` to identify which prompts failed |
 | Remote source rejected | Unsupported MIME type on OpenAI | OpenAI remote URL support is limited to PDFs and images |
 | Keys show as `***redacted***` | Intentional redaction | Your key is still being used. `Config` hides it from string representations |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 <!-- Intent: First contact with Pollux. Get the user to a working result as
      fast as possible. Do NOT teach concepts, source patterns, or advanced
-     features — those are linked at the end. Assume the reader knows what an
+     features, those are linked at the end. Assume the reader knows what an
      LLM API is but has never seen Pollux. Register: warm tutorial. -->
 
 # Getting Started
@@ -98,7 +98,7 @@ That's your first Pollux result. The `status` is `ok` and the answer
 references details from the source text. When this works, swap to your real
 input: `Source.from_file("document.pdf")`.
 
-!!! info "What just happened?"
+!!! info "What happened?"
     **Pollux owned:** normalizing your prompt and source into a request,
     planning the API call, executing it, and extracting the answer into a
     standard [ResultEnvelope](sending-content.md#resultenvelope-reference).
@@ -110,4 +110,6 @@ input: `Source.from_file("document.pdf")`.
     on each page of the docs.
 
 **What's next?** Read [Core Concepts](concepts.md) for the full mental model,
-then [Sending Content to Models](sending-content.md) to explore the API.
+then [Sending Content to Models](sending-content.md) for realtime calls or
+[Submitting Work for Later Collection](submitting-work-for-later-collection.md)
+if your workload can run in the background.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,9 @@ content. No boilerplate.
 **Context caching.** Upload once, reuse across prompts. Automatic TTL
 management saves tokens and money.
 
+**Deferred delivery.** Submit non-urgent work once, persist a handle, and
+collect later in the same `ResultEnvelope` format.
+
 **Built for reliability.** Async pipeline, retries with backoff, structured
 output, usage tracking.
 
@@ -44,6 +47,7 @@ pip install pollux-ai
 - [Core Concepts](concepts.md)
 - [Sending Content to Models](sending-content.md)
 - [Source Patterns](source-patterns.md)
+- [Submitting Work for Later Collection](submitting-work-for-later-collection.md)
 - [Structured Data](structured-data.md)
 - [Conversations and Agents](conversations-and-agents.md)
 - [Agent Loop](agent-loop.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ pip install pollux-ai
 - [Sending Content to Models](sending-content.md)
 - [Source Patterns](source-patterns.md)
 - [Submitting Work for Later Collection](submitting-work-for-later-collection.md)
+- [Building With Deferred Delivery](building-with-deferred-delivery.md)
 - [Structured Data](structured-data.md)
 - [Conversations and Agents](conversations-and-agents.md)
 - [Agent Loop](agent-loop.md)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,6 +16,8 @@ For provider-level feature differences, see [Provider Capabilities](provider-cap
 |---|---|---|
 | Ask one prompt about one source (or no source) | `run()` | [Sending Content to Models](../sending-content.md) |
 | Ask many prompts against shared sources | `run_many()` | [Analyzing Collections with Source Patterns](../source-patterns.md) |
+| Submit non-urgent work and collect it later | `defer()` / `defer_many()` | [Submitting Work for Later Collection](../submitting-work-for-later-collection.md) |
+| Check deferred job status or collect terminal results | `inspect_deferred()` / `collect_deferred()` / `cancel_deferred()` | [Submitting Work for Later Collection](../submitting-work-for-later-collection.md) |
 | Feed tool results back into a conversation turn | `continue_tool()` | [Building an Agent Loop](../agent-loop.md) |
 | Reuse Gemini context across later calls | `create_cache()` | [Reducing Costs with Context Caching](../caching.md) |
 
@@ -26,6 +28,16 @@ The primary execution functions are exported from `pollux`:
 ::: pollux.run
 
 ::: pollux.run_many
+
+::: pollux.defer
+
+::: pollux.defer_many
+
+::: pollux.inspect_deferred
+
+::: pollux.collect_deferred
+
+::: pollux.cancel_deferred
 
 ::: pollux.continue_tool
 
@@ -38,6 +50,10 @@ The primary execution functions are exported from `pollux`:
 ::: pollux.CacheHandle
 
 ::: pollux.Config
+
+::: pollux.DeferredHandle
+
+::: pollux.DeferredSnapshot
 
 ::: pollux.Options
 
@@ -62,3 +78,5 @@ The primary execution functions are exported from `pollux`:
 ::: pollux.RateLimitError
 
 ::: pollux.CacheError
+
+::: pollux.DeferredNotReadyError

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,7 +16,7 @@ For provider-level feature differences, see [Provider Capabilities](provider-cap
 |---|---|---|
 | Ask one prompt about one source (or no source) | `run()` | [Sending Content to Models](../sending-content.md) |
 | Ask many prompts against shared sources | `run_many()` | [Analyzing Collections with Source Patterns](../source-patterns.md) |
-| Submit non-urgent work and collect it later | `defer()` / `defer_many()` | [Submitting Work for Later Collection](../submitting-work-for-later-collection.md) |
+| Submit non-urgent work and collect it later | `defer()` / `defer_many()` | [Building With Deferred Delivery](../building-with-deferred-delivery.md) |
 | Check deferred job status or collect terminal results | `inspect_deferred()` / `collect_deferred()` / `cancel_deferred()` | [Submitting Work for Later Collection](../submitting-work-for-later-collection.md) |
 | Feed tool results back into a conversation turn | `continue_tool()` | [Building an Agent Loop](../agent-loop.md) |
 | Reuse Gemini context across later calls | `create_cache()` | [Reducing Costs with Context Caching](../caching.md) |

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -31,7 +31,7 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
 | Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `response_format` or `structured_outputs` |
 | Reasoning controls (`reasoning_effort`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Passed through to provider where supported; see notes below |
-| Deferred delivery (`delivery_mode="deferred"`) | ❌ | ❌ | ❌ | ❌ | Not supported; raises `ConfigurationError` |
+| Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | Use the sibling deferred API; `delivery_mode="deferred"` remains unsupported |
 | Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `tools`; forced tool use may also require `tool_choice` |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | Works on OpenRouter models that support tool calling |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
@@ -41,6 +41,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 ### Gemini
 
 - Explicit caching uses the Gemini Files API.
+- Deferred delivery uses the Gemini Batch API through Pollux's sibling
+  deferred lifecycle helpers.
 - Gemini also caches repeated long prefixes automatically. Pollux does not
   expose a toggle for that path.
 - Gemini does not support `previous_response_id`; conversation state is
@@ -55,6 +57,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 
 - File uploads are configured to automatically expire on the OpenAI side.
   Pollux also performs best-effort cleanup of uploaded files after execution.
+- Deferred delivery uses the OpenAI Batch API through Pollux's sibling
+  deferred lifecycle helpers.
 - OpenAI caches repeated long prefixes automatically. Pollux does not expose
   OpenAI-specific cache controls.
 - Remote URL support is intentionally narrow: PDFs and images only.
@@ -77,6 +81,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 
 - Local file uploads use the Anthropic Files API (beta). Supported types:
   images, PDFs, and text files.
+- Deferred delivery uses the Anthropic Message Batches API through Pollux's
+  sibling deferred lifecycle helpers.
 - Remote URL support is intentionally narrow: images and PDFs only.
 - Implicit caching is enabled with `Options(implicit_caching=True)`.
   Pollux defaults it on for single-call workloads and off for multi-call

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -31,7 +31,7 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
 | Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `response_format` or `structured_outputs` |
 | Reasoning controls (`reasoning_effort`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Passed through to provider where supported; see notes below |
-| Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | Use the deferred API; `delivery_mode="deferred"` remains unsupported |
+| Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | Use the deferred API directly. |
 | Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `tools`; forced tool use may also require `tool_choice` |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | Works on OpenRouter models that support tool calling |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | Single prompt per call |

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -36,6 +36,9 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | Works on OpenRouter models that support tool calling |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
+For when deferred delivery is a fit and how to structure code around provider
+jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.md).
+
 ## Provider-Specific Notes
 
 ### Gemini

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -31,7 +31,7 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
 | Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `response_format` or `structured_outputs` |
 | Reasoning controls (`reasoning_effort`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Passed through to provider where supported; see notes below |
-| Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | Use the sibling deferred API; `delivery_mode="deferred"` remains unsupported |
+| Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | Use the deferred API; `delivery_mode="deferred"` remains unsupported |
 | Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `tools`; forced tool use may also require `tool_choice` |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | Works on OpenRouter models that support tool calling |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
@@ -41,8 +41,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 ### Gemini
 
 - Explicit caching uses the Gemini Files API.
-- Deferred delivery uses the Gemini Batch API through Pollux's sibling
-  deferred lifecycle helpers.
+- Deferred delivery uses the Gemini Batch API through Pollux's deferred entry
+  points.
 - Gemini also caches repeated long prefixes automatically. Pollux does not
   expose a toggle for that path.
 - Gemini does not support `previous_response_id`; conversation state is
@@ -57,8 +57,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 
 - File uploads are configured to automatically expire on the OpenAI side.
   Pollux also performs best-effort cleanup of uploaded files after execution.
-- Deferred delivery uses the OpenAI Batch API through Pollux's sibling
-  deferred lifecycle helpers.
+- Deferred delivery uses the OpenAI Batch API through Pollux's deferred entry
+  points.
 - OpenAI caches repeated long prefixes automatically. Pollux does not expose
   OpenAI-specific cache controls.
 - Remote URL support is intentionally narrow: PDFs and images only.
@@ -82,7 +82,7 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 - Local file uploads use the Anthropic Files API (beta). Supported types:
   images, PDFs, and text files.
 - Deferred delivery uses the Anthropic Message Batches API through Pollux's
-  sibling deferred lifecycle helpers.
+  deferred entry points.
 - Remote URL support is intentionally narrow: images and PDFs only.
 - Implicit caching is enabled with `Options(implicit_caching=True)`.
   Pollux defaults it on for single-call workloads and off for multi-call
@@ -165,3 +165,6 @@ handle = await create_cache(
 
 The error is raised at `create_cache()` call time because persistent caching
 is a provider capability checked before the upload attempt.
+
+For the deferred lifecycle contract and out-of-scope options, see
+[Submitting Work for Later Collection](../submitting-work-for-later-collection.md).

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -44,7 +44,7 @@ remote  = Source.from_uri("https://example.com/data.csv", mime_type="text/csv")
 metrics = {"revenue_q1": 4_200_000, "growth_pct": 12.5, "region": "EMEA"}
 context = Source.from_json(metrics)
 
-# Pydantic models work directly — model_dump() is called automatically
+# Pydantic models work directly, model_dump() is called automatically
 class UserProfile(BaseModel):
     name: str
     preferences: list[str]
@@ -147,7 +147,7 @@ Q1: Paper 1 argues that multimodal orchestration layers reduce boilerplate by...
 Q2: Key findings: (1) fan-out caching saves 85-92% of input tokens; (2) broad...
 ```
 
-## Choosing `run()` vs `run_many()`
+## Choosing the Entry Point
 
 | Situation | Use | Why |
 |---|---|---|
@@ -155,9 +155,11 @@ Q2: Key findings: (1) fan-out caching saves 85-92% of input tokens; (2) broad...
 | Multiple questions on shared source(s) | `run_many()` | Fan-out efficiency |
 | Same question across many sources | `run_many()` | Fan-in analysis |
 | Many questions across many sources | `run_many()` | Broadcast pattern |
+| Non-urgent work you will collect later | `defer()` / `defer_many()` | Background provider execution with a serializable handle |
 | Returning tool results to the model | `continue_tool()` | Feeds tool outputs back into the conversation |
 
-Rule of thumb: if prompts or sources are plural, reach for `run_many()`.
+Rule of thumb: if prompts or sources are plural and you want answers now, reach
+for `run_many()`. If the workload can wait, reach for `defer_many()`.
 
 `continue_tool()` is a specialized entry point for agent loops. It takes a
 previous `ResultEnvelope` containing tool calls and your tool results, and
@@ -171,8 +173,9 @@ workloads because it shares uploads and runs prompts concurrently.
 
 ## ResultEnvelope Reference
 
-Every `run()` and `run_many()` call returns a `ResultEnvelope`: a dict with
-a stable shape that works the same regardless of provider.
+Every `run()`, `run_many()`, and `collect_deferred()` call returns a
+`ResultEnvelope`: a dict with a stable shape that works the same regardless of
+provider.
 
 | Field | Type | Always present | Description |
 |---|---|---|---|
@@ -183,8 +186,9 @@ a stable shape that works the same regardless of provider.
 | `tool_calls` | `list[list[dict]]` | Only with tool calling | Per-prompt list of tool-call requests. See [Conversations](conversations-and-agents.md) |
 | `confidence` | `float` | Yes | Heuristic: `0.9` for ok, `0.5` otherwise |
 | `extraction_method` | `str` | Yes | Always `"text"` |
-| `usage` | `dict[str, int]` | Yes | Token counts (`input_tokens`, `output_tokens`, `total_tokens`) |
-| `metrics` | `dict[str, Any]` | Yes | `duration_s`, `n_calls`, `cache_used` ([explicit caching](caching.md#explicit-caching-gemini) only), `finish_reasons` (per-prompt, e.g. `"stop"`, `"max_tokens"`) |
+| `usage` | `dict[str, int]` | Yes | Token counts (`input_tokens`, `output_tokens`, `total_tokens`, and optional `reasoning_tokens`) |
+| `metrics` | `dict[str, Any]` | Yes | `duration_s`, `n_calls`, `cache_used` ([explicit caching](caching.md#explicit-caching-gemini) only), `finish_reasons` (per-prompt, e.g. `"stop"`, `"max_tokens"`). Deferred results also add `metrics["deferred"] = True`. |
+| `diagnostics` | `dict[str, Any]` | Yes | Low-level diagnostics. All calls include `raw_responses`. Deferred results also add `diagnostics["deferred"]` with `job_id`, timing, and per-request lifecycle items. |
 
 Example of a complete envelope:
 
@@ -196,6 +200,7 @@ Example of a complete envelope:
     "extraction_method": "text",
     "usage": {"input_tokens": 1250, "output_tokens": 89, "total_tokens": 1339},
     "metrics": {"duration_s": 1.42, "n_calls": 1, "cache_used": False, "finish_reasons": ["stop"]},
+    "diagnostics": {"raw_responses": [...]},
 }
 ```
 
@@ -205,8 +210,11 @@ Example of a complete envelope:
   prompt per call. See
   [Continuing Conversations Across Turns](conversations-and-agents.md).
 - `delivery_mode="deferred"` is not supported on `run()` / `run_many()`.
-  Use the sibling deferred API instead: `defer()`, `defer_many()`,
+  Use the deferred API instead: `defer()`, `defer_many()`,
   `inspect_deferred()`, `collect_deferred()`, and `cancel_deferred()`.
+- Deferred lifecycle calls take a `DeferredHandle`, not `Config`. Persist the
+  handle and restore it later. See
+  [Submitting Work for Later Collection](submitting-work-for-later-collection.md).
 - Provider feature support varies. See
   [Provider Capabilities](reference/provider-capabilities.md).
 
@@ -214,6 +222,8 @@ Example of a complete envelope:
 
 Once you're comfortable with single calls, see
 [Analyzing Collections with Source Patterns](source-patterns.md) for fan-out,
-fan-in, and broadcast workflows, or
+fan-in, and broadcast workflows,
+[Submitting Work for Later Collection](submitting-work-for-later-collection.md)
+when the job can run in the background, or
 [Extracting Structured Data](structured-data.md) to get typed objects instead
 of free-form text.

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -204,7 +204,9 @@ Example of a complete envelope:
 - Conversation continuity (`history`, `continue_from`) works with one
   prompt per call. See
   [Continuing Conversations Across Turns](conversations-and-agents.md).
-- `delivery_mode="deferred"` is not supported and raises an error.
+- `delivery_mode="deferred"` is not supported on `run()` / `run_many()`.
+  Use the sibling deferred API instead: `defer()`, `defer_many()`,
+  `inspect_deferred()`, `collect_deferred()`, and `cancel_deferred()`.
 - Provider feature support varies. See
   [Provider Capabilities](reference/provider-capabilities.md).
 

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -209,9 +209,8 @@ Example of a complete envelope:
 - Conversation continuity (`history`, `continue_from`) works with one
   prompt per call. See
   [Continuing Conversations Across Turns](conversations-and-agents.md).
-- `delivery_mode="deferred"` is not supported on `run()` / `run_many()`.
-  Use the deferred API instead: `defer()`, `defer_many()`,
-  `inspect_deferred()`, `collect_deferred()`, and `cancel_deferred()`.
+- Deferred work uses `defer()`, `defer_many()`, `inspect_deferred()`,
+  `collect_deferred()`, and `cancel_deferred()`.
 - Deferred lifecycle calls take a `DeferredHandle`, not `Config`. Persist the
   handle and restore it later. See
   [Submitting Work for Later Collection](submitting-work-for-later-collection.md).

--- a/docs/submitting-work-for-later-collection.md
+++ b/docs/submitting-work-for-later-collection.md
@@ -90,10 +90,9 @@ turns `True`, `collect_deferred()` returns the same `ResultEnvelope` shape that
 
 - The handle is the lifecycle record. Persist the full `handle.to_dict()`
   payload, including `provider_state`.
-- `inspect_deferred()` takes only the handle. You do not pass `Config` back in.
-- Lifecycle calls resolve auth from `handle.provider` and the usual provider
-  environment variable. If collection runs in another process, export that key
-  there too.
+- Lifecycle calls take only the handle. Auth is resolved from
+  `handle.provider` and the usual provider environment variable. If collection
+  runs in another process, export that key there too.
 - `DeferredSnapshot.is_terminal` is the stable readiness check. Do not branch on
   one provider's raw status strings.
 - `collect_deferred()` is not a polling helper. If the job is still active, it
@@ -119,8 +118,7 @@ returned structured payloads.
 
 - Deferred delivery uses dedicated entry points: `defer()`, `defer_many()`,
   `inspect_deferred()`, `collect_deferred()`, and `cancel_deferred()`.
-- `run()` and `run_many()` remain realtime entry points. Setting
-  `Options(delivery_mode="deferred")` raises `ConfigurationError`.
+- `run()` and `run_many()` remain realtime entry points.
 - Deferred delivery does not support conversation continuity, tool calling,
   persistent cache handles, or implicit caching.
 - `cancel_deferred(handle)` requests provider-side cancellation. Final status is

--- a/docs/submitting-work-for-later-collection.md
+++ b/docs/submitting-work-for-later-collection.md
@@ -1,0 +1,149 @@
+<!-- Intent: Teach the deferred workflow for non-urgent jobs: submit,
+     persist the handle, inspect status, and collect results later. Do NOT
+     teach workflow engines, schedulers, queues, or multi-job orchestration.
+     Assumes the reader already knows run(), run_many(), Source, Config, and
+     ResultEnvelope. Register: guided applied. -->
+
+# Submitting Work for Later Collection
+
+Some work does not need an answer in the next few seconds. A long fan-out over
+large documents, a nightly analysis job, or a backfill across stored reports
+fits a different shape: submit now, collect later, and use provider batch
+pricing when it is available.
+
+Pollux handles the provider-facing deferred lifecycle. Your application stores
+the handle, decides when to poll, and decides what to do with the result.
+
+!!! info "Boundary"
+    **Pollux owns:** request normalization, provider submission, stable request
+    ids, normalized status snapshots, ordered collection, and extraction into a
+    standard `ResultEnvelope`.
+
+    **You own:** handle persistence, polling cadence, scheduling, cross-job
+    orchestration, and downstream storage.
+
+## Complete Example
+
+```python
+import asyncio
+import json
+from pathlib import Path
+
+from pollux import (
+    Config,
+    DeferredHandle,
+    Source,
+    collect_deferred,
+    defer_many,
+    inspect_deferred,
+)
+
+JOB_PATH = Path("outputs/deferred-job.json")
+
+
+async def submit_job() -> None:
+    config = Config(provider="openai", model="gpt-5-nano")
+    handle = await defer_many(
+        [
+            "Summarize the report in five bullets.",
+            "List the three biggest execution risks.",
+        ],
+        sources=(Source.from_file("market-report.pdf"),),
+        config=config,
+    )
+    JOB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    JOB_PATH.write_text(json.dumps(handle.to_dict(), indent=2))
+    print(f"saved {handle.job_id} to {JOB_PATH}")
+
+
+async def collect_job() -> None:
+    handle = DeferredHandle.from_dict(json.loads(JOB_PATH.read_text()))
+    snapshot = await inspect_deferred(handle)
+    print(
+        f"status={snapshot.status} "
+        f"succeeded={snapshot.succeeded} "
+        f"failed={snapshot.failed} "
+        f"pending={snapshot.pending}"
+    )
+    if not snapshot.is_terminal:
+        return
+
+    result = await collect_deferred(handle)
+    print(result["status"])
+    for answer in result["answers"]:
+        print(answer)
+
+
+asyncio.run(submit_job())
+# Later, in the same process or a different one:
+# asyncio.run(collect_job())
+```
+
+Run `submit_job()` once. You should see a provider job id and a JSON file at
+`outputs/deferred-job.json`. Run `collect_job()` later. `inspect_deferred()`
+normalizes the lifecycle into `queued`, `running`, `cancelling`, `completed`,
+`partial`, `failed`, `cancelled`, or `expired`. Once `snapshot.is_terminal`
+turns `True`, `collect_deferred()` returns the same `ResultEnvelope` shape that
+`run()` and `run_many()` return.
+
+### Why this example is shaped this way
+
+- The handle is the lifecycle record. Persist the full `handle.to_dict()`
+  payload, including `provider_state`.
+- `inspect_deferred()` takes only the handle. You do not pass `Config` back in.
+- Lifecycle calls resolve auth from `handle.provider` and the usual provider
+  environment variable. If collection runs in another process, export that key
+  there too.
+- `DeferredSnapshot.is_terminal` is the stable readiness check. Do not branch on
+  one provider's raw status strings.
+- `collect_deferred()` is not a polling helper. If the job is still active, it
+  raises `DeferredNotReadyError`.
+- For a single prompt, use `defer()`. It wraps `defer_many()` the same way
+  `run()` wraps `run_many()`.
+- Collection preserves prompt order. If you submitted two prompts, the first
+  answer still maps to the first prompt.
+
+## Structured Output Across Processes
+
+Deferred collection can still return structured data. Submit with
+`Options(response_schema=YourModel)`, then pass the same schema back to
+`collect_deferred(handle, response_schema=YourModel)`.
+
+Pollux stores a schema fingerprint in the handle. If the schema changed between
+submit and collect, Pollux raises `ConfigurationError` instead of silently
+rehydrating into the wrong shape. If you omit `response_schema` at collect
+time, Pollux returns plain dicts in `result["structured"]` when the provider
+returned structured payloads.
+
+## Current Scope
+
+- Deferred delivery uses dedicated entry points: `defer()`, `defer_many()`,
+  `inspect_deferred()`, `collect_deferred()`, and `cancel_deferred()`.
+- `run()` and `run_many()` remain realtime entry points. Setting
+  `Options(delivery_mode="deferred")` raises `ConfigurationError`.
+- Deferred delivery does not support conversation continuity, tool calling,
+  persistent cache handles, or implicit caching.
+- `cancel_deferred(handle)` requests provider-side cancellation. Final status is
+  still provider-driven.
+
+## Deferred Results
+
+Collected deferred jobs return a standard `ResultEnvelope` plus deferred
+diagnostics:
+
+- `result["metrics"]["deferred"]` is `True`
+- `result["diagnostics"]["deferred"]["job_id"]` identifies the remote job
+- `result["diagnostics"]["deferred"]["items"]` includes per-request status,
+  finish reason, provider status, and any item-level error text
+
+Those are deferred-only additions on top of the standard envelope shape
+documented in [ResultEnvelope Reference](sending-content.md#resultenvelope-reference).
+
+That keeps downstream code small. Your post-processing path can usually treat
+realtime and deferred results the same way.
+
+---
+
+Next, read [Handling Errors and Recovery](error-handling.md) for retry policy
+and error types, or check [Provider Capabilities](reference/provider-capabilities.md)
+to see which providers support deferred delivery in the current release.

--- a/docs/submitting-work-for-later-collection.md
+++ b/docs/submitting-work-for-later-collection.md
@@ -14,6 +14,11 @@ pricing when it is available.
 Pollux handles the provider-facing deferred lifecycle. Your application stores
 the handle, decides when to poll, and decides what to do with the result.
 
+If you are deciding whether deferred is the right shape for a workload, or how
+to structure code around long-running provider jobs, read
+[Building With Deferred Delivery](building-with-deferred-delivery.md) alongside
+this page. This page stays focused on the lifecycle API itself.
+
 !!! info "Boundary"
     **Pollux owns:** request normalization, provider submission, stable request
     ids, normalized status snapshots, ordered collection, and extraction into a
@@ -142,6 +147,8 @@ realtime and deferred results the same way.
 
 ---
 
-Next, read [Handling Errors and Recovery](error-handling.md) for retry policy
-and error types, or check [Provider Capabilities](reference/provider-capabilities.md)
-to see which providers support deferred delivery in the current release.
+Next, read [Building With Deferred Delivery](building-with-deferred-delivery.md)
+for the operating model and where deferred pays off. Then read
+[Handling Errors and Recovery](error-handling.md) for retry policy and error
+types, or check [Provider Capabilities](reference/provider-capabilities.md) to
+see which providers support deferred delivery in the current release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
   - Sending Content to Models: sending-content.md
   - Analyzing Collections with Source Patterns: source-patterns.md
   - Submitting Work for Later Collection: submitting-work-for-later-collection.md
+  - Building With Deferred Delivery: building-with-deferred-delivery.md
   - Extracting Structured Data: structured-data.md
   - Continuing Conversations Across Turns: conversations-and-agents.md
   - Building an Agent Loop: agent-loop.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
   - Core Concepts: concepts.md
   - Sending Content to Models: sending-content.md
   - Analyzing Collections with Source Patterns: source-patterns.md
+  - Submitting Work for Later Collection: submitting-work-for-later-collection.md
   - Extracting Structured Data: structured-data.md
   - Continuing Conversations Across Turns: conversations-and-agents.md
   - Building an Agent Loop: agent-loop.md

--- a/scripts/deferred_delivery_probe.py
+++ b/scripts/deferred_delivery_probe.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+"""Probe Pollux deferred delivery with low-cost live and validation cases.
+
+Examples:
+  uv run python scripts/deferred_delivery_probe.py
+  uv run python scripts/deferred_delivery_probe.py --provider openai --provider gemini
+  uv run python scripts/deferred_delivery_probe.py --case single_text_roundtrip
+  uv run python scripts/deferred_delivery_probe.py --case unsupported_provider_rejected
+  uv run python scripts/deferred_delivery_probe.py --model openai=gpt-5-nano
+  uv run python scripts/deferred_delivery_probe.py --live-only --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Any, Literal
+from uuid import uuid4
+
+from dotenv import load_dotenv
+from pydantic import BaseModel
+
+import pollux
+from pollux import Config, DeferredHandle, Options, Source
+from pollux.cache import CacheHandle
+from pollux.errors import ConfigurationError, DeferredNotReadyError, PolluxError
+
+ProviderName = Literal["gemini", "openai", "anthropic", "openrouter"]
+CaseKind = Literal["live", "validation"]
+
+DEFAULT_MODELS: dict[ProviderName, str] = {
+    "gemini": "gemini-2.5-flash-lite-preview-09-2025",
+    "openai": "gpt-5-nano",
+    "anthropic": "claude-haiku-4-5",
+    "openrouter": "openai/gpt-5-nano",
+}
+LIVE_PROVIDERS: tuple[ProviderName, ...] = ("gemini", "openai", "anthropic")
+ENV_VARS: dict[ProviderName, str] = {
+    "gemini": "GEMINI_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+CASE_DESCRIPTIONS: dict[str, tuple[CaseKind, str]] = {
+    "single_text_roundtrip": (
+        "live",
+        "Submit one prompt, serialize/restore the handle, inspect, and collect.",
+    ),
+    "multi_prompt_order": (
+        "live",
+        "Submit three prompts and verify collection order and deferred metadata.",
+    ),
+    "structured_roundtrip": (
+        "live",
+        "Submit with response_schema, reject a mismatched schema, then collect as Pydantic.",
+    ),
+    "structured_plain_dicts": (
+        "live",
+        "Submit with response_schema and collect without a schema to get plain dicts.",
+    ),
+    "source_only_text": (
+        "live",
+        "Submit a source-only deferred job with no prompt to exercise the prompt-less path.",
+    ),
+    "local_text_file": (
+        "live",
+        "Submit a tiny local text file source to exercise deferred file uploads.",
+    ),
+    "cancel_fast": (
+        "live",
+        "Submit multi-prompt work, cancel quickly, and inspect the terminal outcome.",
+    ),
+    "empty_prompts_rejected": (
+        "validation",
+        "Verify defer_many([]) fails fast with the documented ConfigurationError.",
+    ),
+    "legacy_delivery_mode_rejected": (
+        "validation",
+        "Verify Options(delivery_mode='deferred') is rejected on defer entry points.",
+    ),
+    "out_of_scope_options_rejected": (
+        "validation",
+        "Verify deferred rejects cache, conversation continuity, tools, and implicit caching.",
+    ),
+    "unsupported_provider_rejected": (
+        "validation",
+        "Verify openrouter fails fast because deferred delivery is unsupported.",
+    ),
+}
+DEFAULT_CASES: tuple[str, ...] = tuple(CASE_DESCRIPTIONS)
+
+
+@dataclass(frozen=True, slots=True)
+class RunContext:
+    """Shared probe settings."""
+
+    run_id: str
+    output_path: Path
+    artifact_root: Path
+    poll_interval_seconds: float
+    terminal_timeout_seconds: float
+    keep_jobs: bool
+    model_overrides: dict[ProviderName, str]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--provider",
+        action="append",
+        choices=LIVE_PROVIDERS,
+        default=[],
+        help="Provider to probe live. Repeatable. Defaults to all with configured API keys.",
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        default=[],
+        metavar="PROVIDER=MODEL",
+        help="Override a default model, for example --model openai=gpt-4.1-nano.",
+    )
+    parser.add_argument(
+        "--case",
+        action="append",
+        choices=sorted(CASE_DESCRIPTIONS),
+        default=[],
+        help="Probe case to run. Repeatable. Defaults to the full live+validation matrix.",
+    )
+    parser.add_argument(
+        "--live-only",
+        action="store_true",
+        help="Run only live provider cases.",
+    )
+    parser.add_argument(
+        "--validation-only",
+        action="store_true",
+        help="Run only local validation cases.",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=3.0,
+        help="Seconds between inspect_deferred() polls.",
+    )
+    parser.add_argument(
+        "--terminal-timeout-seconds",
+        type=float,
+        default=180.0,
+        help="Maximum seconds to wait for a job to reach a terminal state.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="JSONL output path. Defaults to artifacts/deferred-probe-<timestamp>.jsonl.",
+    )
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        help="Artifact directory. Defaults to artifacts/deferred-probe-<timestamp>/.",
+    )
+    parser.add_argument(
+        "--keep-jobs",
+        action="store_true",
+        help="Do not auto-cancel jobs that time out before reaching a terminal state.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero if any case fails.",
+    )
+    parser.add_argument(
+        "--list-cases",
+        action="store_true",
+        help="List available probe cases and exit.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    """Run the probe script."""
+    args = parse_args(argv)
+    if args.list_cases:
+        for slug, (kind, description) in CASE_DESCRIPTIONS.items():
+            print(f"{slug:<30} [{kind}] {description}", flush=True)
+        return 0
+    if args.live_only and args.validation_only:
+        print(
+            "--live-only and --validation-only are mutually exclusive.", file=sys.stderr
+        )
+        return 2
+
+    load_dotenv()
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_path = args.out or Path("artifacts") / f"deferred-probe-{timestamp}.jsonl"
+    artifact_root = (
+        args.artifact_dir or Path("artifacts") / f"deferred-probe-{timestamp}"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    artifact_root.mkdir(parents=True, exist_ok=True)
+
+    selected_cases = _resolve_cases(args)
+    model_overrides = _parse_model_overrides(args.model)
+    live_providers = _resolve_live_providers(args.provider, selected_cases)
+
+    context = RunContext(
+        run_id=uuid4().hex,
+        output_path=output_path,
+        artifact_root=artifact_root,
+        poll_interval_seconds=args.poll_interval_seconds,
+        terminal_timeout_seconds=args.terminal_timeout_seconds,
+        keep_jobs=bool(args.keep_jobs),
+        model_overrides=model_overrides,
+    )
+
+    records = asyncio.run(run_probe(context, selected_cases, live_providers))
+    print(f"Wrote {len(records)} records to {output_path}", flush=True)
+    print_summary(records)
+
+    if args.strict and any(not bool(record.get("ok")) for record in records):
+        return 1
+    return 0
+
+
+async def run_probe(
+    context: RunContext,
+    selected_cases: list[str],
+    live_providers: list[ProviderName],
+) -> list[dict[str, Any]]:
+    """Run the selected cases and persist JSONL records."""
+    records: list[dict[str, Any]] = []
+
+    with context.output_path.open("a", encoding="utf-8") as sink:
+        for provider in live_providers:
+            model = context.model_overrides.get(provider, DEFAULT_MODELS[provider])
+            for case_name in selected_cases:
+                if CASE_DESCRIPTIONS[case_name][0] != "live":
+                    continue
+                record = await execute_live_case(
+                    context=context,
+                    provider=provider,
+                    model=model,
+                    case_name=case_name,
+                )
+                records.append(record)
+                sink.write(
+                    json.dumps(record, sort_keys=True, default=_json_default) + "\n"
+                )
+                sink.flush()
+                _print_record(record)
+
+        for case_name in selected_cases:
+            if CASE_DESCRIPTIONS[case_name][0] != "validation":
+                continue
+            record = await execute_validation_case(context=context, case_name=case_name)
+            records.append(record)
+            sink.write(json.dumps(record, sort_keys=True, default=_json_default) + "\n")
+            sink.flush()
+            _print_record(record)
+
+    return records
+
+
+async def execute_live_case(
+    *,
+    context: RunContext,
+    provider: ProviderName,
+    model: str,
+    case_name: str,
+) -> dict[str, Any]:
+    """Execute one live provider probe case."""
+    started_at = time.time()
+    case_dir = context.artifact_root / provider / case_name
+    case_dir.mkdir(parents=True, exist_ok=True)
+    config = Config(provider=provider, model=model)
+
+    try:
+        if case_name == "single_text_roundtrip":
+            details = await _case_single_text_roundtrip(context, case_dir, config)
+        elif case_name == "multi_prompt_order":
+            details = await _case_multi_prompt_order(context, case_dir, config)
+        elif case_name == "structured_roundtrip":
+            details = await _case_structured_roundtrip(context, case_dir, config)
+        elif case_name == "structured_plain_dicts":
+            details = await _case_structured_plain_dicts(context, case_dir, config)
+        elif case_name == "source_only_text":
+            details = await _case_source_only_text(context, case_dir, config)
+        elif case_name == "local_text_file":
+            details = await _case_local_text_file(context, case_dir, config)
+        elif case_name == "cancel_fast":
+            details = await _case_cancel_fast(context, case_dir, config)
+        else:
+            raise AssertionError(f"Unhandled live case: {case_name}")
+        ok = True
+        error: dict[str, Any] | None = None
+    except Exception as exc:
+        details = {}
+        ok = False
+        error = _serialize_exception(exc)
+        _write_json(case_dir / "error.json", error)
+
+    return {
+        "artifact_dir": str(case_dir),
+        "case": case_name,
+        "description": CASE_DESCRIPTIONS[case_name][1],
+        "duration_s": round(time.time() - started_at, 3),
+        "kind": "live",
+        "model": model,
+        "ok": ok,
+        "provider": provider,
+        "started_at": started_at,
+        "run_id": context.run_id,
+        "error": error,
+        **details,
+    }
+
+
+async def execute_validation_case(
+    *,
+    context: RunContext,
+    case_name: str,
+) -> dict[str, Any]:
+    """Execute one local validation case."""
+    started_at = time.time()
+    case_dir = context.artifact_root / "validation" / case_name
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if case_name == "empty_prompts_rejected":
+            details = await _validation_empty_prompts_rejected(case_dir)
+        elif case_name == "legacy_delivery_mode_rejected":
+            details = await _validation_legacy_delivery_mode_rejected(case_dir)
+        elif case_name == "out_of_scope_options_rejected":
+            details = await _validation_out_of_scope_options_rejected(case_dir)
+        elif case_name == "unsupported_provider_rejected":
+            details = await _validation_unsupported_provider_rejected(case_dir)
+        else:
+            raise AssertionError(f"Unhandled validation case: {case_name}")
+        ok = True
+        error: dict[str, Any] | None = None
+    except Exception as exc:
+        details = {}
+        ok = False
+        error = _serialize_exception(exc)
+        _write_json(case_dir / "error.json", error)
+
+    return {
+        "artifact_dir": str(case_dir),
+        "case": case_name,
+        "description": CASE_DESCRIPTIONS[case_name][1],
+        "duration_s": round(time.time() - started_at, 3),
+        "kind": "validation",
+        "model": None,
+        "ok": ok,
+        "provider": None,
+        "started_at": started_at,
+        "run_id": context.run_id,
+        "error": error,
+        **details,
+    }
+
+
+async def _case_single_text_roundtrip(
+    context: RunContext,
+    case_dir: Path,
+    config: Config,
+) -> dict[str, Any]:
+    token = f"{config.provider.upper()}_DEFERRED_SINGLE_OK"
+    handle = await pollux.defer(
+        f"Reply with exactly {token}.",
+        config=config,
+    )
+    return await _collect_text_case(
+        context=context,
+        case_dir=case_dir,
+        handle=handle,
+        expected_tokens=[token],
+        expect_not_ready=True,
+    )
+
+
+async def _case_multi_prompt_order(
+    context: RunContext,
+    case_dir: Path,
+    config: Config,
+) -> dict[str, Any]:
+    tokens = [
+        f"{config.provider.upper()}_ORDER_ALPHA",
+        f"{config.provider.upper()}_ORDER_BRAVO",
+        f"{config.provider.upper()}_ORDER_CHARLIE",
+    ]
+    handle = await pollux.defer_many(
+        [f"Reply with exactly {token}." for token in tokens],
+        config=config,
+    )
+    details = await _collect_text_case(
+        context=context,
+        case_dir=case_dir,
+        handle=handle,
+        expected_tokens=tokens,
+        expect_not_ready=False,
+    )
+    diagnostics = details["result"]["diagnostics"]["deferred"]["items"]
+    request_ids = [item["request_id"] for item in diagnostics]
+    _ensure(
+        condition=request_ids == ["pollux-000000", "pollux-000001", "pollux-000002"],
+        message=f"unexpected request ids: {request_ids}",
+    )
+    details["request_ids"] = request_ids
+    return details
+
+
+async def _case_structured_roundtrip(
+    context: RunContext,
+    case_dir: Path,
+    config: Config,
+) -> dict[str, Any]:
+    class StructuredPayload(BaseModel):
+        label: str
+        count: int
+
+    class WrongPayload(BaseModel):
+        name: str
+
+    handle = await pollux.defer(
+        "Return JSON with label exactly 'STRUCTURED_ROUNDTRIP_OK' and count exactly 7.",
+        config=config,
+        options=Options(response_schema=StructuredPayload),
+    )
+    _write_json(case_dir / "handle.json", handle.to_dict())
+
+    mismatch_message: str | None = None
+    try:
+        await pollux.collect_deferred(handle, response_schema=WrongPayload)
+    except ConfigurationError as exc:
+        mismatch_message = str(exc)
+    _ensure(
+        condition=(
+            mismatch_message is not None and "does not match" in mismatch_message
+        ),
+        message="mismatched collect-time schema did not fail as expected",
+    )
+
+    terminal_snapshot, snapshots = await _wait_for_terminal(context, handle)
+    _write_json(
+        case_dir / "snapshots.json", [asdict(snapshot) for snapshot in snapshots]
+    )
+    _write_json(case_dir / "final_snapshot.json", asdict(terminal_snapshot))
+
+    result = await pollux.collect_deferred(handle, response_schema=StructuredPayload)
+    _write_json(case_dir / "result.json", result)
+
+    structured = result.get("structured")
+    _ensure(
+        condition=isinstance(structured, list) and len(structured) == 1,
+        message="missing structured output",
+    )
+    payload = structured[0]
+    _ensure(
+        condition=isinstance(payload, StructuredPayload),
+        message="structured payload is not a Pydantic model",
+    )
+    _ensure(
+        condition=payload.label == "STRUCTURED_ROUNDTRIP_OK",
+        message=f"unexpected label: {payload.label!r}",
+    )
+    _ensure(
+        condition=payload.count == 7, message=f"unexpected count: {payload.count!r}"
+    )
+    _ensure(
+        condition=result["metrics"]["deferred"] is True,
+        message="missing deferred metric flag",
+    )
+
+    return {
+        "handle": handle.to_dict(),
+        "schema_mismatch_error": mismatch_message,
+        "terminal_snapshot": asdict(terminal_snapshot),
+        "result": result,
+    }
+
+
+async def _case_structured_plain_dicts(
+    context: RunContext,
+    case_dir: Path,
+    config: Config,
+) -> dict[str, Any]:
+    class StructuredPayload(BaseModel):
+        label: str
+        enabled: bool
+
+    handle = await pollux.defer(
+        "Return JSON with label exactly 'STRUCTURED_DICT_OK' and enabled exactly true.",
+        config=config,
+        options=Options(response_schema=StructuredPayload),
+    )
+    _write_json(case_dir / "handle.json", handle.to_dict())
+
+    terminal_snapshot, snapshots = await _wait_for_terminal(context, handle)
+    _write_json(
+        case_dir / "snapshots.json", [asdict(snapshot) for snapshot in snapshots]
+    )
+    _write_json(case_dir / "final_snapshot.json", asdict(terminal_snapshot))
+
+    result = await pollux.collect_deferred(handle)
+    _write_json(case_dir / "result.json", result)
+
+    structured = result.get("structured")
+    _ensure(
+        condition=isinstance(structured, list) and len(structured) == 1,
+        message="missing structured output",
+    )
+    payload = structured[0]
+    _ensure(
+        condition=isinstance(payload, dict),
+        message="collect without schema should return plain dicts",
+    )
+    _ensure(
+        condition=payload.get("label") == "STRUCTURED_DICT_OK",
+        message=f"unexpected label: {payload!r}",
+    )
+    _ensure(
+        condition=payload.get("enabled") is True,
+        message=f"unexpected payload: {payload!r}",
+    )
+
+    return {
+        "handle": handle.to_dict(),
+        "terminal_snapshot": asdict(terminal_snapshot),
+        "result": result,
+    }
+
+
+async def _case_source_only_text(
+    context: RunContext,
+    case_dir: Path,
+    config: Config,
+) -> dict[str, Any]:
+    token = f"{config.provider.upper()}_SOURCE_ONLY_OK"
+    source = Source.from_text(
+        f"Reply with exactly {token}. Do not add anything else.",
+        identifier="source-only-instruction",
+    )
+    handle = await pollux.defer(
+        prompt=None,
+        source=source,
+        config=config,
+    )
+    return await _collect_text_case(
+        context=context,
+        case_dir=case_dir,
+        handle=handle,
+        expected_tokens=[token],
+        expect_not_ready=False,
+    )
+
+
+async def _case_local_text_file(
+    context: RunContext,
+    case_dir: Path,
+    config: Config,
+) -> dict[str, Any]:
+    token = f"{config.provider.upper()}_FILE_OK"
+    input_path = case_dir / "source.txt"
+    input_path.write_text(
+        f"Document token: {token}\nReturn this token when asked.\n",
+        encoding="utf-8",
+    )
+    handle = await pollux.defer(
+        "Read the local file source and reply with exactly the document token.",
+        source=Source.from_file(input_path),
+        config=config,
+    )
+    details = await _collect_text_case(
+        context=context,
+        case_dir=case_dir,
+        handle=handle,
+        expected_tokens=[token],
+        expect_not_ready=False,
+    )
+    details["input_path"] = str(input_path)
+    return details
+
+
+async def _case_cancel_fast(
+    context: RunContext,
+    case_dir: Path,
+    config: Config,
+) -> dict[str, Any]:
+    prompts = [
+        "Reply with exactly CANCEL_FAST_ONE.",
+        "Reply with exactly CANCEL_FAST_TWO.",
+    ]
+    handle = await pollux.defer_many(prompts, config=config)
+    _write_json(case_dir / "handle.json", handle.to_dict())
+    await pollux.cancel_deferred(handle)
+
+    terminal_snapshot, snapshots = await _wait_for_terminal(context, handle)
+    _write_json(
+        case_dir / "snapshots.json", [asdict(snapshot) for snapshot in snapshots]
+    )
+    _write_json(case_dir / "final_snapshot.json", asdict(terminal_snapshot))
+
+    _ensure(
+        condition=terminal_snapshot.status
+        in {"cancelled", "partial", "completed", "failed", "expired"},
+        message=f"unexpected cancel terminal status: {terminal_snapshot.status}",
+    )
+    result = await pollux.collect_deferred(handle)
+    _write_json(case_dir / "result.json", result)
+    _ensure(
+        condition=result["metrics"]["deferred"] is True,
+        message="missing deferred metric flag",
+    )
+
+    return {
+        "handle": handle.to_dict(),
+        "terminal_snapshot": asdict(terminal_snapshot),
+        "result": result,
+    }
+
+
+async def _collect_text_case(
+    *,
+    context: RunContext,
+    case_dir: Path,
+    handle: DeferredHandle,
+    expected_tokens: list[str],
+    expect_not_ready: bool,
+) -> dict[str, Any]:
+    _write_json(case_dir / "handle.json", handle.to_dict())
+    restored = DeferredHandle.from_dict(handle.to_dict())
+
+    first_snapshot = await pollux.inspect_deferred(restored)
+    snapshots = [first_snapshot]
+    _write_json(case_dir / "initial_snapshot.json", asdict(first_snapshot))
+
+    not_ready_observed = False
+    if expect_not_ready and not first_snapshot.is_terminal:
+        try:
+            await pollux.collect_deferred(restored)
+        except DeferredNotReadyError as exc:
+            not_ready_observed = True
+            _write_json(case_dir / "not_ready_snapshot.json", asdict(exc.snapshot))
+
+    terminal_snapshot, later_snapshots = await _wait_for_terminal(
+        context,
+        restored,
+        initial_snapshots=snapshots,
+    )
+    _write_json(
+        case_dir / "snapshots.json", [asdict(snapshot) for snapshot in later_snapshots]
+    )
+    _write_json(case_dir / "final_snapshot.json", asdict(terminal_snapshot))
+
+    result = await pollux.collect_deferred(restored)
+    _write_json(case_dir / "result.json", result)
+
+    answers = result["answers"]
+    _ensure(
+        condition=len(answers) == len(expected_tokens),
+        message="answer count does not match prompt count",
+    )
+    for idx, token in enumerate(expected_tokens):
+        answer = answers[idx]
+        _ensure(condition=bool(answer.strip()), message=f"answer {idx} is empty")
+        _ensure(
+            condition=token.lower() in answer.lower(),
+            message=f"answer {idx} did not include expected token {token!r}: {answer!r}",
+        )
+
+    _ensure(
+        condition=result["metrics"]["deferred"] is True,
+        message="missing deferred metric flag",
+    )
+    _ensure(
+        condition=result["diagnostics"]["deferred"]["job_id"] == restored.job_id,
+        message="deferred diagnostics job id did not round-trip",
+    )
+
+    return {
+        "handle": restored.to_dict(),
+        "immediate_not_ready_observed": not_ready_observed,
+        "terminal_snapshot": asdict(terminal_snapshot),
+        "result": result,
+    }
+
+
+async def _wait_for_terminal(
+    context: RunContext,
+    handle: DeferredHandle,
+    *,
+    initial_snapshots: list[pollux.DeferredSnapshot] | None = None,
+) -> tuple[pollux.DeferredSnapshot, list[pollux.DeferredSnapshot]]:
+    """Poll inspect_deferred() until the job is terminal or times out."""
+    snapshots = list(initial_snapshots or [])
+    if snapshots and snapshots[-1].is_terminal:
+        return snapshots[-1], snapshots
+
+    deadline = time.monotonic() + context.terminal_timeout_seconds
+    last_snapshot = snapshots[-1] if snapshots else None
+
+    while True:
+        if time.monotonic() >= deadline:
+            if not context.keep_jobs:
+                with suppress(Exception):
+                    await pollux.cancel_deferred(handle)
+            raise TimeoutError(
+                f"job {handle.job_id} did not reach a terminal state within "
+                f"{context.terminal_timeout_seconds}s"
+            )
+
+        snapshot = await pollux.inspect_deferred(handle)
+        if last_snapshot is None or snapshot != last_snapshot:
+            snapshots.append(snapshot)
+            last_snapshot = snapshot
+        if snapshot.is_terminal:
+            return snapshot, snapshots
+        await asyncio.sleep(context.poll_interval_seconds)
+
+
+async def _validation_empty_prompts_rejected(case_dir: Path) -> dict[str, Any]:
+    config = Config(
+        provider="openai", model=DEFAULT_MODELS["openai"], api_key="test-key"
+    )
+    message = await _expect_configuration_error(
+        case_dir,
+        "empty_prompts",
+        pollux.defer_many([], config=config),
+        "requires at least one prompt",
+    )
+    return {"checks": [{"name": "empty_prompts", "message": message}]}
+
+
+async def _validation_legacy_delivery_mode_rejected(case_dir: Path) -> dict[str, Any]:
+    config = Config(
+        provider="openai", model=DEFAULT_MODELS["openai"], api_key="test-key"
+    )
+    message = await _expect_configuration_error(
+        case_dir,
+        "legacy_delivery_mode",
+        pollux.defer(
+            "Q1?",
+            config=config,
+            options=Options(delivery_mode="deferred"),
+        ),
+        "not needed with defer",
+    )
+    return {"checks": [{"name": "legacy_delivery_mode", "message": message}]}
+
+
+async def _validation_out_of_scope_options_rejected(case_dir: Path) -> dict[str, Any]:
+    config = Config(
+        provider="openai", model=DEFAULT_MODELS["openai"], api_key="test-key"
+    )
+    checks: list[dict[str, str]] = []
+    options_to_test = [
+        (
+            "cache",
+            Options(
+                cache=CacheHandle(
+                    "cache-1", "openai", DEFAULT_MODELS["openai"], time.time() + 3600
+                )
+            ),
+            "cache",
+        ),
+        (
+            "history",
+            Options(history=[{"role": "user", "content": "hello"}]),
+            "Conversation continuity",
+        ),
+        (
+            "continue_from",
+            Options(continue_from={"status": "ok", "answers": []}),
+            "Conversation continuity",
+        ),
+        (
+            "tools",
+            Options(tools=[{"type": "function", "function": {"name": "f"}}]),
+            "Tool calling",
+        ),
+        ("implicit_caching_true", Options(implicit_caching=True), "implicit_caching"),
+        ("implicit_caching_false", Options(implicit_caching=False), "implicit_caching"),
+    ]
+    for name, options, match in options_to_test:
+        message = await _expect_configuration_error(
+            case_dir,
+            name,
+            pollux.defer("Q1?", config=config, options=options),
+            match,
+        )
+        checks.append({"name": name, "message": message})
+    return {"checks": checks}
+
+
+async def _validation_unsupported_provider_rejected(case_dir: Path) -> dict[str, Any]:
+    config = Config(
+        provider="openrouter",
+        model=DEFAULT_MODELS["openrouter"],
+        api_key="test-key",
+    )
+    message = await _expect_configuration_error(
+        case_dir,
+        "unsupported_provider",
+        pollux.defer("Q1?", config=config),
+        "does not support deferred delivery",
+    )
+    return {"checks": [{"name": "unsupported_provider", "message": message}]}
+
+
+async def _expect_configuration_error(
+    case_dir: Path,
+    slug: str,
+    awaitable: Any,
+    expected_substring: str,
+) -> str:
+    """Await *awaitable* and assert it fails with ConfigurationError."""
+    try:
+        await awaitable
+    except ConfigurationError as exc:
+        payload = _serialize_exception(exc)
+        _write_json(case_dir / f"{slug}.json", payload)
+        _ensure(
+            condition=expected_substring in str(exc),
+            message=f"expected {expected_substring!r} in {exc!r}",
+        )
+        return str(exc)
+    raise AssertionError(f"{slug} did not raise ConfigurationError")
+
+
+def _resolve_cases(args: argparse.Namespace) -> list[str]:
+    cases = list(args.case or DEFAULT_CASES)
+    if args.live_only:
+        cases = [case for case in cases if CASE_DESCRIPTIONS[case][0] == "live"]
+    if args.validation_only:
+        cases = [case for case in cases if CASE_DESCRIPTIONS[case][0] == "validation"]
+    return cases
+
+
+def _resolve_live_providers(
+    requested_providers: list[str],
+    selected_cases: list[str],
+) -> list[ProviderName]:
+    live_cases_selected = any(
+        CASE_DESCRIPTIONS[case][0] == "live" for case in selected_cases
+    )
+    if not live_cases_selected:
+        return []
+
+    if requested_providers:
+        missing = [
+            provider
+            for provider in requested_providers
+            if not os.getenv(ENV_VARS[provider])
+        ]
+        if missing:
+            missing_vars = ", ".join(ENV_VARS[provider] for provider in missing)
+            print(
+                "Missing API keys for requested live providers: " + missing_vars,
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        return list(dict.fromkeys(requested_providers))
+
+    available = [
+        provider for provider in LIVE_PROVIDERS if os.getenv(ENV_VARS[provider])
+    ]
+    if available:
+        return available
+
+    print(
+        "No live providers selected or configured. Set one of "
+        "GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY, "
+        "or run --validation-only.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def _parse_model_overrides(values: list[str]) -> dict[ProviderName, str]:
+    overrides: dict[ProviderName, str] = {}
+    for raw in values:
+        provider, sep, model = raw.partition("=")
+        if sep != "=" or provider not in DEFAULT_MODELS or not model:
+            raise SystemExit(f"Invalid --model value: {raw!r}. Use PROVIDER=MODEL.")
+        overrides[provider] = model
+    return overrides
+
+
+def _ensure(*, condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, default=_json_default) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _serialize_exception(exc: BaseException) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": type(exc).__name__,
+        "message": str(exc),
+    }
+    if isinstance(exc, PolluxError) and exc.hint:
+        payload["hint"] = exc.hint
+    if isinstance(exc, DeferredNotReadyError):
+        payload["snapshot"] = asdict(exc.snapshot)
+    return payload
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, DeferredHandle):
+        return value.to_dict()
+    return str(value)
+
+
+def _print_record(record: dict[str, Any]) -> None:
+    status = "PASS" if record.get("ok") else "FAIL"
+    provider = record.get("provider") or "validation"
+    model = record.get("model") or "-"
+    case = record["case"]
+    suffix = ""
+    if record.get("error"):
+        suffix = f" :: {record['error']['type']}: {record['error']['message']}"
+    elif record.get("terminal_snapshot"):
+        suffix = f" :: terminal={record['terminal_snapshot']['status']}"
+    print(f"{status:<4} {provider:<10} {model:<34} {case}{suffix}", flush=True)
+
+
+def print_summary(records: list[dict[str, Any]]) -> None:
+    """Print a compact run summary."""
+    total = len(records)
+    passed = sum(1 for record in records if record.get("ok"))
+    failed = total - passed
+    by_kind: dict[str, int] = {"live": 0, "validation": 0}
+    for record in records:
+        by_kind[str(record["kind"])] += 1
+    print(
+        "Summary: "
+        f"{passed}/{total} passed, "
+        f"{failed} failed, "
+        f"live={by_kind['live']}, validation={by_kind['validation']}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -79,7 +79,7 @@ async def run(
         prompt: The prompt to run.
         source: Optional source for context (file, text, URL).
         config: Configuration specifying provider and model.
-        options: Optional additive features (schema, reasoning, delivery mode).
+        options: Optional additive features such as schema or reasoning controls.
 
     Returns:
         ResultEnvelope with answers and metrics.
@@ -119,7 +119,7 @@ async def run_many(
         prompts: One or more prompts to run.
         sources: Optional sources for shared context.
         config: Configuration specifying provider and model.
-        options: Optional additive features (schema, reasoning, delivery mode).
+        options: Optional additive features such as schema or reasoning controls.
 
     Returns:
         ResultEnvelope with answers (one per prompt) and metrics.
@@ -169,9 +169,11 @@ async def defer_many(
         await _close_provider(provider)
 
 
-async def inspect_deferred(handle: DeferredHandle) -> DeferredSnapshot:
+async def inspect_deferred(
+    handle: DeferredHandle,
+) -> DeferredSnapshot:
     """Inspect the current state of a deferred job."""
-    provider = _get_deferred_provider_from_handle(handle)
+    provider = _resolve_deferred_provider(handle)
     try:
         return await inspect_deferred_handle(handle, provider)
     finally:
@@ -183,8 +185,14 @@ async def collect_deferred(
     *,
     response_schema: type[Any] | dict[str, Any] | None = None,
 ) -> ResultEnvelope:
-    """Collect a terminal deferred job into the standard ResultEnvelope."""
-    provider = _get_deferred_provider_from_handle(handle)
+    """Collect a terminal deferred job into the standard ResultEnvelope.
+
+    Args:
+        handle: The deferred handle returned by ``defer()`` / ``defer_many()``.
+        response_schema: Optional Pydantic model or JSON Schema for structured
+            output rehydration. Must match the schema used at submission time.
+    """
+    provider = _resolve_deferred_provider(handle)
     try:
         return await collect_deferred_handle(
             handle,
@@ -195,9 +203,11 @@ async def collect_deferred(
         await _close_provider(provider)
 
 
-async def cancel_deferred(handle: DeferredHandle) -> None:
+async def cancel_deferred(
+    handle: DeferredHandle,
+) -> None:
     """Request provider-side cancellation for a deferred job."""
-    provider = _get_deferred_provider_from_handle(handle)
+    provider = _resolve_deferred_provider(handle)
     try:
         await cancel_deferred_handle(handle, provider)
     finally:
@@ -360,7 +370,7 @@ def _get_provider(config: Config) -> Provider:
     return _create_provider(config.provider, config.api_key, use_mock=config.use_mock)
 
 
-def _get_deferred_provider_from_handle(handle: DeferredHandle) -> Provider:
+def _resolve_deferred_provider(handle: DeferredHandle) -> Provider:
     """Resolve a provider client for deferred lifecycle calls from the handle."""
     if handle.provider not in {"gemini", "openai", "anthropic", "openrouter"}:
         raise ConfigurationError(

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -137,13 +137,13 @@ def _validate_deferred_plan(plan: Plan, provider: Provider) -> None:
     options = plan.request.options
     caps = provider.capabilities
 
-    _get_deferred_provider(provider)
-
     if options.delivery_mode == "deferred":
         raise ConfigurationError(
             "delivery_mode='deferred' is not needed with defer() or defer_many()",
             hint="Call defer() / defer_many() directly without setting delivery_mode.",
         )
+
+    _get_deferred_provider(provider)
     if options.cache is not None:
         raise ConfigurationError(
             "Persistent cache handles are not supported with deferred delivery",

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -86,10 +86,11 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
         options.history is not None or options.continue_from is not None
     )
 
-    # TODO: implement deferred delivery via provider batch APIs.
+    # Belt-and-suspenders: Options.__post_init__ already rejects "deferred",
+    # but guard here in case validation is ever bypassed.
     if options.delivery_mode == "deferred":
         raise ConfigurationError(
-            "delivery_mode='deferred' is not supported on run() or run_many()",
+            "delivery_mode='deferred' is a legacy compatibility shim and is not supported",
             hint="Use pollux.defer() or pollux.defer_many() for deferred delivery.",
         )
     if options.response_schema is not None and not caps.structured_outputs:

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -16,7 +16,11 @@ if TYPE_CHECKING:
     from pollux.result import ResultEnvelope
 
 ReasoningEffort = str
-DeliveryMode = Literal["realtime", "deferred"]
+# Intentionally kept as plain ``str`` instead of ``Literal[...]`` so IDEs do
+# not advertise the legacy ``"deferred"`` value in completions while older
+# callers can still pass it during migration. Runtime validation below keeps
+# the accepted set narrow and provides upgrade guidance.
+DeliveryMode = str
 ResponseSchemaInput = type[BaseModel] | dict[str, Any]
 
 
@@ -73,7 +77,7 @@ class Options:
 
     #: Controls model thinking depth; passed through to the provider.
     reasoning_effort: ReasoningEffort | None = None
-    # TODO: implement deferred delivery via provider batch APIs.
+    #: Legacy compatibility shim. Realtime remains the only supported value.
     delivery_mode: DeliveryMode = "realtime"
     #: Mutually exclusive with *continue_from*.
     history: list[dict[str, Any]] | None = None
@@ -115,6 +119,18 @@ class Options:
             raise ConfigurationError(
                 "max_tokens must be a positive integer",
                 hint="Pass max_tokens=16384 or greater for thinking models.",
+            )
+
+        # Keep this runtime guard even though ``delivery_mode`` is typed as
+        # ``str`` on purpose; the loose annotation is a UX choice for editor
+        # autocomplete, not a widening of the supported values.
+        if self.delivery_mode not in {"realtime", "deferred"}:
+            raise ConfigurationError(
+                "delivery_mode must be 'realtime' or 'deferred'",
+                hint=(
+                    "Remove delivery_mode, keep the default realtime mode, "
+                    "or use delivery_mode='deferred' only as a migration shim."
+                ),
             )
 
         if self.history is not None and self.continue_from is not None:

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+import inspect
 import json
 import logging
 from typing import TYPE_CHECKING, Any
@@ -415,7 +416,10 @@ class AnthropicProvider:
             batch = await client.messages.batches.retrieve(handle.job_id)
             items: list[ProviderDeferredItem] = []
             if batch.results_url is not None:
-                async for row in client.messages.batches.results(handle.job_id):
+                results_stream = client.messages.batches.results(handle.job_id)
+                if inspect.isawaitable(results_stream):
+                    results_stream = await results_stream
+                async for row in results_stream:
                     items.append(
                         _parse_batch_result(
                             row,

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 import json
+import logging
 from typing import TYPE_CHECKING, Any
 
 from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import wrap_provider_error
 from pollux.providers._utils import to_strict_schema
-from pollux.providers.base import ProviderCapabilities
+from pollux.providers.base import (
+    DeferredItemStatus,
+    ProviderCapabilities,
+    ProviderDeferredHandle,
+    ProviderDeferredItem,
+    ProviderDeferredSnapshot,
+)
 from pollux.providers.models import (
     Message,
     ProviderFileAsset,
@@ -22,6 +30,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 _ANTHROPIC_DEFAULT_MAX_TOKENS = 16384
+logger = logging.getLogger(__name__)
 _INTERLEAVED_THINKING_BETA_HEADER = "interleaved-thinking-2025-05-14"
 _ANTHROPIC_THINKING_BLOCKS_KEY = "anthropic_thinking_blocks"
 _ALLOWED_REASONING_EFFORTS = {"low", "medium", "high", "max"}
@@ -65,7 +74,7 @@ class AnthropicProvider:
             uploads=True,
             structured_outputs=True,
             reasoning=True,
-            deferred_delivery=False,
+            deferred_delivery=True,
             conversation=True,
             implicit_caching=True,
         )
@@ -204,13 +213,8 @@ class AnthropicProvider:
 
         return messages
 
-    async def generate(
-        self,
-        request: ProviderRequest,
-    ) -> ProviderResponse:
-        """Generate a response using Anthropic's Messages API."""
-        client = self._get_client()
-
+    def _build_messages_create_kwargs(self, request: ProviderRequest) -> dict[str, Any]:
+        """Build the raw Anthropic Messages API request body."""
         # No Anthropic equivalents or deferred features.
         _ = request.cache_name
         _ = request.previous_response_id
@@ -221,7 +225,6 @@ class AnthropicProvider:
             request.provider_state,
         )
 
-        # Build create kwargs.
         default_max_tokens = _ANTHROPIC_DEFAULT_MAX_TOKENS
         if "claude-3-" in request.model:
             # claude-3-haiku, claude-3-sonnet, claude-3-opus only support 4096
@@ -250,7 +253,6 @@ class AnthropicProvider:
         if request.top_p is not None:
             create_kwargs["top_p"] = request.top_p
 
-        # Tool definitions.
         if request.tools is not None:
             anthropic_tools = self._normalize_tools(request.tools)
             if anthropic_tools:
@@ -262,7 +264,6 @@ class AnthropicProvider:
 
         output_config: dict[str, Any] = {}
 
-        # Structured output via output_config.format.
         if request.response_schema is not None:
             strict_schema = to_strict_schema(request.response_schema)
             output_config["format"] = {
@@ -282,8 +283,6 @@ class AnthropicProvider:
                     "type": "enabled",
                     "budget_tokens": _MANUAL_THINKING_BUDGETS[effort],
                 }
-                # Older models only support interleaved thinking via beta header manually.
-                # Adaptive models do this automatically.
                 if request.tools:
                     create_kwargs["extra_headers"] = {
                         "anthropic-beta": _INTERLEAVED_THINKING_BETA_HEADER
@@ -292,15 +291,199 @@ class AnthropicProvider:
         if output_config:
             create_kwargs["output_config"] = output_config
 
-        # The Files API requires this beta header.
         beta_headers = ["files-api-2025-04-14"]
-        if (
-            "extra_headers" in create_kwargs
-            and "anthropic-beta" in create_kwargs["extra_headers"]
-        ):
-            beta_headers.append(create_kwargs["extra_headers"]["anthropic-beta"])
-
+        extra_headers = create_kwargs.get("extra_headers")
+        if isinstance(extra_headers, dict):
+            existing_beta = extra_headers.get("anthropic-beta")
+            if isinstance(existing_beta, str) and existing_beta:
+                beta_headers.append(existing_beta)
         create_kwargs["extra_headers"] = {"anthropic-beta": ",".join(beta_headers)}
+
+        return create_kwargs
+
+    async def submit_deferred(
+        self,
+        requests: list[ProviderRequest],
+        *,
+        request_ids: list[str],
+    ) -> ProviderDeferredHandle:
+        """Submit deferred work through the Anthropic Message Batches API."""
+        client = self._get_client()
+
+        try:
+            upload_cache: dict[tuple[str, str], ProviderFileAsset] = {}
+            batch_requests: list[dict[str, Any]] = []
+            for request_id, request in zip(request_ids, requests, strict=True):
+                resolved_request = await self._resolve_deferred_request(
+                    request,
+                    upload_cache=upload_cache,
+                )
+                create_kwargs = self._build_messages_create_kwargs(resolved_request)
+                create_kwargs.pop("extra_headers", None)
+                batch_requests.append(
+                    {
+                        "custom_id": request_id,
+                        "params": create_kwargs,
+                    }
+                )
+
+            batch = await client.messages.batches.create(
+                requests=batch_requests,
+                extra_headers={"anthropic-beta": "files-api-2025-04-14"},
+            )
+            return ProviderDeferredHandle(
+                job_id=batch.id,
+                submitted_at=_timestamp_or_none(batch.created_at),
+                provider_state={
+                    "request_ids": list(request_ids),
+                    "owned_file_ids": _owned_deferred_file_ids(upload_cache),
+                    "has_response_schema": _requests_have_response_schema(requests),
+                },
+            )
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="anthropic",
+                phase="batch_submit",
+                allow_network_errors=False,
+                message="Anthropic batch submit failed",
+            ) from e
+
+    async def inspect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> ProviderDeferredSnapshot:
+        """Inspect an Anthropic message batch and normalize status/counts."""
+        client = self._get_client()
+        status: str | None = None
+
+        try:
+            batch = await client.messages.batches.retrieve(handle.job_id)
+            total = _batch_request_count(batch, handle=handle)
+            succeeded = int(getattr(batch.request_counts, "succeeded", 0))
+            failed = int(
+                getattr(batch.request_counts, "errored", 0)
+                + getattr(batch.request_counts, "canceled", 0)
+                + getattr(batch.request_counts, "expired", 0)
+            )
+            pending = int(getattr(batch.request_counts, "processing", 0))
+            status = _normalize_batch_status(
+                batch.processing_status,
+                succeeded=succeeded,
+                errored=int(getattr(batch.request_counts, "errored", 0)),
+                canceled=int(getattr(batch.request_counts, "canceled", 0)),
+                expired=int(getattr(batch.request_counts, "expired", 0)),
+                total=total,
+            )
+            return ProviderDeferredSnapshot(
+                status=status,
+                provider_status=str(batch.processing_status),
+                request_count=total,
+                succeeded=succeeded,
+                failed=failed,
+                pending=pending,
+                submitted_at=_timestamp_or_none(batch.created_at),
+                completed_at=_timestamp_or_none(batch.ended_at),
+                expires_at=_timestamp_or_none(batch.expires_at),
+            )
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="anthropic",
+                phase="batch_inspect",
+                allow_network_errors=True,
+                message="Anthropic batch inspect failed",
+            ) from e
+        finally:
+            if status in {"completed", "partial", "failed", "cancelled", "expired"}:
+                await self._cleanup_deferred_owned_files(handle)
+
+    async def collect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> list[ProviderDeferredItem]:
+        """Collect Anthropic batch results into deferred items."""
+        client = self._get_client()
+
+        try:
+            batch = await client.messages.batches.retrieve(handle.job_id)
+            items: list[ProviderDeferredItem] = []
+            if batch.results_url is not None:
+                async for row in client.messages.batches.results(handle.job_id):
+                    items.append(
+                        _parse_batch_result(
+                            row,
+                            parse_structured_json=_provider_handle_has_response_schema(
+                                handle
+                            ),
+                        )
+                    )
+
+            synthesized = _synthesize_terminal_batch_items(
+                batch,
+                handle=handle,
+                existing_request_ids={item.request_id for item in items},
+            )
+            if synthesized is not None:
+                items.extend(synthesized)
+
+            await self._cleanup_deferred_owned_files(handle)
+            return items
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="anthropic",
+                phase="batch_collect",
+                allow_network_errors=True,
+                message="Anthropic batch collect failed",
+            ) from e
+
+    async def cancel_deferred(self, handle: ProviderDeferredHandle) -> None:
+        """Cancel an Anthropic message batch."""
+        client = self._get_client()
+
+        try:
+            batch = await client.messages.batches.cancel(handle.job_id)
+            status = _normalize_batch_status(
+                batch.processing_status,
+                succeeded=int(getattr(batch.request_counts, "succeeded", 0)),
+                errored=int(getattr(batch.request_counts, "errored", 0)),
+                canceled=int(getattr(batch.request_counts, "canceled", 0)),
+                expired=int(getattr(batch.request_counts, "expired", 0)),
+                total=_batch_request_count(batch, handle=handle),
+            )
+            if status in {"completed", "partial", "failed", "cancelled", "expired"}:
+                await self._cleanup_deferred_owned_files(handle)
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="anthropic",
+                phase="batch_cancel",
+                allow_network_errors=True,
+                message="Anthropic batch cancel failed",
+            ) from e
+
+    async def generate(
+        self,
+        request: ProviderRequest,
+    ) -> ProviderResponse:
+        """Generate a response using Anthropic's Messages API."""
+        client = self._get_client()
+        create_kwargs = self._build_messages_create_kwargs(request)
 
         try:
             response = await client.messages.create(**create_kwargs)
@@ -318,6 +501,51 @@ class AnthropicProvider:
                 message="Anthropic generate failed",
             ) from e
 
+    async def _resolve_deferred_request(
+        self,
+        request: ProviderRequest,
+        *,
+        upload_cache: dict[tuple[str, str], ProviderFileAsset],
+    ) -> ProviderRequest:
+        """Resolve local file parts into provider assets for deferred submission."""
+        resolved_parts: list[Any] = []
+        for part in request.parts:
+            if (
+                isinstance(part, dict)
+                and isinstance(part.get("file_path"), str)
+                and isinstance(part.get("mime_type"), str)
+            ):
+                file_path = part["file_path"]
+                mime_type = part["mime_type"]
+                cache_key = (file_path, mime_type)
+                asset = upload_cache.get(cache_key)
+                if asset is None:
+                    from pathlib import Path
+
+                    asset = await self.upload_file(Path(file_path), mime_type)
+                    upload_cache[cache_key] = asset
+                resolved_parts.append(asset)
+            else:
+                resolved_parts.append(part)
+
+        return ProviderRequest(
+            model=request.model,
+            parts=resolved_parts,
+            system_instruction=request.system_instruction,
+            cache_name=request.cache_name,
+            response_schema=request.response_schema,
+            temperature=request.temperature,
+            top_p=request.top_p,
+            tools=request.tools,
+            tool_choice=request.tool_choice,
+            reasoning_effort=request.reasoning_effort,
+            history=request.history,
+            previous_response_id=request.previous_response_id,
+            provider_state=request.provider_state,
+            max_tokens=request.max_tokens,
+            implicit_caching=request.implicit_caching,
+        )
+
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
         """Upload a local file using the Anthropic Files API."""
         client = self._get_client()
@@ -330,7 +558,10 @@ class AnthropicProvider:
                 )
 
             return ProviderFileAsset(
-                file_id=result.id, provider="anthropic", mime_type=mime_type
+                file_id=result.id,
+                provider="anthropic",
+                mime_type=mime_type,
+                file_name=result.id,
             )
         except asyncio.CancelledError:
             raise
@@ -358,6 +589,28 @@ class AnthropicProvider:
         _ = model, parts, system_instruction, tools, ttl_seconds
         raise APIError("Anthropic provider does not support context caching")
 
+    async def delete_file(self, file_id: str) -> None:
+        """Delete a previously uploaded file from Anthropic storage."""
+        client = self._get_client()
+        await client.beta.files.delete(
+            file_id,
+            extra_headers={"anthropic-beta": "files-api-2025-04-14"},
+        )
+
+    async def _cleanup_deferred_owned_files(
+        self, handle: ProviderDeferredHandle
+    ) -> None:
+        """Best-effort cleanup for provider-owned deferred input files."""
+        for file_id in _provider_handle_owned_file_ids(handle):
+            try:
+                await self.delete_file(file_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug(
+                    "Anthropic deferred cleanup failed for file_id=%s", file_id
+                )
+
     async def aclose(self) -> None:
         """Close underlying async client resources."""
         client = self._client
@@ -368,7 +621,10 @@ class AnthropicProvider:
 
 
 def _parse_response(
-    response: Any, *, response_schema: dict[str, Any] | None
+    response: Any,
+    *,
+    response_schema: dict[str, Any] | None,
+    parse_structured_json: bool = False,
 ) -> ProviderResponse:
     """Parse an Anthropic Message response into ProviderResponse."""
     text_parts: list[str] = []
@@ -429,7 +685,7 @@ def _parse_response(
 
     # Structured output extraction.
     structured: Any = None
-    if response_schema is not None and text:
+    if (response_schema is not None or parse_structured_json) and text:
         try:
             structured = json.loads(text)
         except Exception:
@@ -449,6 +705,266 @@ def _parse_response(
             else None
         ),
     )
+
+
+def _timestamp_or_none(value: Any) -> float | None:
+    """Convert datetimes or unix timestamps to floats when present."""
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _provider_handle_request_ids(handle: ProviderDeferredHandle) -> list[str] | None:
+    """Return the submitted Pollux request ids stored in the provider handle."""
+    provider_state = handle.provider_state
+    if not isinstance(provider_state, dict):
+        return None
+    raw_ids = provider_state.get("request_ids")
+    if not isinstance(raw_ids, list):
+        return None
+
+    request_ids: list[str] = []
+    for value in raw_ids:
+        if not isinstance(value, str) or not value:
+            return None
+        request_ids.append(value)
+    return request_ids
+
+
+def _provider_handle_owned_file_ids(handle: ProviderDeferredHandle) -> list[str]:
+    """Return provider-owned file ids stored on the deferred handle."""
+    provider_state = handle.provider_state
+    if not isinstance(provider_state, dict):
+        return []
+    raw_ids = provider_state.get("owned_file_ids")
+    if not isinstance(raw_ids, list):
+        return []
+    return [value for value in raw_ids if isinstance(value, str) and value]
+
+
+def _provider_handle_has_response_schema(handle: ProviderDeferredHandle) -> bool:
+    """Return True when structured outputs were enabled at submission time."""
+    provider_state = handle.provider_state
+    if not isinstance(provider_state, dict):
+        return False
+    return bool(provider_state.get("has_response_schema"))
+
+
+def _owned_deferred_file_ids(
+    upload_cache: dict[tuple[str, str], ProviderFileAsset],
+) -> list[str]:
+    """Return provider-owned remote file ids created during deferred submission."""
+    file_ids = {
+        asset.file_name or asset.file_id
+        for asset in upload_cache.values()
+        if asset.file_id
+    }
+    return sorted(file_ids)
+
+
+def _requests_have_response_schema(requests: list[ProviderRequest]) -> bool:
+    """Persist whether structured outputs were enabled at submission time."""
+    return any(request.response_schema is not None for request in requests)
+
+
+def _provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
+    """Convert ProviderResponse into the normalized deferred response shape."""
+    payload: dict[str, Any] = {"text": response.text, "usage": response.usage}
+    if response.reasoning is not None:
+        payload["reasoning"] = response.reasoning
+    if response.structured is not None:
+        payload["structured"] = response.structured
+    if response.tool_calls is not None:
+        payload["tool_calls"] = [
+            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+            for tc in response.tool_calls
+        ]
+    if response.response_id is not None:
+        payload["response_id"] = response.response_id
+    if response.finish_reason is not None:
+        payload["finish_reason"] = response.finish_reason
+    return payload
+
+
+def _batch_request_count(batch: Any, *, handle: ProviderDeferredHandle) -> int:
+    """Return the total request count for an Anthropic message batch."""
+    request_counts = getattr(batch, "request_counts", None)
+    if request_counts is not None:
+        return int(
+            getattr(request_counts, "succeeded", 0)
+            + getattr(request_counts, "errored", 0)
+            + getattr(request_counts, "canceled", 0)
+            + getattr(request_counts, "expired", 0)
+            + getattr(request_counts, "processing", 0)
+        )
+    request_ids = _provider_handle_request_ids(handle)
+    return len(request_ids) if request_ids is not None else 0
+
+
+def _normalize_batch_status(
+    processing_status: str,
+    *,
+    succeeded: int,
+    errored: int,
+    canceled: int,
+    expired: int,
+    total: int,
+) -> str:
+    """Map Anthropic message batch state into Pollux deferred statuses."""
+    if processing_status == "in_progress":
+        return "running"
+    if processing_status == "canceling":
+        return "cancelling"
+
+    if succeeded == total and total > 0:
+        return "completed"
+    if succeeded > 0:
+        return "partial"
+    if errored == total and total > 0:
+        return "failed"
+    if canceled == total and total > 0:
+        return "cancelled"
+    if expired == total and total > 0:
+        return "expired"
+    if errored > 0 and canceled == 0 and expired == 0:
+        return "failed"
+    if canceled > 0 and errored == 0 and expired == 0:
+        return "cancelled"
+    if expired > 0 and errored == 0 and canceled == 0:
+        return "expired"
+    if errored > 0 or canceled > 0 or expired > 0:
+        return "partial"
+    return "failed"
+
+
+def _parse_batch_result(
+    row: Any,
+    *,
+    parse_structured_json: bool,
+) -> ProviderDeferredItem:
+    """Parse one Anthropic batch result row into a deferred item."""
+    request_id = str(row.custom_id)
+    result = row.result
+    result_type = str(getattr(result, "type", ""))
+
+    if result_type == "succeeded":
+        parsed = _parse_response(
+            result.message,
+            response_schema=None,
+            parse_structured_json=parse_structured_json,
+        )
+        return ProviderDeferredItem(
+            request_id=request_id,
+            status="succeeded",
+            response=_provider_response_to_dict(parsed),
+            provider_status="succeeded",
+            finish_reason=parsed.finish_reason,
+        )
+
+    if result_type == "errored":
+        error = getattr(result, "error", None)
+        return ProviderDeferredItem(
+            request_id=request_id,
+            status="failed",
+            error=_anthropic_error_message(error),
+            provider_status=_anthropic_error_type(error),
+        )
+
+    if result_type == "canceled":
+        return ProviderDeferredItem(
+            request_id=request_id,
+            status="cancelled",
+            provider_status="canceled",
+        )
+
+    if result_type == "expired":
+        return ProviderDeferredItem(
+            request_id=request_id,
+            status="expired",
+            provider_status="expired",
+        )
+
+    raise APIError(f"Unsupported Anthropic batch result type: {result_type}")
+
+
+def _anthropic_error_message(error: Any) -> str | None:
+    """Return a readable message for Anthropic error payloads."""
+    message = getattr(error, "message", None)
+    return message if isinstance(message, str) and message else None
+
+
+def _anthropic_error_type(error: Any) -> str | None:
+    """Return the Anthropic error type when present."""
+    error_type = getattr(error, "type", None)
+    return error_type if isinstance(error_type, str) and error_type else None
+
+
+def _batch_level_item_status(batch: Any) -> DeferredItemStatus | None:
+    """Return a synthesized item status for missing terminal Anthropic rows."""
+    if str(getattr(batch, "processing_status", "")) != "ended":
+        return None
+
+    request_counts = getattr(batch, "request_counts", None)
+    if request_counts is None:
+        return None
+
+    succeeded = int(getattr(request_counts, "succeeded", 0))
+    errored = int(getattr(request_counts, "errored", 0))
+    canceled = int(getattr(request_counts, "canceled", 0))
+    expired = int(getattr(request_counts, "expired", 0))
+
+    if succeeded > 0:
+        if errored > 0 and canceled == 0 and expired == 0:
+            return "failed"
+        if canceled > 0 and errored == 0 and expired == 0:
+            return "cancelled"
+        if expired > 0 and errored == 0 and canceled == 0:
+            return "expired"
+        return None
+    if errored > 0 and canceled == 0 and expired == 0:
+        return "failed"
+    if canceled > 0 and errored == 0 and expired == 0:
+        return "cancelled"
+    if expired > 0 and errored == 0 and canceled == 0:
+        return "expired"
+    if errored > 0 or canceled > 0 or expired > 0:
+        return "failed"
+    return None
+
+
+def _synthesize_terminal_batch_items(
+    batch: Any,
+    *,
+    handle: ProviderDeferredHandle,
+    existing_request_ids: set[str],
+) -> list[ProviderDeferredItem] | None:
+    """Expand missing terminal Anthropic rows into per-request diagnostics."""
+    item_status = _batch_level_item_status(batch)
+    if item_status is None:
+        return None
+
+    request_ids = _provider_handle_request_ids(handle)
+    if request_ids is None:
+        return None
+    missing_request_ids = [
+        request_id
+        for request_id in request_ids
+        if request_id not in existing_request_ids
+    ]
+    if not missing_request_ids:
+        return None
+
+    provider_status = str(getattr(batch, "processing_status", "ended"))
+    return [
+        ProviderDeferredItem(
+            request_id=request_id,
+            status=item_status,
+            provider_status=provider_status,
+        )
+        for request_id in missing_request_ids
+    ]
 
 
 def _normalize_stop_reason(stop_reason: Any) -> str | None:
@@ -636,6 +1152,6 @@ def _normalize_input_part(part: Any) -> dict[str, Any] | None:
         }
 
     raise APIError(
-        f"Unsupported mime type for Anthropic provider: {mime_type}",
+        f"Unsupported mime type for Anthropic provider: {dict_mime_type}",
         hint="Anthropic supports images and PDFs via URL.",
     )

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -3,14 +3,25 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from datetime import datetime
 import json
+import logging
+from pathlib import Path
+import tempfile
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 import uuid
 
 from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import wrap_provider_error
-from pollux.providers.base import ProviderCapabilities
+from pollux.providers.base import (
+    DeferredItemStatus,
+    ProviderCapabilities,
+    ProviderDeferredHandle,
+    ProviderDeferredItem,
+    ProviderDeferredSnapshot,
+)
 from pollux.providers.models import (
     Message,
     ProviderFileAsset,
@@ -19,8 +30,9 @@ from pollux.providers.models import (
     ToolCall,
 )
 
-if TYPE_CHECKING:
-    from pathlib import Path
+logger = logging.getLogger(__name__)
+
+_GEMINI_BATCH_INLINE_LIMIT_BYTES = 20_000_000
 
 
 class GeminiProvider:
@@ -56,7 +68,7 @@ class GeminiProvider:
             uploads=True,
             structured_outputs=True,
             reasoning=True,
-            deferred_delivery=False,
+            deferred_delivery=True,
             conversation=True,
         )
 
@@ -279,6 +291,213 @@ class GeminiProvider:
                 input_contents.append(types.Content(role="user", parts=user_parts_list))
         return input_contents
 
+    async def submit_deferred(
+        self,
+        requests: list[ProviderRequest],
+        *,
+        request_ids: list[str],
+    ) -> ProviderDeferredHandle:
+        """Submit deferred work through the Gemini Batch API."""
+        client = self._get_client()
+        from google.genai import types
+
+        temp_batch_path: Path | None = None
+        try:
+            upload_cache: dict[tuple[str, str], ProviderFileAsset] = {}
+            inlined_requests: list[Any] | None = []
+            payload_bytes = 0
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                suffix=".jsonl",
+                prefix="pollux-gemini-batch-",
+                delete=False,
+            ) as temp_batch:
+                temp_batch_path = Path(temp_batch.name)
+                for request_id, request in zip(request_ids, requests, strict=True):
+                    resolved_request = await self._resolve_deferred_request(
+                        request,
+                        upload_cache=upload_cache,
+                    )
+                    inlined_request = types.InlinedRequest(
+                        contents=self._build_contents(
+                            resolved_request.parts,
+                            resolved_request.history,
+                        ),
+                        config=types.GenerateContentConfig(
+                            **self._build_config_kwargs(resolved_request)
+                        ),
+                        metadata={"pollux_request_id": request_id},
+                    )
+                    if inlined_requests is not None:
+                        inlined_requests.append(inlined_request)
+
+                    batch_line = self._serialize_deferred_request(inlined_request)
+                    encoded_line = (
+                        json.dumps(batch_line, separators=(",", ":")) + "\n"
+                    ).encode("utf-8")
+                    temp_batch.write(encoded_line)
+                    payload_bytes += len(encoded_line)
+                    if payload_bytes > _GEMINI_BATCH_INLINE_LIMIT_BYTES:
+                        inlined_requests = None
+
+            owned_file_ids = _owned_deferred_file_ids(upload_cache)
+            if inlined_requests is not None:
+                batch = await client.aio.batches.create(
+                    model=requests[0].model,
+                    src=inlined_requests,
+                )
+            else:
+                batch_input_file = await self._upload_deferred_batch_input_file(
+                    temp_batch_path
+                )
+                owned_file_ids.append(batch_input_file)
+                batch = await client.aio.batches.create(
+                    model=requests[0].model,
+                    src=types.BatchJobSource(file_name=batch_input_file),
+                )
+            return ProviderDeferredHandle(
+                job_id=str(batch.name),
+                submitted_at=_timestamp_or_none(batch.create_time),
+                provider_state={
+                    "request_ids": list(request_ids),
+                    "owned_file_ids": sorted(set(owned_file_ids)),
+                    "has_response_schema": _requests_have_response_schema(requests),
+                },
+            )
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="gemini",
+                phase="batch_submit",
+                allow_network_errors=False,
+                message="Gemini batch submit failed",
+            ) from e
+        finally:
+            if temp_batch_path is not None:
+                with contextlib.suppress(OSError):
+                    temp_batch_path.unlink()
+
+    async def inspect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> ProviderDeferredSnapshot:
+        """Inspect a Gemini batch and normalize status/counts."""
+        client = self._get_client()
+        status: str | None = None
+
+        try:
+            batch = await client.aio.batches.get(name=handle.job_id)
+            request_ids = _provider_handle_request_ids(handle)
+            total = len(request_ids) if request_ids is not None else 0
+            succeeded, failed, pending = _batch_counts(batch, total=total)
+            status = _normalize_batch_status(
+                _job_state_name(batch.state),
+                succeeded=succeeded,
+                failed=failed,
+            )
+            return ProviderDeferredSnapshot(
+                status=status,
+                provider_status=_job_state_name(batch.state),
+                request_count=total or succeeded + failed + pending,
+                succeeded=succeeded,
+                failed=failed,
+                pending=pending,
+                submitted_at=_timestamp_or_none(batch.create_time),
+                completed_at=_timestamp_or_none(batch.end_time),
+                expires_at=None,
+            )
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="gemini",
+                phase="batch_inspect",
+                allow_network_errors=True,
+                message="Gemini batch inspect failed",
+            ) from e
+        finally:
+            if status in {"completed", "partial", "failed", "cancelled", "expired"}:
+                await self._cleanup_deferred_owned_files(handle)
+
+    async def collect_deferred(
+        self, handle: ProviderDeferredHandle
+    ) -> list[ProviderDeferredItem]:
+        """Collect Gemini batch results into deferred items."""
+        client = self._get_client()
+
+        try:
+            batch = await client.aio.batches.get(name=handle.job_id)
+            request_ids = _provider_handle_request_ids(handle) or []
+            items: list[ProviderDeferredItem] = []
+            inlined_responses = _batch_inlined_responses(batch)
+            if inlined_responses is not None:
+                items.extend(
+                    self._parse_inlined_batch_responses(
+                        inlined_responses,
+                        request_ids=request_ids,
+                    )
+                )
+            else:
+                output_file_name = _batch_output_file_name(batch)
+                if output_file_name is None:
+                    output_file_name = ""
+                if output_file_name:
+                    content = await client.aio.files.download(file=output_file_name)
+                    items.extend(
+                        self._parse_batch_output_file(
+                            content,
+                            request_ids=request_ids,
+                        )
+                    )
+
+            synthesized = self._synthesize_terminal_batch_items(
+                batch,
+                handle=handle,
+                existing_request_ids={item.request_id for item in items},
+            )
+            if synthesized is not None:
+                items.extend(synthesized)
+
+            await self._cleanup_deferred_owned_files(handle)
+            return items
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="gemini",
+                phase="batch_collect",
+                allow_network_errors=True,
+                message="Gemini batch collect failed",
+            ) from e
+
+    async def cancel_deferred(self, handle: ProviderDeferredHandle) -> None:
+        """Cancel a Gemini batch."""
+        client = self._get_client()
+
+        try:
+            await client.aio.batches.cancel(name=handle.job_id)
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="gemini",
+                phase="batch_cancel",
+                allow_network_errors=True,
+                message="Gemini batch cancel failed",
+            ) from e
+
     async def generate(
         self,
         request: ProviderRequest,
@@ -346,6 +565,94 @@ class GeminiProvider:
             f"{timeout_seconds}s (stuck in {last_state})"
         )
 
+    async def _resolve_deferred_request(
+        self,
+        request: ProviderRequest,
+        *,
+        upload_cache: dict[tuple[str, str], ProviderFileAsset],
+    ) -> ProviderRequest:
+        """Resolve local file parts into provider assets for deferred submission."""
+        resolved_parts: list[Any] = []
+        for part in request.parts:
+            if (
+                isinstance(part, dict)
+                and isinstance(part.get("file_path"), str)
+                and isinstance(part.get("mime_type"), str)
+            ):
+                file_path = part["file_path"]
+                mime_type = part["mime_type"]
+                cache_key = (file_path, mime_type)
+                asset = upload_cache.get(cache_key)
+                if asset is None:
+                    from pathlib import Path
+
+                    asset = await self.upload_file(Path(file_path), mime_type)
+                    upload_cache[cache_key] = asset
+                resolved_parts.append(asset)
+            else:
+                resolved_parts.append(part)
+
+        return ProviderRequest(
+            model=request.model,
+            parts=resolved_parts,
+            system_instruction=request.system_instruction,
+            cache_name=request.cache_name,
+            response_schema=request.response_schema,
+            temperature=request.temperature,
+            top_p=request.top_p,
+            tools=request.tools,
+            tool_choice=request.tool_choice,
+            reasoning_effort=request.reasoning_effort,
+            history=request.history,
+            previous_response_id=request.previous_response_id,
+            provider_state=request.provider_state,
+            max_tokens=request.max_tokens,
+            implicit_caching=request.implicit_caching,
+        )
+
+    async def _upload_deferred_batch_input_file(self, path: Path) -> str:
+        """Upload a JSONL batch input file and return its file resource name."""
+        client = self._get_client()
+
+        try:
+            with path.open("rb") as upload:
+                result = await client.aio.files.upload(
+                    file=upload,
+                    config={"mime_type": "application/jsonl"},
+                )
+
+            file_name = getattr(result, "name", None)
+            if not isinstance(file_name, str) or not file_name:
+                raise APIError("Gemini batch input upload did not return a file name")
+
+            state = self._file_state_name(result)
+            if state == "FAILED":
+                raise APIError(
+                    "Batch input file processing failed: "
+                    f"{self._file_error_message(result)}"
+                )
+            if state != "ACTIVE":
+                result = await self._wait_for_file_active(file_name)
+
+            active_file_name = getattr(result, "name", None)
+            if not isinstance(active_file_name, str) or not active_file_name:
+                raise APIError(
+                    "Gemini batch input upload did not return an active file name"
+                )
+            return active_file_name
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="gemini",
+                phase="batch_upload",
+                allow_network_errors=False,
+                message="Gemini batch input upload failed",
+            ) from e
+
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
         """Upload a file to Gemini."""
         client = self._get_client()
@@ -372,7 +679,10 @@ class GeminiProvider:
                 raise APIError("Gemini upload did not return a file uri")
 
             return ProviderFileAsset(
-                file_id=file_uri, provider="gemini", mime_type=mime_type
+                file_id=file_uri,
+                provider="gemini",
+                mime_type=mime_type,
+                file_name=file_name,
             )
         except asyncio.CancelledError:
             raise
@@ -457,19 +767,215 @@ class GeminiProvider:
                 message="Gemini cache creation failed",
             ) from e
 
+    async def delete_file(self, file_id: str) -> None:
+        """Delete a previously uploaded file from Gemini storage."""
+        client = self._get_client()
+        await client.aio.files.delete(name=file_id)
+
+    async def _cleanup_deferred_owned_files(
+        self, handle: ProviderDeferredHandle
+    ) -> None:
+        """Best-effort cleanup for provider-owned deferred input files."""
+        for file_id in _provider_handle_owned_file_ids(handle):
+            try:
+                await self.delete_file(file_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("Gemini deferred cleanup failed for file_id=%s", file_id)
+
+    def _parse_inlined_batch_responses(
+        self,
+        responses: list[Any],
+        *,
+        request_ids: list[str],
+    ) -> list[ProviderDeferredItem]:
+        """Parse Gemini inlined batch responses into deferred items."""
+        items: list[ProviderDeferredItem] = []
+        for index, entry in enumerate(responses):
+            request_id = _inlined_response_request_id(entry)
+            if request_id is None and index < len(request_ids):
+                request_id = request_ids[index]
+            if request_id is None:
+                request_id = f"pollux-{index:06d}"
+
+            error = _field(entry, "error")
+            raw_response = _field(entry, "response")
+            if raw_response is None:
+                items.append(
+                    ProviderDeferredItem(
+                        request_id=request_id,
+                        status="failed",
+                        error=_job_error_message(error),
+                        provider_status=_job_error_code(error),
+                    )
+                )
+                continue
+
+            parsed = self._parse_response(raw_response)
+            items.append(
+                ProviderDeferredItem(
+                    request_id=request_id,
+                    status="succeeded",
+                    response=_provider_response_to_dict(parsed),
+                    provider_status="succeeded",
+                    finish_reason=parsed.finish_reason,
+                )
+            )
+        return items
+
+    def _parse_batch_output_file(
+        self,
+        content: bytes,
+        *,
+        request_ids: list[str],
+    ) -> list[ProviderDeferredItem]:
+        """Parse a Gemini JSONL output file into deferred items."""
+        items: list[ProviderDeferredItem] = []
+        for index, line in enumerate(content.decode("utf-8").splitlines()):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            request_id = _batch_file_request_id(
+                payload,
+                index=index,
+                request_ids=request_ids,
+            )
+            response = _field(payload, "response")
+            error = _field(payload, "error")
+            if response is None and error is None and isinstance(payload, dict):
+                response = payload
+
+            if not isinstance(response, dict):
+                items.append(
+                    ProviderDeferredItem(
+                        request_id=request_id,
+                        status="failed",
+                        error=_job_error_message(error),
+                        provider_status=_job_error_code(error),
+                    )
+                )
+                continue
+
+            parsed = self._parse_response(response)
+            items.append(
+                ProviderDeferredItem(
+                    request_id=request_id,
+                    status="succeeded",
+                    response=_provider_response_to_dict(parsed),
+                    provider_status="succeeded",
+                    finish_reason=parsed.finish_reason,
+                )
+            )
+        return items
+
+    @staticmethod
+    def _serialize_deferred_request(request: Any) -> dict[str, Any]:
+        """Serialize one Gemini deferred request into the JSONL file shape."""
+        normalized_request = request.model_copy(
+            update={
+                "contents": GeminiProvider._normalize_batch_request_contents(
+                    request.contents
+                )
+            }
+        )
+        payload = normalized_request.model_dump(exclude_none=True, by_alias=True)
+        request_payload: dict[str, Any] = {}
+
+        model = payload.pop("model", None)
+        if model is not None:
+            request_payload["model"] = model
+
+        contents = payload.pop("contents", None)
+        if contents is not None:
+            request_payload["contents"] = contents
+
+        config = payload.pop("config", None)
+        if config is not None:
+            request_payload["generationConfig"] = config
+
+        line: dict[str, Any] = {"request": request_payload}
+        metadata = payload.pop("metadata", None)
+        if metadata is not None:
+            line["metadata"] = metadata
+        return line
+
+    @staticmethod
+    def _normalize_batch_request_contents(contents: Any) -> Any:
+        """Normalize inline-friendly contents into explicit Content objects."""
+        from google.genai import types
+
+        if contents is None:
+            return None
+        if _is_content_list(contents):
+            return contents
+        if isinstance(contents, list):
+            return [
+                types.Content(
+                    role="user",
+                    parts=[
+                        types.Part.from_text(text=item)
+                        if isinstance(item, str)
+                        else item
+                        for item in contents
+                    ],
+                )
+            ]
+        return [
+            types.Content(
+                role="user",
+                parts=[
+                    types.Part.from_text(text=contents)
+                    if isinstance(contents, str)
+                    else contents
+                ],
+            )
+        ]
+
+    def _synthesize_terminal_batch_items(
+        self,
+        batch: Any,
+        *,
+        handle: ProviderDeferredHandle,
+        existing_request_ids: set[str],
+    ) -> list[ProviderDeferredItem] | None:
+        """Expand missing terminal batch rows into per-request diagnostics."""
+        item_status = _batch_level_item_status(_job_state_name(batch.state))
+        if item_status is None:
+            return None
+
+        request_ids = _provider_handle_request_ids(handle)
+        if request_ids is None:
+            return None
+        missing_request_ids = [
+            request_id
+            for request_id in request_ids
+            if request_id not in existing_request_ids
+        ]
+        if not missing_request_ids:
+            return None
+
+        error_message = _job_error_message(getattr(batch, "error", None))
+        provider_status = _job_error_code(getattr(batch, "error", None))
+        if provider_status is None:
+            provider_status = _job_state_name(batch.state)
+
+        return [
+            ProviderDeferredItem(
+                request_id=request_id,
+                status=item_status,
+                error=error_message,
+                provider_status=provider_status,
+            )
+            for request_id in missing_request_ids
+        ]
+
     def _parse_response(self, response: Any) -> ProviderResponse:
         """Parse Gemini response into a standard dict."""
-        text = ""
+        text = _extract_response_text(response)
         structured: Any = None
         try:
-            if hasattr(response, "text"):
-                text = response.text or ""
-            # Fallbacks similar to before, but new SDK usually gives .text
-            # if candidates exist and have text.
-        except Exception:
-            text = ""
-        try:
-            structured = getattr(response, "parsed", None)
+            structured = _field(response, "parsed")
             if structured is None and text:
                 structured = json.loads(text)
         except Exception:
@@ -477,33 +983,40 @@ class GeminiProvider:
 
         usage = {}
         try:
-            if hasattr(response, "usage_metadata"):
-                um = response.usage_metadata
+            usage_metadata = _field(response, "usage_metadata")
+            if usage_metadata is not None:
                 # Gemini SDK attrs → provider-agnostic keys
                 usage = {
-                    "input_tokens": getattr(um, "prompt_token_count", 0),
-                    "output_tokens": getattr(um, "candidates_token_count", 0),
-                    "total_tokens": getattr(um, "total_token_count", 0),
+                    "input_tokens": int(
+                        _field(usage_metadata, "prompt_token_count", 0) or 0
+                    ),
+                    "output_tokens": int(
+                        _field(usage_metadata, "candidates_token_count", 0) or 0
+                    ),
+                    "total_tokens": int(
+                        _field(usage_metadata, "total_token_count", 0) or 0
+                    ),
                 }
-                thoughts_toks = getattr(um, "thoughts_token_count", None)
+                thoughts_toks = _field(usage_metadata, "thoughts_token_count")
                 if thoughts_toks is not None:
-                    usage["reasoning_tokens"] = thoughts_toks
+                    usage["reasoning_tokens"] = int(thoughts_toks)
         except Exception:
             usage = {}
 
         tool_calls: list[ToolCall] = []
-        if hasattr(response, "function_calls") and response.function_calls:
-            for fc in response.function_calls:
-                call_id = fc.id or f"call_{uuid.uuid4().hex[:8]}"
+        function_calls = _field(response, "function_calls", []) or []
+        if isinstance(function_calls, list):
+            for function_call in function_calls:
+                call_id = _field(function_call, "id") or f"call_{uuid.uuid4().hex[:8]}"
 
                 # Gemini args are typed as Optional[dict[str, Any]].
                 # We default to an empty dictionary to ensure valid JSON output.
-                args_str = json.dumps(fc.args or {})
+                args_str = json.dumps(_field(function_call, "args") or {})
 
                 tool_calls.append(
                     ToolCall(
                         id=str(call_id),
-                        name=str(fc.name),
+                        name=str(_field(function_call, "name", "")),
                         arguments=args_str,
                     )
                 )
@@ -511,18 +1024,21 @@ class GeminiProvider:
         finish_reason: str | None = None
         reasoning_parts: list[str] = []
         try:
-            if hasattr(response, "candidates") and response.candidates:
-                candidate = response.candidates[0]
+            candidates = _field(response, "candidates", []) or []
+            if isinstance(candidates, list) and candidates:
+                candidate = candidates[0]
                 finish_reason = _normalize_finish_reason(
-                    getattr(candidate, "finish_reason", None)
+                    _field(candidate, "finish_reason")
                 )
-                content = candidate.content
-                if hasattr(content, "parts"):
-                    for part in content.parts:
-                        if getattr(part, "thought", False) and getattr(
-                            part, "text", None
+                content = _field(candidate, "content")
+                parts = _field(content, "parts", []) if content is not None else []
+                if isinstance(parts, list):
+                    for part in parts:
+                        part_text = _field(part, "text")
+                        if _field(part, "thought", default=False) and isinstance(
+                            part_text, str
                         ):
-                            reasoning_parts.append(part.text)
+                            reasoning_parts.append(part_text)
         except Exception:
             reasoning_parts.clear()
 
@@ -535,6 +1051,269 @@ class GeminiProvider:
             response_id=None,
             finish_reason=finish_reason,
         )
+
+
+def _field(obj: Any, key: str, default: Any = None) -> Any:
+    """Read a field from either an SDK object or a raw JSON dict."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _extract_response_text(response: Any) -> str:
+    """Extract text from Gemini responses and raw batch JSON."""
+    text = _field(response, "text")
+    if isinstance(text, str) and text:
+        return text
+
+    parts: list[str] = []
+    candidates = _field(response, "candidates", []) or []
+    if not isinstance(candidates, list):
+        return ""
+    for candidate in candidates:
+        content = _field(candidate, "content")
+        candidate_parts = _field(content, "parts", []) if content is not None else []
+        if not isinstance(candidate_parts, list):
+            continue
+        for part in candidate_parts:
+            part_text = _field(part, "text")
+            if (
+                isinstance(part_text, str)
+                and part_text
+                and not _field(part, "thought", default=False)
+            ):
+                parts.append(part_text)
+    return "".join(parts)
+
+
+def _is_content_list(value: Any) -> bool:
+    """Return True when the payload is already a Gemini content sequence."""
+    if not isinstance(value, list) or not value:
+        return False
+    return all(_is_content_like(item) for item in value)
+
+
+def _is_content_like(value: Any) -> bool:
+    """Best-effort detection for Gemini Content-like objects."""
+    if isinstance(value, dict):
+        return "parts" in value and "role" in value
+    return hasattr(value, "parts") and hasattr(value, "role")
+
+
+def _timestamp_or_none(value: Any) -> float | None:
+    """Convert datetimes or unix timestamps to floats when present."""
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _provider_handle_request_ids(handle: ProviderDeferredHandle) -> list[str] | None:
+    """Return the submitted Pollux request ids stored in the provider handle."""
+    provider_state = handle.provider_state
+    if not isinstance(provider_state, dict):
+        return None
+    raw_ids = provider_state.get("request_ids")
+    if not isinstance(raw_ids, list):
+        return None
+
+    request_ids: list[str] = []
+    for value in raw_ids:
+        if not isinstance(value, str) or not value:
+            return None
+        request_ids.append(value)
+    return request_ids
+
+
+def _provider_handle_owned_file_ids(handle: ProviderDeferredHandle) -> list[str]:
+    """Return provider-owned file ids stored on the deferred handle."""
+    provider_state = handle.provider_state
+    if not isinstance(provider_state, dict):
+        return []
+    raw_ids = provider_state.get("owned_file_ids")
+    if not isinstance(raw_ids, list):
+        return []
+    return [value for value in raw_ids if isinstance(value, str) and value]
+
+
+def _owned_deferred_file_ids(
+    upload_cache: dict[tuple[str, str], ProviderFileAsset],
+) -> list[str]:
+    """Return provider-owned remote file ids created during deferred submission."""
+    file_ids = {
+        asset.file_name or asset.file_id
+        for asset in upload_cache.values()
+        if asset.file_id
+    }
+    return sorted(file_ids)
+
+
+def _requests_have_response_schema(requests: list[ProviderRequest]) -> bool:
+    """Persist whether structured outputs were enabled at submission time."""
+    return any(request.response_schema is not None for request in requests)
+
+
+def _job_state_name(state: Any) -> str:
+    """Return a stable Gemini job state string."""
+    value = getattr(state, "name", None) or getattr(state, "value", None) or state
+    if isinstance(value, str) and value:
+        return value.upper()
+    return "JOB_STATE_UNSPECIFIED"
+
+
+def _batch_inlined_responses(batch: Any) -> list[Any] | None:
+    """Return inlined batch responses when present."""
+    dest = _field(batch, "dest")
+    responses = _field(dest, "inlined_responses") if dest is not None else None
+    return responses if isinstance(responses, list) else None
+
+
+def _batch_output_file_name(batch: Any) -> str | None:
+    """Return the batch output file resource name when present."""
+    dest = _field(batch, "dest")
+    file_name = _field(dest, "file_name") if dest is not None else None
+    return file_name if isinstance(file_name, str) and file_name else None
+
+
+def _batch_counts(batch: Any, *, total: int) -> tuple[int, int, int]:
+    """Return normalized succeeded/failed/pending counts for a Gemini batch."""
+    responses = _batch_inlined_responses(batch)
+    if responses is not None:
+        succeeded = sum(
+            1 for response in responses if _field(response, "response") is not None
+        )
+        failed = len(responses) - succeeded
+        pending = max(total - len(responses), 0)
+        if _job_state_name(_field(batch, "state")) in {
+            "JOB_STATE_SUCCEEDED",
+            "JOB_STATE_FAILED",
+            "JOB_STATE_CANCELLED",
+            "JOB_STATE_EXPIRED",
+            "JOB_STATE_PARTIALLY_SUCCEEDED",
+        }:
+            pending = 0
+            failed += max(total - len(responses), 0)
+        return succeeded, failed, pending
+
+    completion_stats = _field(batch, "completion_stats")
+    successful = _field(completion_stats, "successful_count")
+    failed = _field(completion_stats, "failed_count")
+    incomplete = _field(completion_stats, "incomplete_count")
+    if isinstance(successful, int) and isinstance(failed, int):
+        pending = max(total - successful - failed, 0)
+        if isinstance(incomplete, int) and incomplete >= 0:
+            pending = incomplete
+        return successful, failed, pending
+
+    raw_state = _job_state_name(_field(batch, "state"))
+    if raw_state == "JOB_STATE_SUCCEEDED":
+        return total, 0, 0
+    if raw_state == "JOB_STATE_PARTIALLY_SUCCEEDED":
+        return 0, total, 0
+    if raw_state in {"JOB_STATE_FAILED", "JOB_STATE_CANCELLED", "JOB_STATE_EXPIRED"}:
+        return 0, total, 0
+    return 0, 0, total
+
+
+def _normalize_batch_status(
+    raw_state: str,
+    *,
+    succeeded: int,
+    failed: int,
+) -> str:
+    """Map Gemini batch job states into Pollux deferred statuses."""
+    if raw_state in {"JOB_STATE_QUEUED", "JOB_STATE_PENDING"}:
+        return "queued"
+    if raw_state in {"JOB_STATE_RUNNING", "JOB_STATE_PAUSED", "JOB_STATE_UPDATING"}:
+        return "running"
+    if raw_state == "JOB_STATE_CANCELLING":
+        return "cancelling"
+    if raw_state == "JOB_STATE_SUCCEEDED":
+        if succeeded > 0 and failed > 0:
+            return "partial"
+        if succeeded > 0:
+            return "completed"
+        return "failed"
+    if raw_state == "JOB_STATE_PARTIALLY_SUCCEEDED":
+        return "partial"
+    if raw_state == "JOB_STATE_CANCELLED":
+        return "partial" if succeeded > 0 or failed > 0 else "cancelled"
+    if raw_state == "JOB_STATE_EXPIRED":
+        return "partial" if succeeded > 0 or failed > 0 else "expired"
+    if raw_state == "JOB_STATE_FAILED":
+        return "failed"
+    return "running"
+
+
+def _inlined_response_request_id(entry: Any) -> str | None:
+    """Extract the Pollux request id from Gemini inlined response metadata."""
+    metadata = _field(entry, "metadata")
+    request_id = _field(metadata, "pollux_request_id") if metadata is not None else None
+    return request_id if isinstance(request_id, str) and request_id else None
+
+
+def _batch_file_request_id(
+    entry: Any,
+    *,
+    index: int,
+    request_ids: list[str],
+) -> str:
+    """Recover the Pollux request id from file-backed batch output rows."""
+    request_id = _inlined_response_request_id(entry)
+    if request_id is not None:
+        return request_id
+    if index < len(request_ids):
+        return request_ids[index]
+    return f"pollux-{index:06d}"
+
+
+def _job_error_message(error: Any) -> str | None:
+    """Return a readable message for Gemini job errors."""
+    message = _field(error, "message")
+    return message if isinstance(message, str) and message else None
+
+
+def _job_error_code(error: Any) -> str | None:
+    """Return a stable string code for Gemini job errors."""
+    code = _field(error, "code")
+    if isinstance(code, int):
+        return str(code)
+    if isinstance(code, str) and code:
+        return code
+    return None
+
+
+def _provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
+    """Convert ProviderResponse into the normalized deferred response shape."""
+    payload: dict[str, Any] = {"text": response.text, "usage": response.usage}
+    if response.reasoning is not None:
+        payload["reasoning"] = response.reasoning
+    if response.structured is not None:
+        payload["structured"] = response.structured
+    if response.tool_calls is not None:
+        payload["tool_calls"] = [
+            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+            for tc in response.tool_calls
+        ]
+    if response.response_id is not None:
+        payload["response_id"] = response.response_id
+    if response.finish_reason is not None:
+        payload["finish_reason"] = response.finish_reason
+    return payload
+
+
+def _batch_level_item_status(raw_state: str) -> DeferredItemStatus | None:
+    """Map terminal Gemini batch states into a synthesized item status."""
+    if raw_state == "JOB_STATE_FAILED":
+        return "failed"
+    if raw_state == "JOB_STATE_CANCELLED":
+        return "cancelled"
+    if raw_state == "JOB_STATE_EXPIRED":
+        return "expired"
+    if raw_state == "JOB_STATE_PARTIALLY_SUCCEEDED":
+        return "failed"
+    return None
 
 
 def _normalize_finish_reason(raw_reason: Any) -> str | None:

--- a/src/pollux/providers/mock.py
+++ b/src/pollux/providers/mock.py
@@ -11,6 +11,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def _echo_text(parts: list[Any]) -> str:
+    """Pick the first non-empty string part, falling back to the last string part."""
+    string_parts = [p for p in parts if isinstance(p, str) and p.strip()]
+    if string_parts:
+        return string_parts[0]
+    return next((p for p in reversed(parts) if isinstance(p, str)), "")
+
+
 class MockProvider:
     """Mock provider for testing without API calls.
 
@@ -37,13 +45,8 @@ class MockProvider:
         part (typically the prompt). This keeps file-based recipes informative
         in mock mode.
         """
-        string_parts = [p for p in request.parts if isinstance(p, str) and p.strip()]
-        if string_parts:
-            text = string_parts[0]
-        else:
-            text = next((p for p in reversed(request.parts) if isinstance(p, str)), "")
         return ProviderResponse(
-            text=f"echo: {text[:100]}",
+            text=f"echo: {_echo_text(request.parts)[:100]}",
             usage={"input_tokens": 10, "total_tokens": 20},
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,7 @@ import pytest
 import pollux
 from pollux.config import Config
 from pollux.options import Options
+from pollux.providers import gemini as gemini_module
 from pollux.source import Source
 
 if TYPE_CHECKING:
@@ -365,6 +366,112 @@ async def test_gemini_reasoning_roundtrip_on_gemini3(gemini_api_key: str) -> Non
     assert len(result["reasoning"]) == 1
     assert isinstance(result["reasoning"][0], str)
     assert result["reasoning"][0].strip()
+
+
+@pytest.mark.asyncio
+async def test_gemini_live_deferred_inline_submit_and_inspect(
+    gemini_api_key: str,
+    gemini_test_model: str,
+) -> None:
+    """E2E: Gemini inline deferred submission returns a live inspectable handle."""
+    config = Config(
+        provider="gemini",
+        model=gemini_test_model,
+        api_key=gemini_api_key,
+    )
+    job: pollux.DeferredHandle | None = None
+    try:
+        job = await pollux.defer(
+            "Reply with exactly LIVE_DEFERRED_INLINE_OK.",
+            config=config,
+        )
+        snapshot = await pollux.inspect_deferred(job)
+
+        assert snapshot.job_id == job.job_id
+        assert snapshot.request_count == 1
+        assert snapshot.succeeded + snapshot.failed + snapshot.pending == 1
+        assert snapshot.provider_status
+
+        if snapshot.is_terminal:
+            result = await pollux.collect_deferred(job)
+            assert result["metrics"]["deferred"] is True
+            assert result["diagnostics"]["deferred"]["job_id"] == job.job_id
+    finally:
+        if job is not None:
+            with suppress(Exception):
+                await pollux.cancel_deferred(job)
+
+
+@pytest.mark.asyncio
+async def test_gemini_live_deferred_file_submit_and_inspect(
+    monkeypatch: pytest.MonkeyPatch,
+    gemini_api_key: str,
+    gemini_test_model: str,
+) -> None:
+    """E2E: Gemini file-backed deferred submission supports bounded cancellation."""
+    monkeypatch.setattr(gemini_module, "_GEMINI_BATCH_INLINE_LIMIT_BYTES", 1)
+
+    config = Config(
+        provider="gemini",
+        model=gemini_test_model,
+        api_key=gemini_api_key,
+    )
+    job: pollux.DeferredHandle | None = None
+    cancelled = False
+    try:
+        job = await pollux.defer_many(
+            (
+                "Reply with exactly LIVE_DEFERRED_FILE_ONE.",
+                "Reply with exactly LIVE_DEFERRED_FILE_TWO.",
+            ),
+            config=config,
+        )
+        await pollux.cancel_deferred(job)
+        cancelled = True
+        snapshot = await pollux.inspect_deferred(job)
+
+        assert snapshot.job_id == job.job_id
+        assert snapshot.request_count == 2
+        assert snapshot.succeeded + snapshot.failed + snapshot.pending == 2
+        assert snapshot.provider_status
+        assert job.provider_state is not None
+        assert job.provider_state["owned_file_ids"]
+    finally:
+        if job is not None and not cancelled:
+            with suppress(Exception):
+                await pollux.cancel_deferred(job)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_live_deferred_submit_inspect_and_cancel(
+    anthropic_api_key: str,
+    anthropic_test_model: str,
+) -> None:
+    """E2E: Anthropic deferred submission supports bounded cancellation."""
+    config = Config(
+        provider="anthropic",
+        model=anthropic_test_model,
+        api_key=anthropic_api_key,
+    )
+    job: pollux.DeferredHandle | None = None
+    cancelled = False
+    try:
+        job = await pollux.defer(
+            "Reply with exactly LIVE_ANTHROPIC_DEFERRED_CANCEL_OK.",
+            config=config,
+        )
+        await pollux.cancel_deferred(job)
+        cancelled = True
+        snapshot = await pollux.inspect_deferred(job)
+
+        assert snapshot.job_id == job.job_id
+        assert snapshot.request_count == 1
+        assert snapshot.succeeded + snapshot.failed + snapshot.pending == 1
+        assert snapshot.provider_status
+    finally:
+        if job is not None and not cancelled:
+            with suppress(Exception):
+                await pollux.cancel_deferred(job)
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -23,12 +23,14 @@ from pollux.errors import (
     SourceError,
 )
 from pollux.options import Options
+from pollux.providers.anthropic import AnthropicProvider
 from pollux.providers.base import (
     ProviderCapabilities,
     ProviderDeferredHandle,
     ProviderDeferredItem,
     ProviderDeferredSnapshot,
 )
+from pollux.providers.gemini import GeminiProvider
 from pollux.providers.models import (
     Message,
     ProviderFileAsset,
@@ -2143,6 +2145,280 @@ async def test_openai_deferred_batch_level_failure_returns_error_envelope(
             "finish_reason": None,
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_gemini_deferred_backend_integrates_with_public_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gemini deferred provider should integrate cleanly through Pollux's public API."""
+
+    class _Files:
+        def __init__(self) -> None:
+            self.deleted_file_ids: list[str] = []
+
+        async def delete(self, *, name: str) -> None:
+            self.deleted_file_ids.append(name)
+
+    class _Batches:
+        def __init__(self) -> None:
+            self.cancelled: str | None = None
+
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("Batch", (), {"name": "batches/123", "create_time": 100.0})()
+
+        async def get(self, *, name: str) -> Any:
+            _ = name
+            return type(
+                "Batch",
+                (),
+                {
+                    "state": "JOB_STATE_PARTIALLY_SUCCEEDED",
+                    "create_time": 100.0,
+                    "end_time": 125.0,
+                    "error": None,
+                    "dest": type(
+                        "Dest",
+                        (),
+                        {
+                            "inlined_responses": [
+                                {
+                                    "metadata": {"pollux_request_id": "pollux-000001"},
+                                    "response": {
+                                        "candidates": [
+                                            {
+                                                "finish_reason": "STOP",
+                                                "content": {
+                                                    "parts": [{"text": "Answer 2"}]
+                                                },
+                                            }
+                                        ],
+                                        "usage_metadata": {"total_token_count": 1},
+                                    },
+                                },
+                                {
+                                    "metadata": {"pollux_request_id": "pollux-000000"},
+                                    "error": {
+                                        "code": 400,
+                                        "message": "request failed",
+                                    },
+                                },
+                            ]
+                        },
+                    )(),
+                },
+            )()
+
+        async def cancel(self, *, name: str) -> None:
+            self.cancelled = name
+
+    batches = _Batches()
+    files = _Files()
+
+    def _make_provider(*_args: Any, **_kwargs: Any) -> GeminiProvider:
+        provider = GeminiProvider("test-key")
+        provider._client = type(
+            "Client",
+            (),
+            {"aio": type("Aio", (), {"files": files, "batches": batches})()},
+        )()
+        return provider
+
+    monkeypatch.setattr(pollux, "_create_provider", _make_provider)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+
+    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    snapshot = await pollux.inspect_deferred(job)
+    result = await pollux.collect_deferred(job)
+    await pollux.cancel_deferred(job)
+
+    assert snapshot.status == "partial"
+    assert result["status"] == "partial"
+    assert result["answers"] == ["", "Answer 2"]
+    assert result["diagnostics"]["deferred"]["items"] == [
+        {
+            "request_id": "pollux-000000",
+            "status": "failed",
+            "error": "request failed",
+            "provider_status": "400",
+            "finish_reason": None,
+        },
+        {
+            "request_id": "pollux-000001",
+            "status": "succeeded",
+            "error": None,
+            "provider_status": "succeeded",
+            "finish_reason": "stop",
+        },
+    ]
+    assert batches.cancelled == "batches/123"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_deferred_backend_integrates_with_public_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anthropic deferred provider should integrate cleanly through Pollux's public API."""
+
+    class _Files:
+        def __init__(self) -> None:
+            self.deleted_file_ids: list[str] = []
+
+        async def delete(self, file_id: str, **kwargs: Any) -> None:
+            _ = kwargs
+            self.deleted_file_ids.append(file_id)
+
+    class _AsyncResults:
+        def __init__(self, rows: list[Any]) -> None:
+            self._rows = rows
+            self._index = 0
+
+        def __aiter__(self) -> _AsyncResults:
+            self._index = 0
+            return self
+
+        async def __anext__(self) -> Any:
+            if self._index >= len(self._rows):
+                raise StopAsyncIteration
+            row = self._rows[self._index]
+            self._index += 1
+            return row
+
+    class _Batches:
+        def __init__(self) -> None:
+            self.cancelled: str | None = None
+
+        async def create(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return type("Batch", (), {"id": "msgbatch_123", "created_at": 100.0})()
+
+        async def retrieve(self, message_batch_id: str) -> Any:
+            _ = message_batch_id
+            return type(
+                "Batch",
+                (),
+                {
+                    "id": "msgbatch_123",
+                    "processing_status": "ended",
+                    "created_at": 100.0,
+                    "ended_at": 125.0,
+                    "expires_at": 200.0,
+                    "results_url": "https://example.test/results.jsonl",
+                    "request_counts": type(
+                        "Counts",
+                        (),
+                        {
+                            "processing": 0,
+                            "succeeded": 1,
+                            "errored": 0,
+                            "canceled": 1,
+                            "expired": 0,
+                        },
+                    )(),
+                },
+            )()
+
+        def results(self, message_batch_id: str) -> _AsyncResults:
+            _ = message_batch_id
+            return _AsyncResults(
+                [
+                    type(
+                        "Row",
+                        (),
+                        {
+                            "custom_id": "pollux-000001",
+                            "result": type(
+                                "Succeeded",
+                                (),
+                                {
+                                    "type": "succeeded",
+                                    "message": type(
+                                        "Message",
+                                        (),
+                                        {
+                                            "id": "msg_123",
+                                            "content": [
+                                                type(
+                                                    "Block",
+                                                    (),
+                                                    {
+                                                        "type": "text",
+                                                        "text": "Answer 2",
+                                                    },
+                                                )()
+                                            ],
+                                            "usage": type(
+                                                "Usage",
+                                                (),
+                                                {"input_tokens": 1, "output_tokens": 2},
+                                            )(),
+                                            "stop_reason": "end_turn",
+                                        },
+                                    )(),
+                                },
+                            )(),
+                        },
+                    )(),
+                    type(
+                        "Row",
+                        (),
+                        {
+                            "custom_id": "pollux-000000",
+                            "result": type("Canceled", (), {"type": "canceled"})(),
+                        },
+                    )(),
+                ]
+            )
+
+        async def cancel(self, message_batch_id: str) -> Any:
+            self.cancelled = message_batch_id
+            return await self.retrieve(message_batch_id)
+
+    batches = _Batches()
+    files = _Files()
+
+    def _make_provider(*_args: Any, **_kwargs: Any) -> AnthropicProvider:
+        class _Client:
+            def __init__(self) -> None:
+                self.messages = type("Messages", (), {"batches": batches})()
+                self.beta = type("Beta", (), {"files": files})()
+
+            async def close(self) -> None:
+                return None
+
+        provider = AnthropicProvider("test-key")
+        provider._client = _Client()
+        return provider
+
+    monkeypatch.setattr(pollux, "_create_provider", _make_provider)
+    cfg = Config(provider="anthropic", model=ANTHROPIC_MODEL, use_mock=True)
+
+    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    snapshot = await pollux.inspect_deferred(job)
+    result = await pollux.collect_deferred(job)
+    await pollux.cancel_deferred(job)
+
+    assert snapshot.status == "partial"
+    assert result["status"] == "partial"
+    assert result["answers"] == ["", "Answer 2"]
+    assert result["diagnostics"]["deferred"]["items"] == [
+        {
+            "request_id": "pollux-000000",
+            "status": "cancelled",
+            "error": None,
+            "provider_status": "canceled",
+            "finish_reason": None,
+        },
+        {
+            "request_id": "pollux-000001",
+            "status": "succeeded",
+            "error": None,
+            "provider_status": "succeeded",
+            "finish_reason": "stop",
+        },
+    ]
+    assert batches.cancelled == "msgbatch_123"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1481,7 +1481,7 @@ async def test_implicit_caching_requires_provider_capability_when_enabled(
 async def test_delivery_mode_deferred_is_explicitly_not_implemented(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """run_many() should point callers at the sibling deferred API."""
+    """Legacy deferred mode should fail fast and point callers at the sibling API."""
     fake = FakeProvider(
         _capabilities=ProviderCapabilities(
             persistent_cache=True,
@@ -1495,12 +1495,32 @@ async def test_delivery_mode_deferred_is_explicitly_not_implemented(
     monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
     cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
-    with pytest.raises(ConfigurationError, match="not supported on run"):
+    with pytest.raises(ConfigurationError, match="legacy compatibility shim"):
         await pollux.run_many(
             ("Q1?",),
             config=cfg,
             options=Options(delivery_mode="deferred"),
         )
+
+
+def test_delivery_mode_realtime_is_accepted_as_legacy_compatibility_shim() -> None:
+    """Explicit realtime mode should remain valid for existing callers."""
+    options = Options(delivery_mode="realtime")
+
+    assert options.delivery_mode == "realtime"
+
+
+def test_delivery_mode_deferred_is_accepted_as_legacy_compatibility_shim() -> None:
+    """Deferred remains constructible so Pollux can raise migration guidance."""
+    options = Options(delivery_mode="deferred")
+
+    assert options.delivery_mode == "deferred"
+
+
+def test_delivery_mode_rejects_invalid_values() -> None:
+    """Invalid delivery_mode values should fail fast with a clear error."""
+    with pytest.raises(ConfigurationError, match="must be 'realtime' or 'deferred'"):
+        Options(delivery_mode="bogus")
 
 
 def test_deferred_handle_round_trip_serialization() -> None:
@@ -1532,6 +1552,32 @@ async def test_defer_many_requires_at_least_one_prompt(
 
 
 @pytest.mark.asyncio
+async def test_defer_rejects_global_mock_provider() -> None:
+    """Deferred delivery should not be available through the global mock provider."""
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+
+    with pytest.raises(ConfigurationError, match="does not support deferred delivery"):
+        await pollux.defer_many(
+            ("Summarize this text", "List two risks"),
+            sources=(Source.from_text("shared context"),),
+            config=cfg,
+        )
+
+
+@pytest.mark.asyncio
+async def test_defer_rejects_redundant_legacy_delivery_mode() -> None:
+    """Deferred entry points should tell legacy callers to drop delivery_mode."""
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+
+    with pytest.raises(ConfigurationError, match="not needed with defer"):
+        await pollux.defer_many(
+            ("Summarize this text",),
+            config=cfg,
+            options=Options(delivery_mode="deferred"),
+        )
+
+
+@pytest.mark.asyncio
 async def test_defer_collect_smoke_without_lifecycle_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1546,10 +1592,12 @@ async def test_defer_collect_smoke_without_lifecycle_config(
         config=cfg,
     )
 
-    assert job.provider_state == {"request_ids": ["pollux-000000", "pollux-000001"]}
+    assert job.provider_state is not None
+    assert job.provider_state["request_ids"] == ["pollux-000000", "pollux-000001"]
+    restored = DeferredHandle.from_dict(job.to_dict())
 
-    snapshot = await pollux.inspect_deferred(job)
-    result = await pollux.collect_deferred(job)
+    snapshot = await pollux.inspect_deferred(restored)
+    result = await pollux.collect_deferred(restored)
 
     assert snapshot.is_terminal is True
     assert snapshot.status == "completed"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,6 +11,7 @@ and drift is hard to detect.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,7 @@ import httpx
 import pytest
 
 from pollux.errors import APIError, ConfigurationError
+from pollux.providers import gemini as gemini_module
 from pollux.providers._errors import extract_retry_after_s, wrap_provider_error
 from pollux.providers._utils import to_strict_schema
 from pollux.providers.anthropic import AnthropicProvider
@@ -1891,6 +1893,634 @@ async def test_openai_cancel_deferred_cleans_up_when_batch_is_terminal() -> None
     )
 
     assert files.deleted_file_ids == ["file_batch_input", "file_uploaded_pdf"]
+
+
+# =============================================================================
+# Gemini Deferred Delivery (Characterization)
+# =============================================================================
+
+
+class _FakeGeminiFilesClient:
+    """Captures Gemini Files API interactions for batch tests."""
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict[str, Any]] = []
+        self.deleted_file_ids: list[str] = []
+        self.download_contents: dict[str, bytes] = {}
+
+    async def upload(self, **kwargs: Any) -> Any:
+        self.upload_calls.append(kwargs)
+        config = kwargs.get("config")
+        mime_type = (
+            config.get("mime_type")
+            if isinstance(config, dict)
+            else getattr(config, "mime_type", None)
+        )
+        if mime_type == "application/jsonl":
+            return type(
+                "File",
+                (),
+                {
+                    "name": "files/batch_input",
+                    "uri": "https://example.test/files/batch_input",
+                    "state": "ACTIVE",
+                },
+            )()
+        return type(
+            "File",
+            (),
+            {
+                "name": "files/uploaded_pdf",
+                "uri": "https://example.test/files/uploaded_pdf",
+                "state": "ACTIVE",
+            },
+        )()
+
+    async def delete(self, *, name: str) -> None:
+        self.deleted_file_ids.append(name)
+
+    async def download(self, *, file: str) -> bytes:
+        return self.download_contents[file]
+
+
+class _FakeGeminiBatchesClient:
+    """Captures Gemini Batch API interactions for characterization tests."""
+
+    def __init__(self) -> None:
+        self.create_kwargs: dict[str, Any] | None = None
+        self.get_result: Any = None
+        self.cancelled_name: str | None = None
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.create_kwargs = kwargs
+        return type(
+            "Batch",
+            (),
+            {
+                "name": "batches/123",
+                "create_time": datetime(2026, 3, 1, tzinfo=timezone.utc),
+            },
+        )()
+
+    async def get(self, *, name: str) -> Any:
+        _ = name
+        return self.get_result
+
+    async def cancel(self, *, name: str) -> None:
+        self.cancelled_name = name
+
+
+def _make_gemini_client(
+    *,
+    files: _FakeGeminiFilesClient,
+    batches: _FakeGeminiBatchesClient,
+) -> Any:
+    return type(
+        "Client",
+        (),
+        {
+            "aio": type("Aio", (), {"files": files, "batches": batches})(),
+        },
+    )()
+
+
+@pytest.mark.asyncio
+async def test_gemini_submit_deferred_characterizes_inlined_batch_request(
+    tmp_path: Path,
+) -> None:
+    """Deferred submission should reuse Gemini generate-content payloads."""
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    files = _FakeGeminiFilesClient()
+    batches = _FakeGeminiBatchesClient()
+    provider = GeminiProvider("test-key")
+    provider._client = _make_gemini_client(files=files, batches=batches)
+
+    handle = await provider.submit_deferred(
+        [
+            ProviderRequest(
+                model=GEMINI_MODEL,
+                parts=["Summarize this"],
+                response_schema={
+                    "type": "object",
+                    "properties": {"summary": {"type": "string"}},
+                },
+            ),
+            ProviderRequest(
+                model=GEMINI_MODEL,
+                parts=[
+                    {"file_path": str(pdf_path), "mime_type": "application/pdf"},
+                    "Answer the question",
+                ],
+            ),
+        ],
+        request_ids=["pollux-000000", "pollux-000001"],
+    )
+
+    assert handle.job_id == "batches/123"
+    assert handle.provider_state == {
+        "request_ids": ["pollux-000000", "pollux-000001"],
+        "owned_file_ids": ["files/uploaded_pdf"],
+        "has_response_schema": True,
+    }
+
+    assert len(files.upload_calls) == 1
+    assert batches.create_kwargs is not None
+    assert batches.create_kwargs["model"] == GEMINI_MODEL
+
+    src = batches.create_kwargs["src"]
+    assert len(src) == 2
+    assert src[0].metadata == {"pollux_request_id": "pollux-000000"}
+    assert src[0].config.response_mime_type == "application/json"
+    assert src[1].metadata == {"pollux_request_id": "pollux-000001"}
+    assert (
+        src[1].contents[0].file_data.file_uri
+        == "https://example.test/files/uploaded_pdf"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gemini_submit_deferred_switches_to_file_input_when_inline_too_large(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Oversized Gemini deferred payloads should upload a JSONL batch file."""
+    monkeypatch.setattr(gemini_module, "_GEMINI_BATCH_INLINE_LIMIT_BYTES", 1)
+
+    files = _FakeGeminiFilesClient()
+    batches = _FakeGeminiBatchesClient()
+    provider = GeminiProvider("test-key")
+    provider._client = _make_gemini_client(files=files, batches=batches)
+
+    handle = await provider.submit_deferred(
+        [
+            ProviderRequest(
+                model=GEMINI_MODEL,
+                parts=["Summarize this"],
+            ),
+            ProviderRequest(
+                model=GEMINI_MODEL,
+                parts=["Answer the question"],
+            ),
+        ],
+        request_ids=["pollux-000000", "pollux-000001"],
+    )
+
+    assert handle.job_id == "batches/123"
+    assert handle.provider_state == {
+        "request_ids": ["pollux-000000", "pollux-000001"],
+        "owned_file_ids": ["files/batch_input"],
+        "has_response_schema": False,
+    }
+
+    assert len(files.upload_calls) == 1
+    assert files.upload_calls[0]["config"] == {"mime_type": "application/jsonl"}
+    assert batches.create_kwargs is not None
+    assert batches.create_kwargs["model"] == GEMINI_MODEL
+    assert batches.create_kwargs["src"].file_name == "files/batch_input"
+
+
+@pytest.mark.asyncio
+async def test_gemini_collect_deferred_parses_inlined_responses_and_cleans_up() -> None:
+    """Gemini collection should use inlined batch responses and metadata ids."""
+    files = _FakeGeminiFilesClient()
+    batches = _FakeGeminiBatchesClient()
+    batches.get_result = type(
+        "Batch",
+        (),
+        {
+            "state": "JOB_STATE_PARTIALLY_SUCCEEDED",
+            "create_time": datetime(2026, 3, 1, tzinfo=timezone.utc),
+            "end_time": datetime(2026, 3, 1, 0, 5, tzinfo=timezone.utc),
+            "error": None,
+            "dest": type(
+                "Dest",
+                (),
+                {
+                    "inlined_responses": [
+                        {
+                            "metadata": {"pollux_request_id": "pollux-000001"},
+                            "response": {
+                                "candidates": [
+                                    {
+                                        "finish_reason": "STOP",
+                                        "content": {"parts": [{"text": "Answer 2"}]},
+                                    }
+                                ],
+                                "usage_metadata": {
+                                    "prompt_token_count": 1,
+                                    "candidates_token_count": 2,
+                                    "total_token_count": 3,
+                                },
+                            },
+                        },
+                        {
+                            "metadata": {"pollux_request_id": "pollux-000000"},
+                            "error": {"code": 400, "message": "bad input"},
+                        },
+                    ]
+                },
+            )(),
+        },
+    )()
+    provider = GeminiProvider("test-key")
+    provider._client = _make_gemini_client(files=files, batches=batches)
+
+    handle = ProviderDeferredHandle(
+        job_id="batches/123",
+        provider_state={
+            "request_ids": ["pollux-000000", "pollux-000001"],
+            "owned_file_ids": ["files/uploaded_pdf"],
+        },
+    )
+    snapshot = await provider.inspect_deferred(handle)
+    items = await provider.collect_deferred(handle)
+
+    assert snapshot.status == "partial"
+    assert snapshot.request_count == 2
+    assert snapshot.succeeded == 1
+    assert snapshot.failed == 1
+    assert snapshot.pending == 0
+    assert items == [
+        ProviderDeferredItem(
+            request_id="pollux-000001",
+            status="succeeded",
+            response={
+                "text": "Answer 2",
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                    "total_tokens": 3,
+                },
+                "finish_reason": "stop",
+            },
+            provider_status="succeeded",
+            finish_reason="stop",
+        ),
+        ProviderDeferredItem(
+            request_id="pollux-000000",
+            status="failed",
+            error="bad input",
+            provider_status="400",
+        ),
+    ]
+    assert files.deleted_file_ids == ["files/uploaded_pdf", "files/uploaded_pdf"]
+
+
+@pytest.mark.asyncio
+async def test_gemini_collect_deferred_parses_file_output_and_cleans_up() -> None:
+    """Gemini file-backed collection should recover request ids from metadata."""
+    files = _FakeGeminiFilesClient()
+    files.download_contents["files/output"] = (
+        json.dumps(
+            {
+                "metadata": {"pollux_request_id": "pollux-000001"},
+                "response": {
+                    "candidates": [
+                        {
+                            "finish_reason": "STOP",
+                            "content": {"parts": [{"text": "Answer 2"}]},
+                        }
+                    ],
+                    "usage_metadata": {
+                        "prompt_token_count": 1,
+                        "candidates_token_count": 2,
+                        "total_token_count": 3,
+                    },
+                },
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "metadata": {"pollux_request_id": "pollux-000000"},
+                "error": {"code": 400, "message": "bad input"},
+            }
+        )
+    ).encode("utf-8")
+
+    batches = _FakeGeminiBatchesClient()
+    batches.get_result = type(
+        "Batch",
+        (),
+        {
+            "state": "JOB_STATE_PARTIALLY_SUCCEEDED",
+            "create_time": datetime(2026, 3, 1, tzinfo=timezone.utc),
+            "end_time": datetime(2026, 3, 1, 0, 5, tzinfo=timezone.utc),
+            "error": None,
+            "dest": type("Dest", (), {"file_name": "files/output"})(),
+            "completion_stats": type(
+                "CompletionStats",
+                (),
+                {
+                    "successful_count": 1,
+                    "failed_count": 1,
+                    "incomplete_count": 0,
+                },
+            )(),
+        },
+    )()
+    provider = GeminiProvider("test-key")
+    provider._client = _make_gemini_client(files=files, batches=batches)
+
+    handle = ProviderDeferredHandle(
+        job_id="batches/123",
+        provider_state={
+            "request_ids": ["pollux-000000", "pollux-000001"],
+            "owned_file_ids": ["files/batch_input"],
+        },
+    )
+    snapshot = await provider.inspect_deferred(handle)
+    items = await provider.collect_deferred(handle)
+
+    assert snapshot.status == "partial"
+    assert snapshot.request_count == 2
+    assert snapshot.succeeded == 1
+    assert snapshot.failed == 1
+    assert snapshot.pending == 0
+    assert items == [
+        ProviderDeferredItem(
+            request_id="pollux-000001",
+            status="succeeded",
+            response={
+                "text": "Answer 2",
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                    "total_tokens": 3,
+                },
+                "finish_reason": "stop",
+            },
+            provider_status="succeeded",
+            finish_reason="stop",
+        ),
+        ProviderDeferredItem(
+            request_id="pollux-000000",
+            status="failed",
+            error="bad input",
+            provider_status="400",
+        ),
+    ]
+    assert files.deleted_file_ids == ["files/batch_input", "files/batch_input"]
+
+
+# =============================================================================
+# Anthropic Deferred Delivery (Characterization)
+# =============================================================================
+
+
+class _FakeAnthropicBatchFilesClient:
+    """Captures Anthropic Files API interactions for batch tests."""
+
+    def __init__(self) -> None:
+        self.deleted_file_ids: list[str] = []
+        self.upload_calls: list[dict[str, Any]] = []
+
+    async def upload(self, **kwargs: Any) -> Any:
+        self.upload_calls.append(kwargs)
+        return type("FileMetadata", (), {"id": "file_uploaded_pdf"})()
+
+    async def delete(self, file_id: str, **kwargs: Any) -> None:
+        _ = kwargs
+        self.deleted_file_ids.append(file_id)
+
+
+class _AsyncAnthropicResults:
+    """Simple async iterator wrapper for fake batch result rows."""
+
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+        self._index = 0
+
+    def __aiter__(self) -> _AsyncAnthropicResults:
+        self._index = 0
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._index >= len(self._rows):
+            raise StopAsyncIteration
+        row = self._rows[self._index]
+        self._index += 1
+        return row
+
+
+class _FakeAnthropicBatchesClient:
+    """Captures Anthropic Message Batches API interactions."""
+
+    def __init__(self) -> None:
+        self.create_kwargs: dict[str, Any] | None = None
+        self.retrieve_result: Any = None
+        self.results_rows: list[Any] = []
+        self.cancelled_batch_id: str | None = None
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.create_kwargs = kwargs
+        return type(
+            "MessageBatch",
+            (),
+            {
+                "id": "msgbatch_123",
+                "created_at": datetime(2026, 3, 1, tzinfo=timezone.utc),
+            },
+        )()
+
+    async def retrieve(self, message_batch_id: str) -> Any:
+        _ = message_batch_id
+        return self.retrieve_result
+
+    def results(self, message_batch_id: str) -> _AsyncAnthropicResults:
+        _ = message_batch_id
+        return _AsyncAnthropicResults(self.results_rows)
+
+    async def cancel(self, message_batch_id: str) -> Any:
+        self.cancelled_batch_id = message_batch_id
+        return self.retrieve_result
+
+
+def _make_anthropic_client(
+    *,
+    files: _FakeAnthropicBatchFilesClient,
+    batches: _FakeAnthropicBatchesClient,
+) -> Any:
+    return type(
+        "Client",
+        (),
+        {
+            "messages": type("Messages", (), {"batches": batches})(),
+            "beta": type("Beta", (), {"files": files})(),
+        },
+    )()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_submit_deferred_characterizes_message_batch_request(
+    tmp_path: Path,
+) -> None:
+    """Deferred submission should build Anthropic message-batch requests."""
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    files = _FakeAnthropicBatchFilesClient()
+    batches = _FakeAnthropicBatchesClient()
+    provider = AnthropicProvider("test-key")
+    provider._client = _make_anthropic_client(files=files, batches=batches)
+
+    handle = await provider.submit_deferred(
+        [
+            ProviderRequest(
+                model=ANTHROPIC_MODEL,
+                parts=["Summarize this"],
+                response_schema={
+                    "type": "object",
+                    "properties": {"summary": {"type": "string"}},
+                },
+            ),
+            ProviderRequest(
+                model=ANTHROPIC_MODEL,
+                parts=[
+                    {"file_path": str(pdf_path), "mime_type": "application/pdf"},
+                    "Answer the question",
+                ],
+            ),
+        ],
+        request_ids=["pollux-000000", "pollux-000001"],
+    )
+
+    assert handle.job_id == "msgbatch_123"
+    assert handle.provider_state == {
+        "request_ids": ["pollux-000000", "pollux-000001"],
+        "owned_file_ids": ["file_uploaded_pdf"],
+        "has_response_schema": True,
+    }
+
+    assert len(files.upload_calls) == 1
+    assert batches.create_kwargs is not None
+    assert batches.create_kwargs["extra_headers"] == {
+        "anthropic-beta": "files-api-2025-04-14"
+    }
+    requests = list(batches.create_kwargs["requests"])
+    assert [item["custom_id"] for item in requests] == [
+        "pollux-000000",
+        "pollux-000001",
+    ]
+    assert requests[0]["params"]["output_config"]["format"]["type"] == "json_schema"
+    assert requests[1]["params"]["messages"][0]["content"][0]["source"]["file_id"] == (
+        "file_uploaded_pdf"
+    )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_collect_deferred_parses_result_stream_and_cleans_up() -> None:
+    """Anthropic collection should parse async JSONL results by custom_id."""
+    files = _FakeAnthropicBatchFilesClient()
+    batches = _FakeAnthropicBatchesClient()
+    batches.retrieve_result = type(
+        "MessageBatch",
+        (),
+        {
+            "id": "msgbatch_123",
+            "processing_status": "ended",
+            "created_at": datetime(2026, 3, 1, tzinfo=timezone.utc),
+            "ended_at": datetime(2026, 3, 1, 0, 5, tzinfo=timezone.utc),
+            "expires_at": datetime(2026, 3, 2, tzinfo=timezone.utc),
+            "results_url": "https://example.test/results.jsonl",
+            "request_counts": type(
+                "Counts",
+                (),
+                {
+                    "processing": 0,
+                    "succeeded": 1,
+                    "errored": 0,
+                    "canceled": 1,
+                    "expired": 0,
+                },
+            )(),
+        },
+    )()
+    batches.results_rows = [
+        type(
+            "Row",
+            (),
+            {
+                "custom_id": "pollux-000001",
+                "result": type(
+                    "Succeeded",
+                    (),
+                    {
+                        "type": "succeeded",
+                        "message": type(
+                            "Message",
+                            (),
+                            {
+                                "id": "msg_123",
+                                "content": [
+                                    type(
+                                        "Block",
+                                        (),
+                                        {"type": "text", "text": "Answer 2"},
+                                    )()
+                                ],
+                                "usage": type(
+                                    "Usage", (), {"input_tokens": 1, "output_tokens": 2}
+                                )(),
+                                "stop_reason": "end_turn",
+                            },
+                        )(),
+                    },
+                )(),
+            },
+        )(),
+        type(
+            "Row",
+            (),
+            {
+                "custom_id": "pollux-000000",
+                "result": type("Canceled", (), {"type": "canceled"})(),
+            },
+        )(),
+    ]
+    provider = AnthropicProvider("test-key")
+    provider._client = _make_anthropic_client(files=files, batches=batches)
+
+    handle = ProviderDeferredHandle(
+        job_id="msgbatch_123",
+        provider_state={
+            "request_ids": ["pollux-000000", "pollux-000001"],
+            "owned_file_ids": ["file_uploaded_pdf"],
+        },
+    )
+    snapshot = await provider.inspect_deferred(handle)
+    items = await provider.collect_deferred(handle)
+
+    assert snapshot.status == "partial"
+    assert snapshot.request_count == 2
+    assert snapshot.succeeded == 1
+    assert snapshot.failed == 1
+    assert snapshot.pending == 0
+    assert items == [
+        ProviderDeferredItem(
+            request_id="pollux-000001",
+            status="succeeded",
+            response={
+                "text": "Answer 2",
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                    "total_tokens": 3,
+                },
+                "response_id": "msg_123",
+                "finish_reason": "stop",
+            },
+            provider_status="succeeded",
+            finish_reason="stop",
+        ),
+        ProviderDeferredItem(
+            request_id="pollux-000000",
+            status="cancelled",
+            provider_status="canceled",
+        ),
+    ]
+    assert files.deleted_file_ids == ["file_uploaded_pdf", "file_uploaded_pdf"]
 
 
 # =============================================================================

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2328,13 +2328,21 @@ class _FakeAnthropicBatchesClient:
         _ = message_batch_id
         return self.retrieve_result
 
-    def results(self, message_batch_id: str) -> _AsyncAnthropicResults:
+    def results(self, message_batch_id: str) -> Any:
         _ = message_batch_id
         return _AsyncAnthropicResults(self.results_rows)
 
     async def cancel(self, message_batch_id: str) -> Any:
         self.cancelled_batch_id = message_batch_id
         return self.retrieve_result
+
+
+class _FakeAnthropicAwaitableResultsBatchesClient(_FakeAnthropicBatchesClient):
+    """Variant whose results() method must be awaited before iteration."""
+
+    async def results(self, message_batch_id: str) -> Any:
+        _ = message_batch_id
+        return _AsyncAnthropicResults(self.results_rows)
 
 
 def _make_anthropic_client(
@@ -2521,6 +2529,100 @@ async def test_anthropic_collect_deferred_parses_result_stream_and_cleans_up() -
         ),
     ]
     assert files.deleted_file_ids == ["file_uploaded_pdf", "file_uploaded_pdf"]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_collect_deferred_awaits_results_coroutine() -> None:
+    """Anthropic collection should handle SDK results() methods that are awaitable."""
+    files = _FakeAnthropicBatchFilesClient()
+    batches = _FakeAnthropicAwaitableResultsBatchesClient()
+    batches.retrieve_result = type(
+        "MessageBatch",
+        (),
+        {
+            "id": "msgbatch_123",
+            "processing_status": "ended",
+            "created_at": datetime(2026, 3, 1, tzinfo=timezone.utc),
+            "ended_at": datetime(2026, 3, 1, 0, 5, tzinfo=timezone.utc),
+            "expires_at": datetime(2026, 3, 2, tzinfo=timezone.utc),
+            "results_url": "https://example.test/results.jsonl",
+            "request_counts": type(
+                "Counts",
+                (),
+                {
+                    "processing": 0,
+                    "succeeded": 1,
+                    "errored": 0,
+                    "canceled": 0,
+                    "expired": 0,
+                },
+            )(),
+        },
+    )()
+    batches.results_rows = [
+        type(
+            "Row",
+            (),
+            {
+                "custom_id": "pollux-000000",
+                "result": type(
+                    "Succeeded",
+                    (),
+                    {
+                        "type": "succeeded",
+                        "message": type(
+                            "Message",
+                            (),
+                            {
+                                "id": "msg_awaitable",
+                                "content": [
+                                    type(
+                                        "Block",
+                                        (),
+                                        {"type": "text", "text": "Answer 1"},
+                                    )()
+                                ],
+                                "usage": type(
+                                    "Usage", (), {"input_tokens": 2, "output_tokens": 3}
+                                )(),
+                                "stop_reason": "end_turn",
+                            },
+                        )(),
+                    },
+                )(),
+            },
+        )(),
+    ]
+    provider = AnthropicProvider("test-key")
+    provider._client = _make_anthropic_client(files=files, batches=batches)
+
+    handle = ProviderDeferredHandle(
+        job_id="msgbatch_123",
+        provider_state={
+            "request_ids": ["pollux-000000"],
+            "owned_file_ids": ["file_uploaded_pdf"],
+        },
+    )
+    items = await provider.collect_deferred(handle)
+
+    assert items == [
+        ProviderDeferredItem(
+            request_id="pollux-000000",
+            status="succeeded",
+            response={
+                "text": "Answer 1",
+                "usage": {
+                    "input_tokens": 2,
+                    "output_tokens": 3,
+                    "total_tokens": 5,
+                },
+                "response_id": "msg_awaitable",
+                "finish_reason": "stop",
+            },
+            provider_status="succeeded",
+            finish_reason="stop",
+        )
+    ]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Add Pollux's deferred delivery public lifecycle to the remaining provider backends, round out the boundary and characterization tests, and finish the user-facing documentation for when and how to use deferred work. This also adds a maintainer probe script for low-cost live deferred checks across providers.

## Related issue

None

## Test plan

- `just check`
- `just docs-build`
- `uv run python scripts/deferred_delivery_probe.py --validation-only --strict`
- `OPENAI_API_KEY='' GEMINI_API_KEY='' ANTHROPIC_API_KEY='' uv run python scripts/deferred_delivery_probe.py --live-only --provider openai`

## Notes

- Deferred delivery remains a sibling API to `run()` / `run_many()` rather than a `delivery_mode` on the realtime entry points.
- The new `scripts/deferred_delivery_probe.py` is maintainer-facing. It complements the test suite with live provider checks and fails fast when a requested live provider is missing its API key.
