### PR TITLE
chore(tests): replace retired gemini model string

### DIFF
--- a/scripts/deferred_delivery_probe.py
+++ b/scripts/deferred_delivery_probe.py
@@ -37,7 +37,7 @@ ProviderName = Literal["gemini", "openai", "anthropic", "openrouter"]
 CaseKind = Literal["live", "validation"]
 
 DEFAULT_MODELS: dict[ProviderName, str] = {
-    "gemini": "gemini-2.5-flash-lite-preview-09-2025",
+    "gemini": "gemini-2.5-flash-lite",
     "openai": "gpt-5-nano",
     "anthropic": "claude-haiku-4-5",
     "openrouter": "openai/gpt-5-nano",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ OPENAI_MODEL = "gpt-5-nano"
 ANTHROPIC_MODEL = "claude-haiku-4-5"
 OPENROUTER_MODEL = "google/gemma-3-27b-it:free"
 CACHE_MODEL = "cache-model"
-GEMINI_API_TEST_MODEL = "gemini-2.5-flash-lite-preview-09-2025"
+GEMINI_API_TEST_MODEL = "gemini-2.5-flash-lite"
 OPENAI_API_TEST_MODEL = OPENAI_MODEL
 ANTHROPIC_API_TEST_MODEL = ANTHROPIC_MODEL
 


### PR DESCRIPTION
## Summary

Replace `gemini-2.5-flash-lite-preview-09-2025` with `gemini-2.5-flash-lite` in test config and the deferred-delivery probe script. Google retired the specific preview model string (now returns 404).

## Related issue

None

## Test plan

Non-behavioral change - only test infrastructure and a dev script are affected. No library code changes, no new behavior to test.

## Notes

The retired model string was only used in two internal locations:
- `tests/conftest.py` (API test model constant)
- `scripts/deferred_delivery_probe.py` (default model for the probe)

No library source code, docs, or user-facing defaults reference this model string.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)