### PR TITLE
feat(core): add reasoning budget tokens

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,8 +149,8 @@ options = Options(
 | `tools` | `list[dict] \| None` | `None` | JSON schemas for native tools. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 | `tool_choice` | `str \| dict \| None` | `None` | Tool execution strategy. See [Building an Agent Loop](agent-loop.md) |
 | `response_schema` | `type[BaseModel] \| dict` | `None` | Expected JSON response format. See [Extracting Structured Data](structured-data.md) |
-| `reasoning_effort` | `str \| None` | `None` | Controls model thinking depth. See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints) |
-| `reasoning_budget_tokens` | `int \| None` | `None` | Explicit reasoning token budget where supported. Mutually exclusive with `reasoning_effort`. See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints) |
+| `reasoning_effort` | `str \| None` | `None` | Controls model thinking depth. See [Writing Portable Code Across Providers](portable-code.md#choosing-a-reasoning-control) |
+| `reasoning_budget_tokens` | `int \| None` | `None` | Explicit reasoning token budget where supported. Mutually exclusive with `reasoning_effort`. See [Writing Portable Code Across Providers](portable-code.md#choosing-a-reasoning-control) |
 | `max_tokens` | `int \| None` | `None` | Output-token cap with provider-specific semantics. Anthropic applies provider defaults when omitted; other providers may ignore it. See [Provider Capabilities](reference/provider-capabilities.md) |
 | `history` | `list[dict] \| None` | `None` | Conversation history. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 | `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
@@ -168,9 +168,9 @@ options = Options(
     `reasoning_effort` and `reasoning_budget_tokens` are mutually exclusive.
     Use `reasoning_effort` when the provider exposes named levels
     (`"low"`, `"medium"`, `"high"`). Use `reasoning_budget_tokens` when you
-    need an exact token ceiling, for example `reasoning_budget_tokens=0` to
-    disable thinking on Gemini 2.5 Flash. Not every provider accepts both;
-    see [Reasoning Control Mapping](portable-code.md#reasoning-control-mapping).
+    need an exact token ceiling. Not every provider accepts both, and some
+    provider/model combinations may still reject a value at call time; see
+    [Reasoning Control Mapping](portable-code.md#reasoning-control-mapping).
 
 !!! note
     `max_tokens` is not a portable "length knob" with identical behavior

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,6 +135,7 @@ options = Options(
     tool_choice="auto",               # Tool calling mode ('auto', 'required', 'none', or dict)
     response_schema=MyPydanticModel,  # Structured output extraction
     reasoning_effort="medium",        # Controls model thinking depth
+    # reasoning_budget_tokens=0,      # Explicit reasoning token budget where supported
     max_tokens=4096,                  # Provider-specific output cap
     implicit_caching=True,            # Auto-cache prefix (Anthropic only)
 )
@@ -149,6 +150,7 @@ options = Options(
 | `tool_choice` | `str \| dict \| None` | `None` | Tool execution strategy. See [Building an Agent Loop](agent-loop.md) |
 | `response_schema` | `type[BaseModel] \| dict` | `None` | Expected JSON response format. See [Extracting Structured Data](structured-data.md) |
 | `reasoning_effort` | `str \| None` | `None` | Controls model thinking depth. See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints) |
+| `reasoning_budget_tokens` | `int \| None` | `None` | Explicit reasoning token budget where supported. Mutually exclusive with `reasoning_effort`. See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints) |
 | `max_tokens` | `int \| None` | `None` | Output-token cap with provider-specific semantics. Anthropic applies provider defaults when omitted; other providers may ignore it. See [Provider Capabilities](reference/provider-capabilities.md) |
 | `history` | `list[dict] \| None` | `None` | Conversation history. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 | `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
@@ -161,6 +163,14 @@ options = Options(
     Older OpenAI models (for example `gpt-4.1-nano`) still accept them.
     See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints)
     for the full constraints mapping.
+
+!!! note
+    `reasoning_effort` and `reasoning_budget_tokens` are mutually exclusive.
+    Use `reasoning_effort` when the provider exposes named levels
+    (`"low"`, `"medium"`, `"high"`). Use `reasoning_budget_tokens` when you
+    need an exact token ceiling, for example `reasoning_budget_tokens=0` to
+    disable thinking on Gemini 2.5 Flash. Not every provider accepts both;
+    see [Reasoning Control Mapping](portable-code.md#reasoning-control-mapping).
 
 !!! note
     `max_tokens` is not a portable "length knob" with identical behavior

--- a/docs/portable-code.md
+++ b/docs/portable-code.md
@@ -157,19 +157,32 @@ options = Options(temperature=0.8, top_p=0.9)
 options = Options(reasoning_effort="medium")
 ```
 
-### Gemini 2.5 and Reasoning Controls
+### Choosing a Reasoning Control
 
-Gemini 2.x models use dynamic reasoning internally but do not accept the
-`reasoning_effort` option directly. Setting it on a `gemini-2.5` model
-results in a provider error. Gemini 3 models (`gemini-3-flash-preview`)
-do accept reasoning controls.
+Pollux exposes two reasoning knobs, and they are mutually exclusive:
+
+- `reasoning_effort` takes named levels (`"low"`, `"medium"`, `"high"`, and
+  provider-specific extras).
+- `reasoning_budget_tokens` takes an explicit integer ceiling.
+
+Pick `reasoning_effort` on providers that expose named levels (OpenAI GPT-5,
+Gemini 3.x, Claude 4.x). Pick `reasoning_budget_tokens` on providers that only
+accept a budget (Gemini 2.5), or when you need exact control such as
+disabling thinking entirely on a model that allows it.
 
 ```python
-# Works with Gemini 3 models
+# Name an effort level on a provider that accepts one.
 result = await run(
     "Solve this step by step...",
     config=Config(provider="gemini", model="gemini-3-flash-preview"),
     options=Options(reasoning_effort="high"),
+)
+
+# Disable thinking on Gemini 2.5 Flash with an explicit budget of zero.
+result = await run(
+    "Reply with exactly OK.",
+    config=Config(provider="gemini", model="gemini-2.5-flash"),
+    options=Options(reasoning_budget_tokens=0),
 )
 
 if "reasoning" in result:
@@ -178,15 +191,19 @@ if "reasoning" in result:
             print("Thinking:", text)
 ```
 
+Provider minimums vary: Anthropic requires at least 1024 tokens and Gemini 2.5
+Pro requires at least 128. A budget that sits below a provider's floor surfaces
+as a provider error at call time.
+
 ### Reasoning Control Mapping
 
-| Provider | Model Family | Valid `reasoning_effort` values | Provider Behavior |
-| --- | --- | --- | --- |
-| **OpenAI** | `gpt-5` family | `"low"`, `"medium"`, `"high"` | Returns a reasoning summary |
-| **Gemini** | `gemini-3` family | `"low"`, `"medium"`, `"high"`, `"minimal"` | Returns full thinking text |
-| **Gemini** | `gemini-2.5` family | *N/A (raises error)* | *N/A* |
-| **Anthropic** | `claude-4.x` family | `"low"`, `"medium"`, `"high"`, `"max"` (Opus 4.6 only) | Returns thinking text and preserves replay blocks for tool loops |
-| **OpenRouter** | reasoning-capable models | Model-dependent | Returns reasoning text |
+| Provider | Model Family | `reasoning_effort` | `reasoning_budget_tokens` | Provider Behavior |
+| --- | --- | --- | --- | --- |
+| **OpenAI** | `gpt-5` family | `"low"`, `"medium"`, `"high"` | ❌ | Returns a reasoning summary |
+| **Gemini** | `gemini-3` family | `"low"`, `"medium"`, `"high"`, `"minimal"` | ✅ | Returns full thinking text |
+| **Gemini** | `gemini-2.5` family | ❌ | ✅ | Uses provider-native thinking budgets |
+| **Anthropic** | `claude-4.x` family | `"low"`, `"medium"`, `"high"`, `"max"` (Opus 4.6 only) | ✅ | Returns thinking text and preserves replay blocks for tool loops |
+| **OpenRouter** | reasoning-capable models | Model-dependent | ❌ | Returns reasoning text |
 
 ## Variations
 

--- a/docs/portable-code.md
+++ b/docs/portable-code.md
@@ -46,7 +46,7 @@ from dataclasses import dataclass
 
 from pydantic import BaseModel
 
-from pollux import Config, ConfigurationError, Options, Source, run
+from pollux import APIError, Config, ConfigurationError, Options, Source, run
 
 
 class DocumentSummary(BaseModel):
@@ -106,7 +106,7 @@ async def main() -> None:
                 "report.pdf", prompt, provider_name=provider,
             )
             print(f"[{provider}] {summary.title}: {len(summary.key_points)} points")
-        except ConfigurationError as exc:
+        except (ConfigurationError, APIError) as exc:
             print(f"[{provider}] Skipped: {exc.hint}")
 
 
@@ -133,8 +133,9 @@ asyncio.run(main())
    provider name and builds the config internally. The prompt, source, and
    schema are the same regardless of provider.
 
-4. **Handle config errors at the edge.** The `main` function catches
-   `ConfigurationError` and logs a skip. This is the right place for
+4. **Handle portability failures at the edge.** The `main` function catches
+   `ConfigurationError` for Pollux-level unsupported features and `APIError`
+   for provider-side model mismatches. This is the right place for
    provider-specific fallback logic.
 
 ## Model-Specific Constraints
@@ -150,7 +151,7 @@ OpenAI's `gpt-5` family (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`) rejects
 models (like `gpt-4.1-nano`) still accept them.
 
 ```python
-# This will fail with a ProviderError for gpt-5 family models
+# This will fail with an APIError for gpt-5 family models
 options = Options(temperature=0.8, top_p=0.9)
 
 # Instead, use the default behavior or rely on reasoning_effort
@@ -165,10 +166,10 @@ Pollux exposes two reasoning knobs, and they are mutually exclusive:
   provider-specific extras).
 - `reasoning_budget_tokens` takes an explicit integer ceiling.
 
-Pick `reasoning_effort` on providers that expose named levels (OpenAI GPT-5,
-Gemini 3.x, Claude 4.x). Pick `reasoning_budget_tokens` on providers that only
-accept a budget (Gemini 2.5), or when you need exact control such as
-disabling thinking entirely on a model that allows it.
+Pick `reasoning_effort` when you want the most portable reasoning control.
+Pick `reasoning_budget_tokens` when you need an exact provider-native token
+ceiling. Pollux rejects the option up front on providers that never support
+it, but model-specific acceptance and minimums remain provider-defined.
 
 ```python
 # Name an effort level on a provider that accepts one.
@@ -178,11 +179,11 @@ result = await run(
     options=Options(reasoning_effort="high"),
 )
 
-# Disable thinking on Gemini 2.5 Flash with an explicit budget of zero.
+# Use an explicit budget on a provider that accepts token-based reasoning.
 result = await run(
-    "Reply with exactly OK.",
-    config=Config(provider="gemini", model="gemini-2.5-flash"),
-    options=Options(reasoning_budget_tokens=0),
+    "Think briefly, then answer.",
+    config=Config(provider="anthropic", model="claude-haiku-4-5"),
+    options=Options(reasoning_budget_tokens=2048),
 )
 
 if "reasoning" in result:
@@ -191,18 +192,17 @@ if "reasoning" in result:
             print("Thinking:", text)
 ```
 
-Provider minimums vary: Anthropic requires at least 1024 tokens and Gemini 2.5
-Pro requires at least 128. A budget that sits below a provider's floor surfaces
-as a provider error at call time.
+Exact budget floors are provider-defined. Pollux validates the shape
+(`int >= 0`) and provider-level support; the upstream provider may still
+reject a model-specific value at call time.
 
 ### Reasoning Control Mapping
 
 | Provider | Model Family | `reasoning_effort` | `reasoning_budget_tokens` | Provider Behavior |
 | --- | --- | --- | --- | --- |
-| **OpenAI** | `gpt-5` family | `"low"`, `"medium"`, `"high"` | ❌ | Returns a reasoning summary |
-| **Gemini** | `gemini-3` family | `"low"`, `"medium"`, `"high"`, `"minimal"` | ✅ | Returns full thinking text |
-| **Gemini** | `gemini-2.5` family | ❌ | ✅ | Uses provider-native thinking budgets |
-| **Anthropic** | `claude-4.x` family | `"low"`, `"medium"`, `"high"`, `"max"` (Opus 4.6 only) | ✅ | Returns thinking text and preserves replay blocks for tool loops |
+| **OpenAI** | provider-supported reasoning models | `"low"`, `"medium"`, `"high"` | ❌ | Returns a reasoning summary |
+| **Gemini** | reasoning-capable Gemini models | provider-defined | ✅ | Returns full thinking text |
+| **Anthropic** | provider-supported reasoning models | `"low"`, `"medium"`, `"high"`, `"max"` (Opus 4.6 only) | ✅ | Returns thinking text and preserves replay blocks for tool loops |
 | **OpenRouter** | reasoning-capable models | Model-dependent | ❌ | Returns reasoning text |
 
 ## Variations
@@ -249,8 +249,8 @@ async def analyze_with_reasoning(
             reasoning = result["reasoning"][0]
         return result["answers"][0], reasoning
 
-    except ConfigurationError:
-        # Provider doesn't support reasoning — retry without it
+    except (ConfigurationError, APIError):
+        # Provider or model doesn't support this reasoning mode — retry without it
         result = await run(
             prompt,
             source=Source.from_file(file_path),
@@ -289,9 +289,11 @@ async def test_analyze_document_mock(provider: str) -> None:
   (explicit for Gemini, implicit for Anthropic). YouTube URLs have limited
   OpenAI and Anthropic support. Check
   [Provider Capabilities](reference/provider-capabilities.md).
-- **Config errors are your portability signal.** A `ConfigurationError` for
-  an unsupported feature marks the boundary of portability. Handle it at
-  the call site.
+- **Config and provider errors are your portability signal.** A
+  `ConfigurationError` marks a Pollux-level unsupported feature. An
+  `APIError` often means the provider rejected a model-specific combination.
+  Handle both at the call site when you intentionally probe provider-specific
+  features.
 - **Model names are provider-specific.** Never hardcode model names in your
   pipeline logic. Keep them in config or a lookup table.
 - **Sampling controls vary.** OpenAI GPT-5 family models reject `temperature`

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -30,8 +30,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Implicit caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | Anthropic-only; see [caching docs](../caching.md#implicit-caching-anthropic) |
 | Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
 | Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `response_format` or `structured_outputs` |
-| `reasoning_effort` | ✅ (Gemini 3.x) | ✅ (GPT-5 family) | ✅ (Claude 4.x) | ⚠️ model-dependent | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.) |
-| `reasoning_budget_tokens` | ✅ (Gemini 2.5+) | ❌ | ✅ (Claude 4.x) | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
+| `reasoning_effort` | ✅ | ✅ | ✅ | ⚠️ model-dependent | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.); exact model support remains provider-defined |
+| `reasoning_budget_tokens` | ✅ | ❌ | ✅ | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
 | Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | Use the deferred API directly. |
 | Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `tools`; forced tool use may also require `tool_choice` |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | Works on OpenRouter models that support tool calling |
@@ -57,12 +57,10 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   carried entirely via `history`.
 - Tool parameter schemas are normalized at the provider boundary:
   `additionalProperties` is stripped because the Gemini API rejects it.
-- Reasoning: Gemini 3 models (for example `gemini-3-flash-preview`) support
-  `reasoning_effort` and return full thinking text in
-  `ResultEnvelope.reasoning`. Gemini 2.5 models reject `reasoning_effort` at
-  the provider API; use `reasoning_budget_tokens` instead. Both 2.5 and 3.x
-  accept `reasoning_budget_tokens`, with provider minimums that vary by
-  model (2.5 Flash accepts `0`; 2.5 Pro requires at least 128).
+- Reasoning: Gemini returns full thinking text in `ResultEnvelope.reasoning`
+  when the selected model and reasoning mode support it. Pollux forwards both
+  `reasoning_effort` and `reasoning_budget_tokens`; model-specific acceptance
+  is enforced by the Gemini API.
 
 ### OpenAI
 
@@ -102,10 +100,10 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   fan-out. Requesting it on unsupported providers raises `ConfigurationError`.
 - See [current caching scope](../caching.md#current-pollux-scope) for what
   Pollux exposes from Anthropic's caching surface.
-- Reasoning: thinking text appears in `ResultEnvelope.reasoning`. All
-  `claude-4.x` models support `reasoning_effort`; the `"max"` level is
-  Opus 4.6 only. `reasoning_budget_tokens` is also accepted; Anthropic
-  enforces a minimum of 1024 tokens.
+- Reasoning: thinking text appears in `ResultEnvelope.reasoning`.
+  `reasoning_effort` and `reasoning_budget_tokens` are both forwarded for
+  Anthropic models that support them. Exact model support and budget floors
+  are enforced by Anthropic.
 - Thinking block replay: when Anthropic returns `thinking` or
   `redacted_thinking` blocks, Pollux preserves them in conversation state and
   replays them verbatim on continuation turns so tool loops remain valid.

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -30,7 +30,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Implicit caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | Anthropic-only; see [caching docs](../caching.md#implicit-caching-anthropic) |
 | Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
 | Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `response_format` or `structured_outputs` |
-| Reasoning controls (`reasoning_effort`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Passed through to provider where supported; see notes below |
+| `reasoning_effort` | ✅ (Gemini 3.x) | ✅ (GPT-5 family) | ✅ (Claude 4.x) | ⚠️ model-dependent | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.) |
+| `reasoning_budget_tokens` | ✅ (Gemini 2.5+) | ❌ | ✅ (Claude 4.x) | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
 | Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | Use the deferred API directly. |
 | Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `tools`; forced tool use may also require `tool_choice` |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | Works on OpenRouter models that support tool calling |
@@ -56,9 +57,12 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   carried entirely via `history`.
 - Tool parameter schemas are normalized at the provider boundary:
   `additionalProperties` is stripped because the Gemini API rejects it.
-- Reasoning: Gemini 3 models (for example `gemini-3-flash-preview`) return
-  full thinking text in `ResultEnvelope.reasoning`. Gemini 2.x models do not
-  support `reasoning_effort` and return a provider error if it is set.
+- Reasoning: Gemini 3 models (for example `gemini-3-flash-preview`) support
+  `reasoning_effort` and return full thinking text in
+  `ResultEnvelope.reasoning`. Gemini 2.5 models reject `reasoning_effort` at
+  the provider API; use `reasoning_budget_tokens` instead. Both 2.5 and 3.x
+  accept `reasoning_budget_tokens`, with provider minimums that vary by
+  model (2.5 Flash accepts `0`; 2.5 Pro requires at least 128).
 
 ### OpenAI
 
@@ -82,7 +86,9 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - Reasoning: OpenAI provides reasoning summaries (not raw traces) in
   `ResultEnvelope.reasoning`. Token counts appear in
   `ResultEnvelope.usage["reasoning_tokens"]` when the model returns them.
-  Some older models reject `reasoning_effort`.
+  Some older models reject `reasoning_effort`. OpenAI does not accept
+  `reasoning_budget_tokens`; Pollux raises `ConfigurationError` before the
+  request is dispatched.
 
 ### Anthropic
 
@@ -98,7 +104,8 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   Pollux exposes from Anthropic's caching surface.
 - Reasoning: thinking text appears in `ResultEnvelope.reasoning`. All
   `claude-4.x` models support `reasoning_effort`; the `"max"` level is
-  Opus 4.6 only.
+  Opus 4.6 only. `reasoning_budget_tokens` is also accepted; Anthropic
+  enforces a minimum of 1024 tokens.
 - Thinking block replay: when Anthropic returns `thinking` or
   `redacted_thinking` blocks, Pollux preserves them in conversation state and
   replays them verbatim on continuation turns so tool loops remain valid.
@@ -148,7 +155,9 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   Pollux does not expose OpenRouter-specific cache controls.
 - Reasoning: works on OpenRouter models that support reasoning. Thinking text
   appears in `ResultEnvelope.reasoning`, and token counts in
-  `ResultEnvelope.usage["reasoning_tokens"]` when available.
+  `ResultEnvelope.usage["reasoning_tokens"]` when available. OpenRouter does
+  not accept `reasoning_budget_tokens`; Pollux raises `ConfigurationError`
+  before dispatch.
 
 ## Error Semantics
 

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -17,6 +17,7 @@ from pollux.providers.base import (
     ProviderDeferredHandle,
     ProviderDeferredItem,
     ProviderDeferredSnapshot,
+    ValidatingProvider,
 )
 from pollux.providers.models import ProviderRequest
 from pollux.result import build_result_from_responses
@@ -218,13 +219,26 @@ def _build_provider_requests(plan: Plan) -> list[ProviderRequest]:
     return requests
 
 
+async def _validate_provider_requests(
+    provider: Provider,
+    requests: list[ProviderRequest],
+) -> None:
+    """Run provider-owned validation before deferred submission side effects."""
+    if not isinstance(provider, ValidatingProvider):
+        return
+    for request in requests:
+        await provider.validate_request(request)
+
+
 async def submit_deferred(plan: Plan, provider: Provider) -> DeferredHandle:
     """Submit provider-backed deferred work and return the Pollux handle."""
     _validate_deferred_plan(plan, provider)
+    requests = _build_provider_requests(plan)
+    await _validate_provider_requests(provider, requests)
     deferred_provider = _get_deferred_provider(provider)
     request_ids = _request_ids(len(plan.request.prompts))
     provider_handle = await deferred_provider.submit_deferred(
-        _build_provider_requests(plan),
+        requests,
         request_ids=request_ids,
     )
     submitted_at = (

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -174,6 +174,14 @@ def _validate_deferred_plan(plan: Plan, provider: Provider) -> None:
             "Provider does not support reasoning controls",
             hint="Remove reasoning_effort or choose a provider with reasoning support.",
         )
+    if options.reasoning_budget_tokens is not None and not caps.reasoning_budget_tokens:
+        raise ConfigurationError(
+            "Provider does not support reasoning_budget_tokens",
+            hint=(
+                "Use reasoning_effort, or choose a provider that accepts "
+                "an explicit reasoning token budget."
+            ),
+        )
     if (not caps.uploads) and any(
         isinstance(part, dict)
         and isinstance(part.get("file_path"), str)
@@ -203,6 +211,7 @@ def _build_provider_requests(plan: Plan) -> list[ProviderRequest]:
                 temperature=options.temperature,
                 top_p=options.top_p,
                 reasoning_effort=options.reasoning_effort,
+                reasoning_budget_tokens=options.reasoning_budget_tokens,
                 max_tokens=options.max_tokens,
             )
         )

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -226,6 +226,8 @@ async def _validate_provider_requests(
     """Run provider-owned validation before deferred submission side effects."""
     if not isinstance(provider, ValidatingProvider):
         return
+    # TODO: parallelize if a future provider's validate_request does I/O
+    # (e.g. OpenRouter-style metadata lookups). Current validators are local.
     for request in requests:
         await provider.validate_request(request)
 

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import json
 import logging
 from pathlib import Path
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from pollux._singleflight import singleflight_cached
 from pollux.errors import APIError, ConfigurationError, InternalError, PolluxError
+from pollux.providers.base import ValidatingProvider
 from pollux.providers.models import (
     Message,
     ProviderFileAsset,
@@ -30,6 +31,15 @@ if TYPE_CHECKING:
     from pollux.providers.base import Provider
 
 logger = logging.getLogger(__name__)
+
+
+async def _validate_provider_request(
+    provider: Provider,
+    request: ProviderRequest,
+) -> None:
+    """Run provider-owned validation before uploads or other side effects."""
+    if isinstance(provider, ValidatingProvider):
+        await provider.validate_request(request)
 
 
 def _with_call_idx(err: APIError, call_idx: int | None) -> APIError:
@@ -225,16 +235,6 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                         if prompt_part is not None
                         else [*shared_parts]
                     )
-                    parts = await _substitute_upload_parts(
-                        raw_parts,
-                        provider=provider,
-                        call_idx=call_idx,
-                        upload_cache=upload_cache,
-                        upload_inflight=upload_inflight,
-                        upload_lock=upload_lock,
-                        retry_policy=retry_policy,
-                    )
-
                     history_msgs: list[Message] | None = None
                     request_provider_state = (
                         dict(provider_state)
@@ -290,10 +290,9 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                             if request_provider_state is None:
                                 request_provider_state = {}
                             request_provider_state["history"] = history_item_states
-
                     req = ProviderRequest(
                         model=model,
-                        parts=parts,
+                        parts=raw_parts,
                         system_instruction=options.system_instruction,
                         cache_name=cache_name,
                         response_schema=schema,
@@ -309,6 +308,17 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                         max_tokens=options.max_tokens,
                         implicit_caching=implicit_caching,
                     )
+                    await _validate_provider_request(provider, req)
+                    parts = await _substitute_upload_parts(
+                        raw_parts,
+                        provider=provider,
+                        call_idx=call_idx,
+                        upload_cache=upload_cache,
+                        upload_inflight=upload_inflight,
+                        upload_lock=upload_lock,
+                        retry_policy=retry_policy,
+                    )
+                    req = replace(req, parts=parts)
 
                     if retry_policy.max_attempts <= 1:
                         resp = await provider.generate(req)

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -103,6 +103,14 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
             "Provider does not support reasoning controls",
             hint="Remove reasoning_effort or choose a provider with reasoning support.",
         )
+    if options.reasoning_budget_tokens is not None and not caps.reasoning_budget_tokens:
+        raise ConfigurationError(
+            "Provider does not support reasoning_budget_tokens",
+            hint=(
+                "Use reasoning_effort, or choose a provider that accepts "
+                "an explicit reasoning token budget."
+            ),
+        )
     if options.implicit_caching is True and not caps.implicit_caching:
         raise ConfigurationError(
             "Provider does not support implicit caching",
@@ -294,6 +302,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                         tools=options.tools,
                         tool_choice=options.tool_choice,
                         reasoning_effort=options.reasoning_effort,
+                        reasoning_budget_tokens=options.reasoning_budget_tokens,
                         history=history_msgs,
                         previous_response_id=previous_response_id,
                         provider_state=request_provider_state,

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -130,9 +130,9 @@ class Options:
             raise ConfigurationError(
                 "reasoning_budget_tokens must be a non-negative integer",
                 hint=(
-                    "Providers enforce their own minimums: Gemini 2.5 Flash "
-                    "accepts 0 to disable thinking; Anthropic requires at "
-                    "least 1024; Gemini 2.5 Pro requires at least 128."
+                    "Pass reasoning_budget_tokens=0 or a larger integer. "
+                    "Provider- and model-specific limits are enforced by the "
+                    "provider API."
                 ),
             )
         if (

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -77,6 +77,8 @@ class Options:
 
     #: Controls model thinking depth; passed through to the provider.
     reasoning_effort: ReasoningEffort | None = None
+    #: Controls provider reasoning token budget where supported.
+    reasoning_budget_tokens: int | None = None
     #: Legacy compatibility shim. Realtime remains the only supported value.
     delivery_mode: DeliveryMode = "realtime"
     #: Mutually exclusive with *continue_from*.
@@ -119,6 +121,27 @@ class Options:
             raise ConfigurationError(
                 "max_tokens must be a positive integer",
                 hint="Pass max_tokens=16384 or greater for thinking models.",
+            )
+        if self.reasoning_budget_tokens is not None and (
+            isinstance(self.reasoning_budget_tokens, bool)
+            or not isinstance(self.reasoning_budget_tokens, int)
+            or self.reasoning_budget_tokens < 0
+        ):
+            raise ConfigurationError(
+                "reasoning_budget_tokens must be a non-negative integer",
+                hint=(
+                    "Providers enforce their own minimums: Gemini 2.5 Flash "
+                    "accepts 0 to disable thinking; Anthropic requires at "
+                    "least 1024; Gemini 2.5 Pro requires at least 128."
+                ),
+            )
+        if (
+            self.reasoning_effort is not None
+            and self.reasoning_budget_tokens is not None
+        ):
+            raise ConfigurationError(
+                "reasoning_effort and reasoning_budget_tokens are mutually exclusive",
+                hint="Choose either qualitative effort or an explicit token budget.",
             )
 
         # Keep this runtime guard even though ``delivery_mode`` is typed as

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -75,6 +75,7 @@ class AnthropicProvider:
             uploads=True,
             structured_outputs=True,
             reasoning=True,
+            reasoning_budget_tokens=True,
             deferred_delivery=True,
             conversation=True,
             implicit_caching=True,
@@ -288,6 +289,15 @@ class AnthropicProvider:
                     create_kwargs["extra_headers"] = {
                         "anthropic-beta": _INTERLEAVED_THINKING_BETA_HEADER
                     }
+        elif request.reasoning_budget_tokens is not None:
+            create_kwargs["thinking"] = {
+                "type": "enabled",
+                "budget_tokens": request.reasoning_budget_tokens,
+            }
+            if request.tools:
+                create_kwargs["extra_headers"] = {
+                    "anthropic-beta": _INTERLEAVED_THINKING_BETA_HEADER
+                }
 
         if output_config:
             create_kwargs["output_config"] = output_config
@@ -543,6 +553,7 @@ class AnthropicProvider:
             tools=request.tools,
             tool_choice=request.tool_choice,
             reasoning_effort=request.reasoning_effort,
+            reasoning_budget_tokens=request.reasoning_budget_tokens,
             history=request.history,
             previous_response_id=request.previous_response_id,
             provider_state=request.provider_state,

--- a/src/pollux/providers/base.py
+++ b/src/pollux/providers/base.py
@@ -101,6 +101,18 @@ class Provider(Protocol):
 
 
 @runtime_checkable
+class ValidatingProvider(Protocol):
+    """Optional provider hook for request validation before side effects."""
+
+    async def validate_request(
+        self,
+        request: ProviderRequest,
+    ) -> None:
+        """Fail fast on unsupported model- or request-specific features."""
+        ...
+
+
+@runtime_checkable
 class DeferredProvider(Protocol):
     """Lifecycle operations for provider-backed deferred delivery."""
 

--- a/src/pollux/providers/base.py
+++ b/src/pollux/providers/base.py
@@ -104,6 +104,9 @@ class Provider(Protocol):
 class ValidatingProvider(Protocol):
     """Optional provider hook for request validation before side effects."""
 
+    # TODO: Gemini and Anthropic could adopt this to pre-flight model-specific
+    # rejections (e.g. gemini-2.5 refusing reasoning_effort) instead of
+    # deferring to upstream errors.
     async def validate_request(
         self,
         request: ProviderRequest,

--- a/src/pollux/providers/base.py
+++ b/src/pollux/providers/base.py
@@ -25,6 +25,7 @@ class ProviderCapabilities:
     uploads: bool
     structured_outputs: bool = False
     reasoning: bool = False
+    reasoning_budget_tokens: bool = False
     deferred_delivery: bool = False
     conversation: bool = False
     implicit_caching: bool = False

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -33,25 +33,6 @@ from pollux.providers.models import (
 logger = logging.getLogger(__name__)
 
 _GEMINI_BATCH_INLINE_LIMIT_BYTES = 20_000_000
-_GEMINI_REASONING_EFFORT_PREFIXES = ("gemini-3",)
-_GEMINI_REASONING_BUDGET_PREFIXES = ("gemini-2.5", "gemini-3")
-
-
-def _normalized_model_name(model: str) -> str:
-    """Normalize Gemini model names for family checks."""
-    return model.strip().lower()
-
-
-def _supports_reasoning_effort(model: str) -> bool:
-    """Return True when the Gemini model family accepts qualitative effort."""
-    normalized = _normalized_model_name(model)
-    return normalized.startswith(_GEMINI_REASONING_EFFORT_PREFIXES)
-
-
-def _supports_reasoning_budget_tokens(model: str) -> bool:
-    """Return True when the Gemini model family accepts thinking budgets."""
-    normalized = _normalized_model_name(model)
-    return normalized.startswith(_GEMINI_REASONING_BUDGET_PREFIXES)
 
 
 def _provider_hint_payload(
@@ -243,30 +224,6 @@ class GeminiProvider:
             }
         return None
 
-    async def validate_request(self, request: ProviderRequest) -> None:
-        """Validate Gemini model-family constraints before side effects."""
-        if request.reasoning_effort is not None and not _supports_reasoning_effort(
-            request.model
-        ):
-            raise ConfigurationError(
-                f"Gemini model {request.model!r} does not support reasoning_effort",
-                hint=(
-                    "Use a Gemini 3 model for reasoning_effort, or switch to "
-                    "reasoning_budget_tokens on Gemini 2.5 models."
-                ),
-            )
-        if (
-            request.reasoning_budget_tokens is not None
-            and not _supports_reasoning_budget_tokens(request.model)
-        ):
-            raise ConfigurationError(
-                f"Gemini model {request.model!r} does not support reasoning_budget_tokens",
-                hint=(
-                    "Use a Gemini 2.5+ or 3 model when you need an explicit "
-                    "reasoning token budget."
-                ),
-            )
-
     def _build_config_kwargs(self, request: ProviderRequest) -> dict[str, Any]:
         """Assemble Gemini GenerateContentConfig keyword arguments."""
         from google.genai import types
@@ -426,7 +383,6 @@ class GeminiProvider:
             ) as temp_batch:
                 temp_batch_path = Path(temp_batch.name)
                 for request_id, request in zip(request_ids, requests, strict=True):
-                    await self.validate_request(request)
                     resolved_request = await self._resolve_deferred_request(
                         request,
                         upload_cache=upload_cache,
@@ -616,7 +572,6 @@ class GeminiProvider:
         request: ProviderRequest,
     ) -> ProviderResponse:
         """Generate content from the Gemini model."""
-        await self.validate_request(request)
         client = self._get_client()
         from google.genai import types
 

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -120,6 +120,7 @@ class GeminiProvider:
             uploads=True,
             structured_outputs=True,
             reasoning=True,
+            reasoning_budget_tokens=True,
             deferred_delivery=True,
             conversation=True,
         )
@@ -233,6 +234,11 @@ class GeminiProvider:
             config_kwargs["thinking_config"] = types.ThinkingConfig(
                 include_thoughts=True,
                 thinking_level=request.reasoning_effort,  # type: ignore[arg-type]
+            )
+        elif request.reasoning_budget_tokens is not None:
+            config_kwargs["thinking_config"] = types.ThinkingConfig(
+                include_thoughts=request.reasoning_budget_tokens > 0,
+                thinking_budget=request.reasoning_budget_tokens,
             )
 
         if request.system_instruction is not None:
@@ -676,6 +682,7 @@ class GeminiProvider:
             tools=request.tools,
             tool_choice=request.tool_choice,
             reasoning_effort=request.reasoning_effort,
+            reasoning_budget_tokens=request.reasoning_budget_tokens,
             history=request.history,
             previous_response_id=request.previous_response_id,
             provider_state=request.provider_state,

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -33,6 +33,25 @@ from pollux.providers.models import (
 logger = logging.getLogger(__name__)
 
 _GEMINI_BATCH_INLINE_LIMIT_BYTES = 20_000_000
+_GEMINI_REASONING_EFFORT_PREFIXES = ("gemini-3",)
+_GEMINI_REASONING_BUDGET_PREFIXES = ("gemini-2.5", "gemini-3")
+
+
+def _normalized_model_name(model: str) -> str:
+    """Normalize Gemini model names for family checks."""
+    return model.strip().lower()
+
+
+def _supports_reasoning_effort(model: str) -> bool:
+    """Return True when the Gemini model family accepts qualitative effort."""
+    normalized = _normalized_model_name(model)
+    return normalized.startswith(_GEMINI_REASONING_EFFORT_PREFIXES)
+
+
+def _supports_reasoning_budget_tokens(model: str) -> bool:
+    """Return True when the Gemini model family accepts thinking budgets."""
+    normalized = _normalized_model_name(model)
+    return normalized.startswith(_GEMINI_REASONING_BUDGET_PREFIXES)
 
 
 def _provider_hint_payload(
@@ -224,6 +243,30 @@ class GeminiProvider:
             }
         return None
 
+    async def validate_request(self, request: ProviderRequest) -> None:
+        """Validate Gemini model-family constraints before side effects."""
+        if request.reasoning_effort is not None and not _supports_reasoning_effort(
+            request.model
+        ):
+            raise ConfigurationError(
+                f"Gemini model {request.model!r} does not support reasoning_effort",
+                hint=(
+                    "Use a Gemini 3 model for reasoning_effort, or switch to "
+                    "reasoning_budget_tokens on Gemini 2.5 models."
+                ),
+            )
+        if (
+            request.reasoning_budget_tokens is not None
+            and not _supports_reasoning_budget_tokens(request.model)
+        ):
+            raise ConfigurationError(
+                f"Gemini model {request.model!r} does not support reasoning_budget_tokens",
+                hint=(
+                    "Use a Gemini 2.5+ or 3 model when you need an explicit "
+                    "reasoning token budget."
+                ),
+            )
+
     def _build_config_kwargs(self, request: ProviderRequest) -> dict[str, Any]:
         """Assemble Gemini GenerateContentConfig keyword arguments."""
         from google.genai import types
@@ -383,6 +426,7 @@ class GeminiProvider:
             ) as temp_batch:
                 temp_batch_path = Path(temp_batch.name)
                 for request_id, request in zip(request_ids, requests, strict=True):
+                    await self.validate_request(request)
                     resolved_request = await self._resolve_deferred_request(
                         request,
                         upload_cache=upload_cache,
@@ -572,6 +616,7 @@ class GeminiProvider:
         request: ProviderRequest,
     ) -> ProviderResponse:
         """Generate content from the Gemini model."""
+        await self.validate_request(request)
         client = self._get_client()
         from google.genai import types
 

--- a/src/pollux/providers/models.py
+++ b/src/pollux/providers/models.py
@@ -50,6 +50,7 @@ class ProviderRequest:
     tools: list[dict[str, Any]] | None = None
     tool_choice: Literal["auto", "required", "none"] | dict[str, Any] | None = None
     reasoning_effort: str | None = None
+    reasoning_budget_tokens: int | None = None
     history: list[Message] | None = None
     previous_response_id: str | None = None
     provider_state: dict[str, Any] | None = None

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from pollux.errors import APIError
+from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import wrap_provider_error
 from pollux.providers._utils import to_strict_schema
 from pollux.providers.base import (
@@ -542,6 +542,15 @@ class OpenAIProvider:
         self, request: ProviderRequest
     ) -> dict[str, Any]:
         """Build the raw `/v1/responses` request body."""
+        if request.reasoning_budget_tokens is not None:
+            raise ConfigurationError(
+                "Provider does not support reasoning_budget_tokens",
+                hint=(
+                    "Use reasoning_effort, or choose a provider that accepts "
+                    "an explicit reasoning token budget."
+                ),
+            )
+
         input_messages = self._build_input(
             request.parts, request.history, request.previous_response_id
         )
@@ -621,6 +630,7 @@ class OpenAIProvider:
             tools=request.tools,
             tool_choice=request.tool_choice,
             reasoning_effort=request.reasoning_effort,
+            reasoning_budget_tokens=request.reasoning_budget_tokens,
             history=request.history,
             previous_response_id=request.previous_response_id,
             provider_state=request.provider_state,

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -100,6 +100,22 @@ class OpenAIProvider:
         return None
 
     @staticmethod
+    def _validate_request_features(request: ProviderRequest) -> None:
+        """Reject unsupported request features before any provider side effects."""
+        if request.reasoning_budget_tokens is not None:
+            raise ConfigurationError(
+                "Provider does not support reasoning_budget_tokens",
+                hint=(
+                    "Use reasoning_effort, or choose a provider that accepts "
+                    "an explicit reasoning token budget."
+                ),
+            )
+
+    async def validate_request(self, request: ProviderRequest) -> None:
+        """Validate OpenAI-specific request constraints."""
+        self._validate_request_features(request)
+
+    @staticmethod
     def _build_input(
         parts: list[Any],
         history: list[Any] | None,
@@ -453,6 +469,7 @@ class OpenAIProvider:
     ) -> ProviderResponse:
         """Generate a response using OpenAI's responses endpoint."""
         _ = request.cache_name
+        await self.validate_request(request)
         client = self._get_client()
         create_kwargs = self._build_responses_create_kwargs(request)
 
@@ -542,14 +559,7 @@ class OpenAIProvider:
         self, request: ProviderRequest
     ) -> dict[str, Any]:
         """Build the raw `/v1/responses` request body."""
-        if request.reasoning_budget_tokens is not None:
-            raise ConfigurationError(
-                "Provider does not support reasoning_budget_tokens",
-                hint=(
-                    "Use reasoning_effort, or choose a provider that accepts "
-                    "an explicit reasoning token budget."
-                ),
-            )
+        self._validate_request_features(request)
 
         input_messages = self._build_input(
             request.parts, request.history, request.previous_response_id
@@ -601,6 +611,7 @@ class OpenAIProvider:
         upload_cache: dict[tuple[str, str], ProviderFileAsset],
     ) -> dict[str, Any]:
         """Build one OpenAI Batch API line body for `/v1/responses`."""
+        self._validate_request_features(request)
         resolved_parts: list[Any] = []
         for part in request.parts:
             if (

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -469,7 +469,6 @@ class OpenAIProvider:
     ) -> ProviderResponse:
         """Generate a response using OpenAI's responses endpoint."""
         _ = request.cache_name
-        await self.validate_request(request)
         client = self._get_client()
         create_kwargs = self._build_responses_create_kwargs(request)
 

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -193,6 +193,15 @@ class OpenRouterProvider:
 
     async def validate_request(self, request: ProviderRequest) -> None:
         """Validate model-dependent OpenRouter behavior before dispatch."""
+        if request.reasoning_budget_tokens is not None:
+            raise ConfigurationError(
+                "Provider does not support reasoning_budget_tokens",
+                hint=(
+                    "Use reasoning_effort, or choose a provider that accepts "
+                    "an explicit reasoning token budget."
+                ),
+            )
+
         metadata = await self._get_model_metadata(request.model)
         _require_text_io(metadata, model=request.model)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ class FakeProvider:
             "tools": request.tools,
             "tool_choice": request.tool_choice,
             "reasoning_effort": request.reasoning_effort,
+            "reasoning_budget_tokens": request.reasoning_budget_tokens,
             "history": request.history,
             "previous_response_id": request.previous_response_id,
             "provider_state": request.provider_state,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -158,6 +158,34 @@ class InMemoryDeferredProvider(FakeProvider):
         return items
 
 
+@dataclass
+class RejectingValidatingProvider(FakeProvider):
+    """Provider double that fails validation before uploads begin."""
+
+    validation_calls: list[ProviderRequest] = field(default_factory=list)
+
+    async def validate_request(self, request: ProviderRequest) -> None:
+        self.validation_calls.append(request)
+        raise ConfigurationError(
+            "validation failed",
+            hint="Validation should run before uploads.",
+        )
+
+
+@dataclass
+class RejectingValidatingDeferredProvider(InMemoryDeferredProvider):
+    """Deferred provider double that fails validation before submission side effects."""
+
+    validation_calls: list[ProviderRequest] = field(default_factory=list)
+
+    async def validate_request(self, request: ProviderRequest) -> None:
+        self.validation_calls.append(request)
+        raise ConfigurationError(
+            "validation failed",
+            hint="Validation should run before deferred uploads.",
+        )
+
+
 @pytest.mark.asyncio
 async def test_run_and_run_many_smoke() -> None:
     """Smoke: public API returns stable envelope shapes."""
@@ -974,6 +1002,29 @@ async def test_openai_upload_cleanup_runs_even_when_generate_fails(
 
 
 @pytest.mark.asyncio
+async def test_provider_validation_runs_before_uploads(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Provider-owned validation should reject realtime requests before uploads."""
+    fake = RejectingValidatingProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+
+    file_path = tmp_path / "doc.pdf"
+    file_path.write_bytes(b"%PDF-1.4 fake")
+
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+    with pytest.raises(ConfigurationError, match="validation failed"):
+        await pollux.run(
+            "Read this",
+            source=Source.from_file(file_path, mime_type="application/pdf"),
+            config=cfg,
+        )
+
+    assert fake.upload_calls == 0
+    assert len(fake.validation_calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_duration_includes_upload_cleanup_latency(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Any
 ) -> None:
@@ -1653,6 +1704,30 @@ async def test_defer_many_requires_at_least_one_prompt(
 
     with pytest.raises(ConfigurationError, match="requires at least one prompt"):
         await pollux.defer_many([], config=cfg)
+
+
+@pytest.mark.asyncio
+async def test_deferred_provider_validation_runs_before_uploads(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Deferred provider validation should reject requests before submission uploads."""
+    fake = RejectingValidatingDeferredProvider()
+    monkeypatch.setattr(pollux, "_create_provider", lambda *_a, **_kw: fake)
+
+    file_path = tmp_path / "doc.pdf"
+    file_path.write_bytes(b"%PDF-1.4 fake")
+
+    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+    with pytest.raises(ConfigurationError, match="validation failed"):
+        await pollux.defer_many(
+            ("Q1?",),
+            sources=(Source.from_file(file_path, mime_type="application/pdf"),),
+            config=cfg,
+        )
+
+    assert fake.upload_calls == 0
+    assert fake.submitted_requests == {}
+    assert len(fake.validation_calls) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1416,8 +1416,9 @@ async def test_create_cache_validates_ttl() -> None:
     [
         ({"response_schema": {"type": "object"}}, "structured outputs"),
         ({"reasoning_effort": "high"}, "reasoning"),
+        ({"reasoning_budget_tokens": 0}, "reasoning"),
     ],
-    ids=["structured_outputs", "reasoning"],
+    ids=["structured_outputs", "reasoning_effort", "reasoning_budget_tokens"],
 )
 async def test_option_requires_provider_capability(
     option_kwargs: dict[str, Any],
@@ -1439,9 +1440,47 @@ def test_options_system_instruction_requires_string() -> None:
         Options(system_instruction=123)  # type: ignore[arg-type]
 
 
+def test_options_reasoning_budget_tokens_requires_non_negative_int() -> None:
+    """Budget-based reasoning control should validate shape at option creation."""
+    with pytest.raises(
+        ConfigurationError,
+        match="reasoning_budget_tokens must be a non-negative integer",
+    ):
+        Options(reasoning_budget_tokens=-1)
+
+
+def test_options_reasoning_budget_tokens_rejects_bool() -> None:
+    """Boolean values should not be accepted as integer reasoning budgets."""
+    with pytest.raises(
+        ConfigurationError,
+        match="reasoning_budget_tokens must be a non-negative integer",
+    ):
+        Options(reasoning_budget_tokens=True)
+
+
+def test_options_reasoning_controls_are_mutually_exclusive() -> None:
+    """Qualitative and quantitative reasoning controls should not mix."""
+    with pytest.raises(
+        ConfigurationError,
+        match="reasoning_effort and reasoning_budget_tokens are mutually exclusive",
+    ):
+        Options(reasoning_effort="high", reasoning_budget_tokens=0)
+
+
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reasoning_options", "expected_effort", "expected_budget"),
+    [
+        ({"reasoning_effort": "high"}, "high", None),
+        ({"reasoning_budget_tokens": 0}, None, 0),
+    ],
+    ids=["reasoning_effort", "reasoning_budget_tokens"],
+)
 async def test_options_are_forwarded_when_provider_supports_features(
     monkeypatch: pytest.MonkeyPatch,
+    reasoning_options: dict[str, Any],
+    expected_effort: str | None,
+    expected_budget: int | None,
 ) -> None:
     """Options should be normalized and passed through to provider.generate()."""
 
@@ -1454,6 +1493,7 @@ async def test_options_are_forwarded_when_provider_supports_features(
             uploads=True,
             structured_outputs=True,
             reasoning=True,
+            reasoning_budget_tokens=True,
             deferred_delivery=True,
             conversation=True,
         )
@@ -1468,13 +1508,14 @@ async def test_options_are_forwarded_when_provider_supports_features(
         options=Options(
             system_instruction="Reply in one sentence.",
             response_schema=ExampleSchema,
-            reasoning_effort="high",
+            **reasoning_options,
             delivery_mode="realtime",
         ),
     )
 
     assert fake.last_generate_kwargs is not None
-    assert fake.last_generate_kwargs["reasoning_effort"] == "high"
+    assert fake.last_generate_kwargs["reasoning_effort"] == expected_effort
+    assert fake.last_generate_kwargs["reasoning_budget_tokens"] == expected_budget
     assert fake.last_generate_kwargs["history"] is None
     assert fake.last_generate_kwargs["system_instruction"] == "Reply in one sentence."
     response_schema = fake.last_generate_kwargs["response_schema"]
@@ -1550,6 +1591,7 @@ async def test_delivery_mode_deferred_is_explicitly_not_implemented(
             uploads=True,
             structured_outputs=True,
             reasoning=True,
+            reasoning_budget_tokens=True,
             deferred_delivery=True,
             conversation=True,
         )

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -501,7 +501,9 @@ async def test_gemini_generate_passes_thinking_level_from_reasoning_effort() -> 
 
     await provider.generate(
         ProviderRequest(
-            model=GEMINI_MODEL, parts=["Think hard."], reasoning_effort="low"
+            model="gemini-3-flash-preview",
+            parts=["Think hard."],
+            reasoning_effort="low",
         )
     )
 
@@ -533,7 +535,7 @@ async def test_gemini_generate_passes_thinking_budget_from_reasoning_budget_toke
 
     await provider.generate(
         ProviderRequest(
-            model=GEMINI_MODEL,
+            model="gemini-2.5-flash",
             parts=["Think less."],
             reasoning_budget_tokens=0,
         )
@@ -565,7 +567,7 @@ async def test_gemini_generate_includes_thoughts_for_non_zero_budget() -> None:
 
     await provider.generate(
         ProviderRequest(
-            model=GEMINI_MODEL,
+            model="gemini-2.5-flash",
             parts=["Think a little."],
             reasoning_budget_tokens=512,
         )
@@ -576,6 +578,59 @@ async def test_gemini_generate_includes_thoughts_for_non_zero_budget() -> None:
     tc = config.thinking_config
     assert tc.include_thoughts is True
     assert tc.thinking_budget == 512
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_rejects_reasoning_budget_tokens_for_older_models() -> (
+    None
+):
+    """Older Gemini families should fail fast on explicit thinking budgets."""
+    fake_models = MagicMock()
+    fake_models.generate_content = AsyncMock()
+    fake_aio = MagicMock()
+    fake_aio.models = fake_models
+
+    provider = GeminiProvider("test-key")
+    provider._client = MagicMock()
+    provider._client.aio = fake_aio
+
+    with pytest.raises(
+        ConfigurationError,
+        match="does not support reasoning_budget_tokens",
+    ):
+        await provider.generate(
+            ProviderRequest(
+                model=GEMINI_MODEL,
+                parts=["Think less."],
+                reasoning_budget_tokens=0,
+            )
+        )
+
+    fake_models.generate_content.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_rejects_reasoning_effort_for_2_5_models() -> None:
+    """Gemini 2.5 should tell callers to use explicit thinking budgets instead."""
+    fake_models = MagicMock()
+    fake_models.generate_content = AsyncMock()
+    fake_aio = MagicMock()
+    fake_aio.models = fake_models
+
+    provider = GeminiProvider("test-key")
+    provider._client = MagicMock()
+    provider._client.aio = fake_aio
+
+    with pytest.raises(ConfigurationError, match="does not support reasoning_effort"):
+        await provider.generate(
+            ProviderRequest(
+                model="gemini-2.5-flash",
+                parts=["Think hard."],
+                reasoning_effort="high",
+            )
+        )
+
+    fake_models.generate_content.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1492,6 +1547,40 @@ async def test_openai_submit_deferred_reuses_shared_file_uploads(
     second_file = lines[1]["body"]["input"][0]["content"][0]["file_id"]
     assert first_file == "file_uploaded_pdf"
     assert second_file == first_file
+
+
+@pytest.mark.asyncio
+async def test_openai_submit_deferred_rejects_reasoning_budget_tokens_before_upload(
+    tmp_path: Path,
+) -> None:
+    """Unsupported reasoning budgets should fail before deferred uploads begin."""
+    pdf_path = tmp_path / "paper.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+
+    files = _FakeBatchFilesClient()
+    batches = _FakeBatchesClient()
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"files": files, "batches": batches})()
+
+    with pytest.raises(
+        ConfigurationError, match="Provider does not support reasoning_budget_tokens"
+    ):
+        await provider.submit_deferred(
+            [
+                ProviderRequest(
+                    model=OPENAI_MODEL,
+                    parts=[
+                        {"file_path": str(pdf_path), "mime_type": "application/pdf"},
+                        "Question",
+                    ],
+                    reasoning_budget_tokens=0,
+                )
+            ],
+            request_ids=["pollux-000000"],
+        )
+
+    assert files.create_calls == []
+    assert batches.create_kwargs is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -513,6 +513,72 @@ async def test_gemini_generate_passes_thinking_level_from_reasoning_effort() -> 
 
 
 @pytest.mark.asyncio
+async def test_gemini_generate_passes_thinking_budget_from_reasoning_budget_tokens() -> (
+    None
+):
+    """reasoning_budget_tokens should map to ThinkingConfig with thinking_budget."""
+    captured: dict[str, Any] = {}
+
+    async def fake_generate_content(**kwargs: Any) -> Any:
+        captured["config"] = kwargs.get("config")
+        return MagicMock(text="ok", parsed=None, usage_metadata=None)
+
+    provider = GeminiProvider("test-key")
+    fake_models = MagicMock()
+    fake_models.generate_content = fake_generate_content
+    fake_aio = MagicMock()
+    fake_aio.models = fake_models
+    provider._client = MagicMock()
+    provider._client.aio = fake_aio
+
+    await provider.generate(
+        ProviderRequest(
+            model=GEMINI_MODEL,
+            parts=["Think less."],
+            reasoning_budget_tokens=0,
+        )
+    )
+
+    config = captured["config"]
+    assert config is not None
+    tc = config.thinking_config
+    assert tc.include_thoughts is False
+    assert tc.thinking_budget == 0
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_includes_thoughts_for_non_zero_budget() -> None:
+    """A positive reasoning_budget_tokens should still request thought text."""
+    captured: dict[str, Any] = {}
+
+    async def fake_generate_content(**kwargs: Any) -> Any:
+        captured["config"] = kwargs.get("config")
+        return MagicMock(text="ok", parsed=None, usage_metadata=None)
+
+    provider = GeminiProvider("test-key")
+    fake_models = MagicMock()
+    fake_models.generate_content = fake_generate_content
+    fake_aio = MagicMock()
+    fake_aio.models = fake_models
+    provider._client = MagicMock()
+    provider._client.aio = fake_aio
+
+    await provider.generate(
+        ProviderRequest(
+            model=GEMINI_MODEL,
+            parts=["Think a little."],
+            reasoning_budget_tokens=512,
+        )
+    )
+
+    config = captured["config"]
+    assert config is not None
+    tc = config.thinking_config
+    assert tc.include_thoughts is True
+    assert tc.thinking_budget == 512
+
+
+@pytest.mark.asyncio
 async def test_gemini_generate_attaches_video_metadata_from_source_settings() -> None:
     """Gemini adapter should interpret Pollux's explicit Gemini video settings."""
     captured: dict[str, Any] = {}
@@ -1070,6 +1136,29 @@ async def test_openai_generate_forwards_reasoning_effort_and_summary() -> None:
         "effort": "high",
         "summary": "auto",
     }
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_rejects_reasoning_budget_tokens() -> None:
+    """OpenAI adapter should fail fast on unsupported budget-based reasoning."""
+    responses = _FakeResponses()
+    fake_client = type("Client", (), {"responses": responses})()
+
+    provider = OpenAIProvider("test-key")
+    provider._client = fake_client
+
+    with pytest.raises(
+        ConfigurationError, match="Provider does not support reasoning_budget_tokens"
+    ):
+        await provider.generate(
+            ProviderRequest(
+                model=OPENAI_MODEL,
+                parts=["Think about this."],
+                reasoning_budget_tokens=0,
+            )
+        )
+
+    assert responses.last_kwargs is None
 
 
 @pytest.mark.asyncio
@@ -3437,6 +3526,29 @@ async def test_anthropic_generate_maps_reasoning_to_adaptive_for_opus_and_sonnet
 
 
 @pytest.mark.asyncio
+async def test_anthropic_generate_maps_reasoning_budget_tokens_to_thinking_budget() -> (
+    None
+):
+    """Budget-based reasoning should pass through Anthropic's budget_tokens knob."""
+    provider, messages = _anthropic_provider_with_fake()
+
+    await provider.generate(
+        ProviderRequest(
+            model="claude-haiku-4-5",
+            parts=["Think."],
+            reasoning_budget_tokens=1024,
+        )
+    )
+
+    assert messages.last_kwargs is not None
+    assert "output_config" not in messages.last_kwargs
+    assert messages.last_kwargs["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": 1024,
+    }
+
+
+@pytest.mark.asyncio
 async def test_anthropic_generate_reasoning_with_tools_adds_interleaved_header_for_manual() -> (
     None
 ):
@@ -4698,6 +4810,30 @@ async def test_openrouter_validate_request_rejects_unknown_model() -> None:
     with pytest.raises(ConfigurationError, match="model not found"):
         await provider.validate_request(
             ProviderRequest(model="missing/model", parts=["Hello"])
+        )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_validate_request_rejects_reasoning_budget_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsupported reasoning budgets should fail before metadata lookup."""
+    provider = OpenRouterProvider("test-key")
+
+    async def fail_metadata_lookup(_model: str) -> Any:
+        raise AssertionError("metadata lookup should not run")
+
+    monkeypatch.setattr(provider, "_get_model_metadata", fail_metadata_lookup)
+
+    with pytest.raises(
+        ConfigurationError, match="Provider does not support reasoning_budget_tokens"
+    ):
+        await provider.validate_request(
+            ProviderRequest(
+                model=OPENROUTER_MODEL,
+                parts=["Hello"],
+                reasoning_budget_tokens=0,
+            )
         )
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -501,7 +501,7 @@ async def test_gemini_generate_passes_thinking_level_from_reasoning_effort() -> 
 
     await provider.generate(
         ProviderRequest(
-            model="gemini-3-flash-preview",
+            model="models/gemini-3-flash-preview",
             parts=["Think hard."],
             reasoning_effort="low",
         )
@@ -535,7 +535,7 @@ async def test_gemini_generate_passes_thinking_budget_from_reasoning_budget_toke
 
     await provider.generate(
         ProviderRequest(
-            model="gemini-2.5-flash",
+            model="models/gemini-2.5-flash",
             parts=["Think less."],
             reasoning_budget_tokens=0,
         )
@@ -567,7 +567,7 @@ async def test_gemini_generate_includes_thoughts_for_non_zero_budget() -> None:
 
     await provider.generate(
         ProviderRequest(
-            model="gemini-2.5-flash",
+            model="models/gemini-2.5-flash",
             parts=["Think a little."],
             reasoning_budget_tokens=512,
         )
@@ -578,59 +578,6 @@ async def test_gemini_generate_includes_thoughts_for_non_zero_budget() -> None:
     tc = config.thinking_config
     assert tc.include_thoughts is True
     assert tc.thinking_budget == 512
-
-
-@pytest.mark.asyncio
-async def test_gemini_generate_rejects_reasoning_budget_tokens_for_older_models() -> (
-    None
-):
-    """Older Gemini families should fail fast on explicit thinking budgets."""
-    fake_models = MagicMock()
-    fake_models.generate_content = AsyncMock()
-    fake_aio = MagicMock()
-    fake_aio.models = fake_models
-
-    provider = GeminiProvider("test-key")
-    provider._client = MagicMock()
-    provider._client.aio = fake_aio
-
-    with pytest.raises(
-        ConfigurationError,
-        match="does not support reasoning_budget_tokens",
-    ):
-        await provider.generate(
-            ProviderRequest(
-                model=GEMINI_MODEL,
-                parts=["Think less."],
-                reasoning_budget_tokens=0,
-            )
-        )
-
-    fake_models.generate_content.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_gemini_generate_rejects_reasoning_effort_for_2_5_models() -> None:
-    """Gemini 2.5 should tell callers to use explicit thinking budgets instead."""
-    fake_models = MagicMock()
-    fake_models.generate_content = AsyncMock()
-    fake_aio = MagicMock()
-    fake_aio.models = fake_models
-
-    provider = GeminiProvider("test-key")
-    provider._client = MagicMock()
-    provider._client.aio = fake_aio
-
-    with pytest.raises(ConfigurationError, match="does not support reasoning_effort"):
-        await provider.generate(
-            ProviderRequest(
-                model="gemini-2.5-flash",
-                parts=["Think hard."],
-                reasoning_effort="high",
-            )
-        )
-
-    fake_models.generate_content.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Add `Options.reasoning_budget_tokens` and thread it through Pollux's request pipeline for providers that support explicit reasoning budgets. Gemini and Anthropic now accept the option, OpenAI and OpenRouter reject it consistently, and the docs/tests now describe and characterize the provider-specific behavior.

## Related issue

None

## Test plan

- `export PATH="/opt/homebrew/bin:$PATH" && /opt/homebrew/bin/just check`
- Live provider probes with local `.env` credentials:
  - Gemini `gemini-2.5-flash` with `reasoning_budget_tokens=0` and `256`
  - Gemini `gemini-3-flash-preview` with `reasoning_budget_tokens=0` and `128`
  - Anthropic `claude-haiku-4-5` with `reasoning_budget_tokens=1024` and `0`
  - Negative checks for OpenAI `gpt-5-nano` and OpenRouter `google/gemma-3-27b-it:free`
- Added boundary coverage for:
  - option validation and mutual exclusivity
  - pipeline forwarding for both `reasoning_effort` and `reasoning_budget_tokens`
  - Gemini and Anthropic request mapping
  - OpenAI and OpenRouter fail-fast rejection for unsupported budgets

## Notes

- OpenAI and OpenRouter now reject `reasoning_budget_tokens` at the adapter boundary too, so direct provider usage no longer silently ignores the option.
- The known upstream removal of `gemini-2.5-flash-lite-preview-09-2025` is intentionally left for the next PR.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
