### PR TITLE
docs: refresh README and roadmap for v1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
+<!-- Intent: Repository landing page for first-time users. Get the reader to a
+     working result quickly, then show the three execution shapes they are most
+     likely to need: single-call realtime, source-pattern realtime, and
+     deferred delivery. Do NOT reteach lifecycle details, provider caveats, or
+     architecture concepts that already live in the docs. Assumes the reader
+     knows what an LLM API is and is deciding whether to try Pollux. Register:
+     landing copy. -->
+
 # Pollux
 
 Multimodal orchestration for LLM APIs.
 
-> You describe what to analyze. Pollux handles source patterns, context caching, and multimodal content, so you don't.
+> You describe what to analyze. Pollux handles source patterns, context caching, deferred delivery, and multimodal content.
 
 [Documentation](https://polluxlib.dev/) ·
-[Getting Started](https://polluxlib.dev/getting-started/)
+[Getting Started](https://polluxlib.dev/getting-started/) ·
+[Building With Deferred Delivery](https://polluxlib.dev/building-with-deferred-delivery/)
 
 [![PyPI](https://img.shields.io/pypi/v/pollux-ai)](https://pypi.org/project/pollux-ai/)
 [![CI](https://github.com/seanbrar/pollux/actions/workflows/ci.yml/badge.svg)](https://github.com/seanbrar/pollux/actions/workflows/ci.yml)
@@ -35,14 +44,26 @@ print(result["answers"][0])
 
 `run()` returns a `ResultEnvelope`: `answers` holds one entry per prompt.
 
-To use OpenAI instead: `Config(provider="openai", model="gpt-5-nano")`.
-For Anthropic: `Config(provider="anthropic", model="claude-haiku-4-5")`.
+To use OpenAI instead: `Config(provider="openai", model="gpt-5-nano")`.<br>
+For Anthropic: `Config(provider="anthropic", model="claude-haiku-4-5")`.<br>
 For OpenRouter: `Config(provider="openrouter", model="google/gemma-3-27b-it:free")`.
 
 For a full walkthrough (install, key setup, first result), see
 [Getting Started](https://polluxlib.dev/getting-started/).
 
-## What Problems Does Pollux Solve?
+## Which Entry Point Should I Use?
+
+| If you want to... | Use |
+|---|---|
+| Ask one prompt and get an answer now | `run()` |
+| Ask many prompts against shared source(s) | `run_many()` |
+| Submit non-urgent work and collect it later | `defer()` / `defer_many()` |
+
+Pollux keeps realtime and deferred work on separate entry points. If the result
+can wait, submit it once, persist the handle, and collect the same
+`ResultEnvelope` later.
+
+## What Pollux Handles
 
 Say you have a document and ten questions about it. Each API call re-uploads the file, and you're left managing caching, retries, and concurrency yourself. Pollux uploads once, caches the content, fans out your prompts concurrently, and hands back results.
 
@@ -71,6 +92,43 @@ for answer in envelope["answers"]:
 
 Add more sources and Pollux broadcasts every prompt across every source, uploading each once regardless of how many prompts reference it.
 
+## When the Work Can Wait
+
+Deferred delivery is for long fan-out work, backfills, and scheduled analysis
+where no one is waiting on the answer in the current process.
+
+```python
+import asyncio
+from pollux import (
+    Config,
+    Source,
+    collect_deferred,
+    defer,
+    inspect_deferred,
+)
+
+config = Config(provider="openai", model="gpt-5-nano")
+
+handle = asyncio.run(
+    defer(
+        "Summarize the report in five bullets.",
+        source=Source.from_file("market-report.pdf"),
+        config=config,
+    )
+)
+
+snapshot = asyncio.run(inspect_deferred(handle))
+if snapshot.is_terminal:
+    result = asyncio.run(collect_deferred(handle))
+    print(result["answers"][0])
+```
+
+In production code, persist `handle.to_dict()` and restore it later with
+`DeferredHandle.from_dict(...)`. For the full lifecycle, read
+[Submitting Work for Later Collection](https://polluxlib.dev/submitting-work-for-later-collection/)
+and
+[Building With Deferred Delivery](https://polluxlib.dev/building-with-deferred-delivery/).
+
 ## Where Pollux Ends
 
 Pollux owns content delivery, context caching, and provider translation. Prompt design, workflow orchestration, and what you do with results are yours. See [Core Concepts](https://polluxlib.dev/concepts/) for the full boundary model.
@@ -96,6 +154,8 @@ Keys from: [Google AI Studio](https://ai.dev/) · [OpenAI](https://platform.open
 
 - [Getting Started](https://polluxlib.dev/getting-started/): first result in 2 minutes
 - [Core Concepts](https://polluxlib.dev/concepts/): mental model and vocabulary
+- [Submitting Work for Later Collection](https://polluxlib.dev/submitting-work-for-later-collection/): deferred lifecycle API
+- [Building With Deferred Delivery](https://polluxlib.dev/building-with-deferred-delivery/): when deferred is worth it
 - [API Reference](https://polluxlib.dev/reference/api/): entry points and types
 - [Cookbook](https://polluxlib.dev/reference/cli/): runnable end-to-end recipes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,38 +1,113 @@
 # Pollux Roadmap
 
-This roadmap is intentionally scope-constrained: ship a stable, high-quality core in v1.0, then expand deliberately.
+This roadmap is intentionally scope-constrained. Pollux is already past the
+"ship the core at all costs" phase; the next phase is to make the core more
+trustworthy, more legible, and harder to misuse.
 
-- **Intent**: communicate priorities and scope boundaries (not a promise or contract).
-- **Last updated**: 2026-02-08
-- **Status tracking**: Issues and PRs are the source of truth for current work.
+- **Intent**: communicate priorities and scope boundaries, not promises.
+- **Last updated**: 2026-03-16
+- **Current status**: v1.5 is complete. Realtime and deferred APIs are both in
+  scope and shipped.
+- **Status tracking**: Issues and PRs are the source of truth for active work.
 
 ## Product Strategy
 
 - **Policy**: Pollux is capability-transparent, not capability-equalizing.
-- Provider differences are allowed when clearly documented and surfaced via explicit errors.
-- Provider feature parity is a nice-to-have, not a v1.0 requirement.
-- New provider features do not require simultaneous implementation across all providers.
+- Pollux owns orchestration primitives, not full application workflows.
+- Prefer stronger guarantees, clearer docs, and sharper errors over a broader
+  public API.
+- New surface area should earn its place by removing repeated downstream
+  boilerplate without hiding meaningful provider differences.
+- Upstream concerns stay upstream: model quality, pricing, provider-side
+  latency, and feature availability belong to providers.
+- Downstream concerns stay downstream: scheduling, job queues, human review,
+  storage, business workflows, and long-running agent policy belong to
+  applications using Pollux.
 
-## v1.0 (Release Gate)
+## Current Position
 
-- Stable core API: `run`, `run_many`, `Config`, `Source`, `Options`, `ResultEnvelope`.
-- Correct multimodal behavior for supported provider + input combinations.
-- Clear capability boundaries with fail-fast errors for unsupported options.
-- Quality gates pass: `make test`, `make lint`, `make typecheck`.
+The core library now covers the main orchestration responsibilities it set out
+to own:
 
-### Explicitly Out of Scope for v1.0
+- Stable entry points for realtime and deferred execution:
+  `run()`, `run_many()`, `defer()`, `defer_many()`,
+  `inspect_deferred()`, `collect_deferred()`, `cancel_deferred()`.
+- Multimodal source handling across the supported provider matrix.
+- Source patterns: fan-out, fan-in, and broadcast.
+- Context reuse through explicit caching, implicit caching where exposed, and
+  provider-managed prompt caching where available.
+- Structured outputs, tool calling, and conversation continuity.
 
-- Feature-parity layers that mask provider differences (example: automatic YouTube download/re-upload for OpenAI).
-- Conversation continuity (`history`, `continue_from`).
-- Deferred delivery via dedicated entry points (`defer()` / `defer_many()`).
+That means the roadmap should no longer be "more features by default." The bar
+for new work is now: does it make the existing contract more reliable or more
+usable without expanding Pollux into a framework?
 
-## Post-1.0 Candidates
+## Important Future Work
 
-- Conversation continuity with clear lifecycle semantics.
-- Optional lifecycle controls for provider-managed artifacts (for example, OpenAI uploaded files).
-- Expand/maintain the provider capability matrix as features evolve.
-- Selective parity adapters only when justified by user demand and maintenance cost.
+### 1. Provider Contract Hardening
+
+- Expand characterization and real API coverage for the highest-drift
+  boundaries: multimodal inputs, deferred lifecycle normalization, tool-call
+  continuations, reasoning metadata, and routed-provider variability.
+- Make capability drift easier to detect so the public capability docs stay
+  aligned with real provider behavior.
+- Keep unsupported combinations fail-fast, with concrete hints instead of
+  silent degradation.
+
+### 2. Deferred Delivery Operational Polish
+
+- Improve docs and cookbook coverage for the real deferred operating model:
+  handle persistence, polling cadence, collection, cancellation, partial
+  failure handling, and backfill-style workflows.
+- Keep the lifecycle intentionally small: submit, inspect, collect, cancel.
+  Prefer better guarantees and diagnostics over more deferred entry points.
+- Consider narrowly scoped controls for provider-owned deferred artifacts only
+  when they solve a real operational problem without turning Pollux into a
+  background job manager.
+
+### 3. API Simplification After v1.5
+
+- Remove or deprecate migration shims once they have served their purpose
+  (example: legacy `Options.delivery_mode` compatibility).
+- Keep the boundary between realtime and deferred execution explicit and hard
+  to misuse.
+- Continue pruning ambiguous naming and low-value convenience layers.
+
+### 4. Production Ergonomics for Core Patterns
+
+- Add stronger cookbook coverage for common production shapes: resume on
+  failure, structured extraction, tool loops, and provider switching where the
+  switch is truly one line.
+- Improve guidance for adopting Pollux correctly on the first try, especially
+  around caching, deferred delivery, and provider capability differences.
+- Favor examples and documentation that reduce downstream rework over new
+  abstractions in `src/pollux/`.
+
+### 5. Selective Expansion, Not Breadth for Breadth's Sake
+
+- Add new provider support or new capability surface only when it clearly
+  reinforces Pollux's core job: delivering prompts and sources, reusing
+  context, normalizing provider lifecycle behavior, and extracting stable
+  results.
+- Hold a high bar for parity adapters that mask provider differences and add
+  maintenance cost.
+- Prefer additive, low-policy features over broad "one API for everything"
+  designs.
+
+## High-Bar / Not Planned
+
+The following are intentionally outside Pollux's target shape unless a very
+strong case emerges:
+
+- Workflow schedulers, background workers, cron abstractions, or queue systems
+- Vector stores, retrieval frameworks, or document indexing pipelines
+- Agent runtimes, planning frameworks, or memory systems
+- Automatic parity layers that hide fundamental provider limitations
+- Provider-agnostic knobs for every provider-specific feature
+- Cross-job recovery systems that own application-level orchestration
 
 ## References
 
-- Provider-by-provider contract: `docs/reference/provider-capabilities.md`
+- Provider contract: `docs/reference/provider-capabilities.md`
+- Testing philosophy: `TESTING.md`
+- Contributor guidance: `docs/contributing.md`


### PR DESCRIPTION
## Summary

Refresh the README to present Pollux's shipped realtime and deferred entry points more clearly, including the deferred lifecycle docs. Rebuild the roadmap around the post-v1.5 state so it focuses on hardening, operational polish, API simplification, and explicit non-goals instead of stale v1.0 gates.

## Related issue

None

## Test plan

- `just check`
- `just docs-build`
- No new tests added; non-behavioral change (documentation only)

## Notes

The roadmap rewrite is intentionally scope-defensive: it keeps Pollux positioned as an orchestration layer and calls out high-bar / not-planned areas to guard against framework creep.
