### PR TITLE
feat(api): add Gemini video metadata controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ can wait, submit it once, persist the handle, and collect the same
 Say you have a document and ten questions about it. Each API call re-uploads the file, and you're left managing caching, retries, and concurrency yourself. Pollux uploads once, caches the content, fans out your prompts concurrently, and hands back results.
 
 The same `Source` interface handles PDFs, images, video, YouTube URLs, and arXiv papers. No per-format upload code.
+Gemini-specific video clipping and FPS controls are available via
+`Source.with_gemini_video_settings(...)`; see the sending-content docs for the
+intended scope.
 
 Need structured output? Pass a Pydantic model as `response_schema` and get a validated instance alongside the raw text. Switching providers is a one-line change: `provider="gemini"` to `provider="openai"`.
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -219,7 +219,7 @@ reuse the cached context automatically.
 ## Cache Identity
 
 For explicit caches, keys are deterministic:
-`hash(model + provider + api_key + system_instruction + tools + content hashes of sources)`.
+`hash(model + provider + api_key + system_instruction + tools + source identity hashes)`.
 
 This means:
 
@@ -232,6 +232,10 @@ This means:
   Pollux scopes explicit cache reuse to the provider account that created it.
 - **Different baked-in `system_instruction` or `tools`** → different cache
   keys. Changing the cached behavior contract creates a fresh cache entry.
+- **Different Gemini video settings** → different cache keys. Two sources with
+  the same content but different clip windows or FPS do not collapse to the
+  same cache entry. This applies only to Gemini, where those settings change
+  the provider-visible meaning of the source.
 - **Content changes** → new cache key. Editing a source file produces a fresh
   cache entry.
 

--- a/docs/portable-code.md
+++ b/docs/portable-code.md
@@ -125,6 +125,9 @@ asyncio.run(main())
    automatically. Gate these conditional optimizations on the provider name
    or handle them near the call site; see
    [Reducing Costs with Context Caching](caching.md#three-caching-paths).
+   The same rule applies to source helpers like
+   `Source.with_gemini_video_settings(...)`: keep them behind a Gemini branch
+   instead of trying to invent a fake cross-provider equivalent.
 
 3. **Write provider-agnostic functions.** `analyze_document` accepts a
    provider name and builds the config internally. The prompt, source, and

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -45,6 +45,9 @@ The primary execution functions are exported from `pollux`:
 
 ## Core Types
 
+`Source` includes both the generic source constructors and narrow
+provider-specific helpers such as `Source.with_gemini_video_settings(...)`.
+
 ::: pollux.Source
 
 ::: pollux.CacheHandle

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -46,6 +46,10 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - Explicit caching uses the Gemini Files API.
 - Deferred delivery uses the Gemini Batch API through Pollux's deferred entry
   points.
+- Video sources can carry Gemini-specific clipping and FPS controls via
+  `Source.with_gemini_video_settings(...)`.
+- Those controls are intentionally not normalized across providers. Pollux
+  keeps them explicit so portability decisions stay in caller code.
 - Gemini also caches repeated long prefixes automatically. Pollux does not
   expose a toggle for that path.
 - Gemini does not support `previous_response_id`; conversation state is

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -62,6 +62,49 @@ you do not need to specify format-specific options. For media sources (images,
 video, audio), keep prompts concrete: ask for objects, attributes, timestamps,
 or quoted text rather than open-ended descriptions.
 
+### Gemini Video Controls
+
+Gemini supports clip windows and custom frame sampling for video inputs. Pollux
+exposes these as an explicit Gemini-only source helper instead of a generic
+provider passthrough, so the public API stays stable even if Google's wire
+format changes.
+
+**Example: Gemini video clipping**
+
+```python
+import asyncio
+from pollux import Config, Source, run
+
+async def main() -> None:
+    config = Config(provider="gemini", model="gemini-2.5-flash-lite")
+    source = Source.from_file(
+        "lecture.mp4", mime_type="video/mp4"
+    ).with_gemini_video_settings(
+        start_offset="33m0s",
+        end_offset="34m10s",
+        fps=1.0,
+    )
+
+    result = await run(
+        "What claim does the lecturer make in this segment?",
+        source=source,
+        config=config,
+    )
+    print(result["answers"][0])
+
+asyncio.run(main())
+```
+
+Pollux validates these settings up front and maps them onto Gemini's current
+video-processing request shape internally. See the
+[Gemini video guide](https://ai.google.dev/gemini-api/docs/video-understanding)
+for the current provider behavior.
+
+Use this helper only when you have consciously chosen Gemini as the provider.
+On non-Gemini providers, the source still works as a normal video source, but
+the Gemini-specific controls are ignored rather than translated to another
+provider-specific feature.
+
 ## Single Prompt: `run()`
 
 Start with the simplest case: one prompt, one source, one answer.

--- a/src/pollux/cache.py
+++ b/src/pollux/cache.py
@@ -73,11 +73,11 @@ def compute_cache_key(
     system_instruction: str | None = None,
     tools: list[dict[str, Any]] | list[Any] | None = None,
 ) -> str:
-    """Compute deterministic cache key using content hashes.
+    """Compute deterministic cache key using source identity hashes.
 
-    Key = hash(model + provider + api_key + system + content digests of sources).
-    Including ``api_key`` prevents cross-account handle reuse when multiple
-    keys for the same provider/model coexist in one process.
+    Key = hash(model + provider + api_key + system + source identity digests).
+    Including ``api_key`` prevents cross-account handle reuse when multiple keys
+    for the same provider/model coexist in one process.
     """
     parts = [model]
     if provider:
@@ -99,8 +99,7 @@ def compute_cache_key(
             ) from e
 
     for source in sources:
-        # Use content hash, not identifier
-        parts.append(source.content_hash())
+        parts.append(source.cache_identity_hash(provider=provider))
 
     combined = "|".join(parts)
     return hashlib.sha256(combined.encode()).hexdigest()[:32]
@@ -187,24 +186,34 @@ async def _resolve_file_parts(
             and isinstance(part.get("mime_type"), str)
         ):
             fp, mt = part["file_path"], part["mime_type"]
+            provider_hints = part.get("provider_hints")
             key = (fp, mt)
             if key in seen:
-                resolved.append(seen[key])
-                continue
-            if retry_policy.max_attempts <= 1:
-                asset = await provider.upload_file(Path(fp), mt)
+                asset = seen[key]
             else:
+                if retry_policy.max_attempts <= 1:
+                    asset = await provider.upload_file(Path(fp), mt)
+                else:
 
-                async def _upload(_fp: str = fp, _mt: str = mt) -> Any:
-                    return await provider.upload_file(Path(_fp), _mt)
+                    async def _upload(_fp: str = fp, _mt: str = mt) -> Any:
+                        return await provider.upload_file(Path(_fp), _mt)
 
-                asset = await retry_async(
-                    _upload,
-                    policy=retry_policy,
-                    should_retry=should_retry_side_effect,
+                    asset = await retry_async(
+                        _upload,
+                        policy=retry_policy,
+                        should_retry=should_retry_side_effect,
+                    )
+                seen[key] = asset
+            if provider_hints is not None:
+                resolved.append(
+                    {
+                        "uri": asset.file_id,
+                        "mime_type": mt,
+                        "provider_hints": provider_hints,
+                    }
                 )
-            seen[key] = asset
-            resolved.append(asset)
+            else:
+                resolved.append(asset)
         else:
             resolved.append(part)
     return resolved
@@ -285,7 +294,7 @@ async def create_cache_impl(
             expires_at=expires_at,
         )
 
-    raw_parts = build_shared_parts(src_tuple)
+    raw_parts = build_shared_parts(src_tuple, provider=config.provider)
 
     result = await get_or_create_cache(
         provider,

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -450,6 +450,7 @@ async def _substitute_upload_parts(
         ):
             file_path = part["file_path"]
             mime_type = part["mime_type"]
+            provider_hints = part.get("provider_hints")
             cache_key = (file_path, mime_type)
 
             async def _work(
@@ -473,7 +474,7 @@ async def _substitute_upload_parts(
                     ) from e
 
             try:
-                uri = await singleflight_cached(
+                asset = await singleflight_cached(
                     cache_key,
                     lock=upload_lock,
                     inflight=upload_inflight,
@@ -484,9 +485,17 @@ async def _substitute_upload_parts(
             except APIError as e:
                 raise _with_call_idx(e, call_idx) from e
 
-            # Instead of appending a {"uri": ...} dict, we append the object itself
-            # The provider's _normalize_input_parts logic will reconstruct the SDK payload.
-            resolved.append(uri)
+            # The provider adapter reconstructs the SDK payload from the uploaded asset.
+            if provider_hints is not None:
+                resolved.append(
+                    {
+                        "uri": asset.file_id,
+                        "mime_type": mime_type,
+                        "provider_hints": provider_hints,
+                    }
+                )
+            else:
+                resolved.append(asset)
             continue
 
         resolved.append(part)

--- a/src/pollux/plan.py
+++ b/src/pollux/plan.py
@@ -35,7 +35,7 @@ def build_plan(request: Request) -> Plan:
     before any network I/O.
     """
     sources = request.sources
-    shared_parts = build_shared_parts(sources)
+    shared_parts = build_shared_parts(sources, provider=request.config.provider)
 
     cache_name: str | None = None
     if request.options.cache is not None:
@@ -102,11 +102,17 @@ def build_plan(request: Request) -> Plan:
     )
 
 
-def build_shared_parts(sources: tuple[Source, ...]) -> list[Any]:
+def build_shared_parts(
+    sources: tuple[Source, ...],
+    *,
+    provider: str | None = None,
+) -> list[Any]:
     """Convert sources to API parts."""
     parts: list[Any] = []
 
     for source in sources:
+        provider_hints = source.provider_hints_for(provider)
+
         if source.source_type in {"text", "json"}:
             # Load text content
             try:
@@ -122,11 +128,18 @@ def build_shared_parts(sources: tuple[Source, ...]) -> list[Any]:
                 ) from e
         elif source.source_type == "file":
             # File placeholder - will be uploaded during execution
-            parts.append(
-                {"file_path": source.identifier, "mime_type": source.mime_type}
-            )
+            part: dict[str, Any] = {
+                "file_path": source.identifier,
+                "mime_type": source.mime_type,
+            }
+            if provider_hints is not None:
+                part["provider_hints"] = provider_hints
+            parts.append(part)
         else:
             # URI-based sources
-            parts.append({"uri": source.identifier, "mime_type": source.mime_type})
+            part = {"uri": source.identifier, "mime_type": source.mime_type}
+            if provider_hints is not None:
+                part["provider_hints"] = provider_hints
+            parts.append(part)
 
     return parts

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -35,6 +35,58 @@ logger = logging.getLogger(__name__)
 _GEMINI_BATCH_INLINE_LIMIT_BYTES = 20_000_000
 
 
+def _provider_hint_payload(
+    part: dict[str, Any], *, name: str
+) -> dict[str, str | float] | None:
+    """Extract one provider hint payload from a transport part."""
+    provider_hints = part.get("provider_hints")
+    if provider_hints is None:
+        return None
+    if not isinstance(provider_hints, dict):
+        raise APIError("Provider hints must be a dictionary")
+    payload = provider_hints.get(name)
+    if payload is None:
+        return None
+    if not isinstance(payload, dict) or not payload:
+        raise APIError(f"Provider hint {name!r} must be a non-empty dictionary")
+    return payload
+
+
+def _build_video_metadata(part: dict[str, Any], *, mime_type: str | None) -> Any:
+    """Build Gemini SDK video metadata from Pollux's validated source settings.
+
+    Values are already validated by ``Source.with_gemini_video_settings``.
+    This function only translates them to the SDK type; the ``try/except``
+    catches any SDK-level rejection as a safety net.
+    """
+    from google.genai import types
+
+    settings = _provider_hint_payload(part, name="video_metadata")
+    if settings is None:
+        return None
+    if not isinstance(mime_type, str) or not mime_type.startswith("video/"):
+        raise APIError("Gemini video settings can only be attached to video parts")
+
+    # Extract with type narrowing — values are pre-validated by Source.
+    start = settings.get("start_offset")
+    end = settings.get("end_offset")
+    fps = settings.get("fps")
+    try:
+        return types.VideoMetadata(
+            start_offset=start if isinstance(start, str) else None,
+            end_offset=end if isinstance(end, str) else None,
+            fps=float(fps) if isinstance(fps, (int, float)) else None,
+        )
+    except Exception as e:
+        raise APIError(
+            "Invalid Gemini video settings",
+            hint=(
+                "Use Source.with_gemini_video_settings("
+                "start_offset=..., end_offset=..., fps=...)"
+            ),
+        ) from e
+
+
 class GeminiProvider:
     """Google Gemini API provider."""
 
@@ -91,20 +143,31 @@ class GeminiProvider:
                     )
                 )
             elif isinstance(p, dict):
-                # Handle URI-based parts (after upload)
+                # Handle URI-based parts (including uploaded assets with video settings)
                 if "uri" in p and "mime_type" in p:
                     converted.append(
                         types.Part(
                             file_data=types.FileData(
                                 file_uri=p["uri"], mime_type=p["mime_type"]
-                            )
+                            ),
+                            video_metadata=_build_video_metadata(
+                                p, mime_type=p["mime_type"]
+                            ),
                         )
                     )
                 # Handle text parts in dict
                 elif "text" in p:
+                    if _provider_hint_payload(p, name="video_metadata") is not None:
+                        raise APIError(
+                            "Gemini video settings require a video file or URI part"
+                        )
                     converted.append(p["text"])
                 else:
                     # Fallback for other dicts, though we should likely validate
+                    if _provider_hint_payload(p, name="video_metadata") is not None:
+                        raise APIError(
+                            "Gemini video settings require a video file or URI part"
+                        )
                     converted.append(p)
             else:
                 converted.append(p)
@@ -581,6 +644,7 @@ class GeminiProvider:
             ):
                 file_path = part["file_path"]
                 mime_type = part["mime_type"]
+                provider_hints = part.get("provider_hints")
                 cache_key = (file_path, mime_type)
                 asset = upload_cache.get(cache_key)
                 if asset is None:
@@ -588,7 +652,16 @@ class GeminiProvider:
 
                     asset = await self.upload_file(Path(file_path), mime_type)
                     upload_cache[cache_key] = asset
-                resolved_parts.append(asset)
+                if provider_hints is not None:
+                    resolved_parts.append(
+                        {
+                            "uri": asset.file_id,
+                            "mime_type": mime_type,
+                            "provider_hints": provider_hints,
+                        }
+                    )
+                else:
+                    resolved_parts.append(asset)
             else:
                 resolved_parts.append(part)
 

--- a/src/pollux/source.py
+++ b/src/pollux/source.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable  # noqa: TC003 - used at runtime in dataclass
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import hashlib
 import json
 import mimetypes
@@ -23,6 +23,19 @@ _ARXIV_ID_RE = re.compile(
 
 
 @dataclass(frozen=True, slots=True)
+class ProviderHint:
+    """Immutable provider-scoped source extension."""
+
+    provider: str
+    name: str
+    payload: tuple[tuple[str, str | float], ...]
+
+    def payload_dict(self) -> dict[str, str | float]:
+        """Convert the immutable payload back to a dictionary."""
+        return dict(self.payload)
+
+
+@dataclass(frozen=True, slots=True)
 class Source:
     """A structured representation of a single input source."""
 
@@ -31,6 +44,7 @@ class Source:
     mime_type: str
     size_bytes: int
     content_loader: Callable[[], bytes]
+    provider_hints: tuple[ProviderHint, ...] = ()
 
     @classmethod
     def from_text(cls, text: str, *, identifier: str | None = None) -> Source:
@@ -185,7 +199,144 @@ class Source:
 
         return f"https://arxiv.org/pdf/{arxiv_id}.pdf"
 
-    def content_hash(self) -> str:
-        """Compute SHA256 hash of content for cache identity."""
+    def _content_hash(self) -> str:
+        """Compute SHA256 hash of raw content bytes."""
         content = self.content_loader()
         return hashlib.sha256(content).hexdigest()
+
+    def gemini_video_settings_for(
+        self, provider: str | None
+    ) -> dict[str, str | float] | None:
+        """Return Gemini video settings when the active provider can use them."""
+        provider_hints = self.provider_hints_for(provider)
+        if provider_hints is None:
+            return None
+        return provider_hints.get("video_metadata")
+
+    def provider_hints_for(
+        self, provider: str | None
+    ) -> dict[str, dict[str, str | float]] | None:
+        """Return immutable provider hints as plain dictionaries for transport."""
+        if provider is None:
+            return None
+
+        hints = {
+            hint.name: hint.payload_dict()
+            for hint in self.provider_hints
+            if hint.provider == provider
+        }
+        return hints or None
+
+    def cache_identity_hash(self, *, provider: str | None = None) -> str:
+        """Compute SHA256 hash for cache identity.
+
+        Includes provider-visible source semantics such as Gemini video settings.
+        Falls back to raw content hash when no provider-specific settings apply,
+        preserving backward-compatible cache keys.
+        """
+        provider_hints = self.provider_hints_for(provider)
+        if provider_hints is None:
+            return self._content_hash()
+        combined = (
+            self._content_hash()
+            + "|"
+            + json.dumps(
+                provider_hints,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        return hashlib.sha256(combined.encode("utf-8")).hexdigest()
+
+    def with_gemini_video_settings(
+        self,
+        *,
+        start_offset: str | None = None,
+        end_offset: str | None = None,
+        fps: float | None = None,
+    ) -> Source:
+        """Return a copy with validated Gemini video controls attached.
+
+        Pollux keeps this API provider-specific and stable even if Google's
+        underlying wire fields evolve. The Gemini adapter maps these settings
+        to the current SDK request shape. These settings only affect Gemini
+        requests and Gemini explicit-cache identity.
+        """
+        if not self._is_video_source():
+            raise SourceError(
+                "Gemini video settings require a video source "
+                "(local video file, video URI, or YouTube URL)"
+            )
+
+        validated_start_offset: str | None = None
+        validated_end_offset: str | None = None
+        validated_fps: float | None = None
+
+        if start_offset is not None:
+            if not isinstance(start_offset, str) or not start_offset.strip():
+                raise SourceError("start_offset must be a non-empty string")
+            validated_start_offset = start_offset
+
+        if end_offset is not None:
+            if not isinstance(end_offset, str) or not end_offset.strip():
+                raise SourceError("end_offset must be a non-empty string")
+            validated_end_offset = end_offset
+
+        if fps is not None:
+            if isinstance(fps, bool) or not isinstance(fps, (int, float)):
+                raise SourceError("fps must be a number")
+            fps_value = float(fps)
+            if fps_value <= 0 or fps_value > 24:
+                raise SourceError("fps must be > 0 and <= 24")
+            validated_fps = fps_value
+
+        if (
+            validated_start_offset is None
+            and validated_end_offset is None
+            and validated_fps is None
+        ):
+            raise SourceError(
+                "Provide at least one Gemini video setting: "
+                "start_offset, end_offset, or fps"
+            )
+
+        return replace(
+            self,
+            provider_hints=self._with_provider_hint(
+                provider="gemini",
+                name="video_metadata",
+                payload={
+                    k: v
+                    for k, v in (
+                        ("start_offset", validated_start_offset),
+                        ("end_offset", validated_end_offset),
+                        ("fps", validated_fps),
+                    )
+                    if v is not None
+                },
+            ),
+        )
+
+    def _is_video_source(self) -> bool:
+        """Return True when Gemini video controls can apply to this source."""
+        return self.source_type == "youtube" or self.mime_type.startswith("video/")
+
+    def _with_provider_hint(
+        self,
+        *,
+        provider: str,
+        name: str,
+        payload: dict[str, str | float],
+    ) -> tuple[ProviderHint, ...]:
+        """Return provider hints with one named hint replaced or added."""
+        hint = ProviderHint(
+            provider=provider,
+            name=name,
+            payload=tuple(sorted(payload.items())),
+        )
+        existing = tuple(
+            item
+            for item in self.provider_hints
+            if not (item.provider == provider and item.name == name)
+        )
+        return (*existing, hint)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -714,6 +714,37 @@ async def test_file_placeholders_are_uploaded_before_generate(
 
 
 @pytest.mark.asyncio
+async def test_gemini_video_settings_survive_upload_substitution(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Gemini video settings should survive the file upload substitution step."""
+    fake = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+
+    video_path = tmp_path / "lecture.mp4"
+    video_path.write_bytes(b"fake-mp4")
+    source = Source.from_file(
+        video_path, mime_type="video/mp4"
+    ).with_gemini_video_settings(start_offset="10s", end_offset="20s", fps=1.0)
+
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+    await pollux.run_many(("Describe the clip",), sources=(source,), config=cfg)
+
+    assert fake.last_parts is not None
+    part = fake.last_parts[0]
+    assert isinstance(part, dict)
+    assert "uri" in part
+    assert part["mime_type"] == "video/mp4"
+    assert part["provider_hints"] == {
+        "video_metadata": {
+            "start_offset": "10s",
+            "end_offset": "20s",
+            "fps": 1.0,
+        }
+    }
+
+
+@pytest.mark.asyncio
 async def test_upload_single_flight_propagates_failure_and_can_recover(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
@@ -1191,6 +1222,37 @@ def test_cache_identity_uses_content_digest_not_identifier_only() -> None:
         compute_cache_key(model, (uri_b,)),
     ]
     assert len(set(keys)) == len(keys)
+
+
+def test_cache_identity_varies_with_gemini_video_settings() -> None:
+    """Different Gemini video settings should produce distinct cache keys."""
+    base = Source.from_youtube("https://www.youtube.com/watch?v=video-a")
+    clip_a = base.with_gemini_video_settings(
+        start_offset="10s", end_offset="20s", fps=1.0
+    )
+    clip_b = base.with_gemini_video_settings(
+        start_offset="30s", end_offset="40s", fps=1.0
+    )
+
+    key_a = compute_cache_key(GEMINI_MODEL, (clip_a,), provider="gemini")
+    key_b = compute_cache_key(GEMINI_MODEL, (clip_b,), provider="gemini")
+
+    assert key_a != key_b
+
+
+def test_cache_identity_ignores_gemini_video_settings_for_other_providers() -> None:
+    """Gemini-only video settings should not fragment non-Gemini cache identities."""
+    base = Source.from_youtube("https://www.youtube.com/watch?v=video-a")
+    gemini_only = base.with_gemini_video_settings(fps=1.0)
+    plain = Source.from_youtube("https://www.youtube.com/watch?v=video-a")
+
+    gemini_key = compute_cache_key(GEMINI_MODEL, (gemini_only,), provider="gemini")
+    plain_gemini_key = compute_cache_key(GEMINI_MODEL, (plain,), provider="gemini")
+    openai_key = compute_cache_key(OPENAI_MODEL, (gemini_only,), provider="openai")
+    plain_openai_key = compute_cache_key(OPENAI_MODEL, (plain,), provider="openai")
+
+    assert gemini_key != plain_gemini_key
+    assert openai_key == plain_openai_key
 
 
 @pytest.mark.parametrize(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -513,6 +513,50 @@ async def test_gemini_generate_passes_thinking_level_from_reasoning_effort() -> 
 
 
 @pytest.mark.asyncio
+async def test_gemini_generate_attaches_video_metadata_from_source_settings() -> None:
+    """Gemini adapter should interpret Pollux's explicit Gemini video settings."""
+    captured: dict[str, Any] = {}
+
+    async def fake_generate_content(**kwargs: Any) -> Any:
+        captured["contents"] = kwargs.get("contents")
+        return MagicMock(text="ok", parsed=None, usage_metadata=None)
+
+    provider = GeminiProvider("test-key")
+    fake_models = MagicMock()
+    fake_models.generate_content = fake_generate_content
+    fake_aio = MagicMock()
+    fake_aio.models = fake_models
+    provider._client = MagicMock()
+    provider._client.aio = fake_aio
+
+    await provider.generate(
+        ProviderRequest(
+            model=GEMINI_MODEL,
+            parts=[
+                {
+                    "uri": "https://example.test/files/uploaded_video",
+                    "mime_type": "video/mp4",
+                    "provider_hints": {
+                        "video_metadata": {
+                            "start_offset": "40s",
+                            "end_offset": "80s",
+                            "fps": 1.0,
+                        },
+                    },
+                },
+                "Describe this clip.",
+            ],
+        )
+    )
+
+    contents = captured["contents"]
+    assert contents[0].file_data.file_uri == "https://example.test/files/uploaded_video"
+    assert contents[0].video_metadata.start_offset == "40s"
+    assert contents[0].video_metadata.end_offset == "80s"
+    assert contents[0].video_metadata.fps == 1.0
+
+
+@pytest.mark.asyncio
 async def test_gemini_strips_additional_properties_from_tool_schemas() -> None:
     """Gemini rejects additionalProperties; Pollux should strip it."""
     captured: dict[str, Any] = {}
@@ -690,6 +734,54 @@ async def test_gemini_upload_raises_on_failed_processing(tmp_path: Any) -> None:
 
     assert files.upload_calls == 1
     assert files.get_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_gemini_create_cache_attaches_video_metadata_from_source_settings() -> (
+    None
+):
+    """Gemini cache creation should interpret explicit Gemini video settings."""
+    captured: dict[str, Any] = {}
+
+    async def fake_create(*, model: str, config: Any) -> Any:
+        captured["model"] = model
+        captured["config"] = config
+        return type("CacheResult", (), {"name": "cachedContents/video"})()
+
+    provider = GeminiProvider("test-key")
+    fake_caches = MagicMock()
+    fake_caches.create = fake_create
+    fake_aio = MagicMock()
+    fake_aio.caches = fake_caches
+    provider._client = MagicMock()
+    provider._client.aio = fake_aio
+
+    await provider.create_cache(
+        model=GEMINI_MODEL,
+        parts=[
+            {
+                "uri": "https://www.youtube.com/watch?v=9hE5-98ZeCg",
+                "mime_type": "video/mp4",
+                "provider_hints": {
+                    "video_metadata": {
+                        "start_offset": "40s",
+                        "end_offset": "80s",
+                        "fps": 1.0,
+                    },
+                },
+            }
+        ],
+    )
+
+    assert captured["model"] == GEMINI_MODEL
+    contents = captured["config"].contents
+    assert len(contents) == 1
+    assert (
+        contents[0].file_data.file_uri == "https://www.youtube.com/watch?v=9hE5-98ZeCg"
+    )
+    assert contents[0].video_metadata.start_offset == "40s"
+    assert contents[0].video_metadata.end_offset == "80s"
+    assert contents[0].video_metadata.fps == 1.0
 
 
 # =============================================================================
@@ -2038,6 +2130,55 @@ async def test_gemini_submit_deferred_characterizes_inlined_batch_request(
         src[1].contents[0].file_data.file_uri
         == "https://example.test/files/uploaded_pdf"
     )
+
+
+@pytest.mark.asyncio
+async def test_gemini_submit_deferred_preserves_video_settings(
+    tmp_path: Path,
+) -> None:
+    """Deferred Gemini requests should preserve video settings through upload."""
+    video_path = tmp_path / "lecture.mp4"
+    video_path.write_bytes(b"fake-mp4")
+
+    files = _FakeGeminiFilesClient()
+    batches = _FakeGeminiBatchesClient()
+    provider = GeminiProvider("test-key")
+    provider._client = _make_gemini_client(files=files, batches=batches)
+
+    await provider.submit_deferred(
+        [
+            ProviderRequest(
+                model=GEMINI_MODEL,
+                parts=[
+                    {
+                        "file_path": str(video_path),
+                        "mime_type": "video/mp4",
+                        "provider_hints": {
+                            "video_metadata": {
+                                "start_offset": "40s",
+                                "end_offset": "80s",
+                                "fps": 1.0,
+                            },
+                        },
+                    },
+                    "Describe this clip",
+                ],
+            ),
+        ],
+        request_ids=["pollux-000000"],
+    )
+
+    assert batches.create_kwargs is not None
+    src = batches.create_kwargs["src"]
+    assert len(src) == 1
+    # URI comes from the fake files client's fixed fixture value.
+    assert (
+        src[0].contents[0].file_data.file_uri
+        == "https://example.test/files/uploaded_pdf"
+    )
+    assert src[0].contents[0].video_metadata.start_offset == "40s"
+    assert src[0].contents[0].video_metadata.end_offset == "80s"
+    assert src[0].contents[0].video_metadata.fps == 1.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -61,3 +61,89 @@ def test_source_from_arxiv_rejects_non_arxiv_urls() -> None:
     """Only arxiv.org URLs should be accepted."""
     with pytest.raises(SourceError):
         Source.from_arxiv("https://example.com/abs/1706.03762")
+
+
+def test_with_gemini_video_settings_stores_validated_settings() -> None:
+    """Gemini video settings should be stored and re-exposed for Gemini only."""
+    source = Source.from_youtube(
+        "https://www.youtube.com/watch?v=abc123"
+    ).with_gemini_video_settings(start_offset="10s", end_offset="20s", fps=1.0)
+
+    assert source.gemini_video_settings_for("gemini") == {
+        "start_offset": "10s",
+        "end_offset": "20s",
+        "fps": 1.0,
+    }
+
+
+def test_gemini_video_settings_for_scopes_to_gemini_provider() -> None:
+    """Gemini video settings should only affect Gemini requests."""
+    source = Source.from_youtube(
+        "https://www.youtube.com/watch?v=abc123"
+    ).with_gemini_video_settings(fps=1.0)
+
+    assert source.gemini_video_settings_for("gemini") == {"fps": 1.0}
+    assert source.gemini_video_settings_for("openai") is None
+    assert source.gemini_video_settings_for(None) is None
+
+
+def test_with_gemini_video_settings_rejects_non_video_source() -> None:
+    """Gemini video settings should fail fast on non-video sources."""
+    source = Source.from_text("hello")
+    with pytest.raises(SourceError, match="video source"):
+        source.with_gemini_video_settings(fps=1.0)
+
+
+def test_with_gemini_video_settings_requires_at_least_one_value() -> None:
+    """An empty Gemini video settings payload should be rejected."""
+    source = Source.from_youtube("https://www.youtube.com/watch?v=abc123")
+    with pytest.raises(SourceError, match="Provide at least one"):
+        source.with_gemini_video_settings()
+
+
+@pytest.mark.parametrize("bad_fps", [0, -1, 25, True, "fast"])
+def test_with_gemini_video_settings_rejects_invalid_fps(bad_fps: Any) -> None:
+    """fps should be validated before any provider call is attempted."""
+    source = Source.from_youtube("https://www.youtube.com/watch?v=abc123")
+    with pytest.raises(SourceError, match="fps"):
+        source.with_gemini_video_settings(fps=bad_fps)
+
+
+def test_with_gemini_video_settings_requires_non_empty_offsets() -> None:
+    """Offsets should fail fast when blank."""
+    source = Source.from_youtube("https://www.youtube.com/watch?v=abc123")
+    with pytest.raises(SourceError, match="start_offset"):
+        source.with_gemini_video_settings(start_offset="  ")
+    with pytest.raises(SourceError, match="end_offset"):
+        source.with_gemini_video_settings(end_offset="")
+
+
+def test_with_gemini_video_settings_does_not_mutate_original() -> None:
+    """with_gemini_video_settings returns a new Source; the original is unchanged."""
+    original = Source.from_youtube("https://www.youtube.com/watch?v=abc123")
+    modified = original.with_gemini_video_settings(fps=1.0)
+
+    assert original.gemini_video_settings_for("gemini") is None
+    assert modified.gemini_video_settings_for("gemini") == {"fps": 1.0}
+
+
+def test_with_gemini_video_settings_preserves_source_hashability() -> None:
+    """Configured sources should remain hashable like other frozen sources."""
+    source = Source.from_youtube(
+        "https://www.youtube.com/watch?v=abc123"
+    ).with_gemini_video_settings(fps=1.0)
+
+    assert isinstance(hash(source), int)
+
+
+def test_with_gemini_video_settings_returns_copied_payloads() -> None:
+    """Returned payload dicts should be detached from the stored source state."""
+    source = Source.from_youtube(
+        "https://www.youtube.com/watch?v=abc123"
+    ).with_gemini_video_settings(fps=1.0)
+
+    payload = source.gemini_video_settings_for("gemini")
+    assert payload is not None
+    payload["fps"] = 99.0
+
+    assert source.gemini_video_settings_for("gemini") == {"fps": 1.0}


### PR DESCRIPTION
## Summary

Add `Source.with_gemini_video_settings(start_offset, end_offset, fps)` for Gemini-specific video clipping and frame sampling. Settings are stored as generic provider hints so Gemini-isms stay behind a uniform wall in the core model, threaded through the pipeline, and materialized only in the Gemini adapter.

## Related issue

None

## Test plan

Three test boundaries exercised, all passing via `just check`:

- **Source boundary** (`test_source.py`): validation (non-video rejection, invalid fps, blank offsets, at-least-one-value), provider scoping (Gemini returns settings, OpenAI/None return None), immutability, hashability, and payload isolation
- **Pipeline boundary** (`test_pipeline.py`): video settings survive upload substitution end-to-end; cache identity varies with Gemini video settings but stays stable for non-Gemini providers
- **Provider characterization** (`test_providers.py`): Gemini adapter attaches `VideoMetadata` to generate, create_cache, and deferred submission paths

Docs build verified clean (`just docs-build`).

## Notes

- `ProviderHint` is intentionally generic rather than a typed `GeminiVideoSettings` field on Source. This keeps provider-specific concerns behind a uniform wall and prevents Gemini-isms from drifting into the core model over time.
- `content_hash()` was made private (`_content_hash()`) since callers should use `cache_identity_hash()` which incorporates provider context.
- The Gemini adapter trusts Source-level validation and only does type narrowing (not full re-validation) before passing values to the SDK.