### PR TITLE
feat(core): surface cached_tokens in result usage across all providers

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,5 +1,6 @@
 <!-- Intent: Teach context caching mechanics: the redundant-context problem,
-     creating a cache, cache identity, TTL tuning, when caching pays off, and
+     creating a cache, cache identity, TTL tuning, when caching pays off,
+     reading cache hit token counts from result["usage"]["cached_tokens"], and
      the distinction between Pollux-controlled caching and provider-side
      automatic prompt caching. Do NOT cover source patterns or structured output
      in depth — link to those pages. Assumes the reader understands run_many()
@@ -16,11 +17,13 @@ depending on the provider.
     **Pollux owns:** creating and reusing cached context via `create_cache()`
     (Gemini), toggling Anthropic prompt caching via
     `Options(implicit_caching=...)`, cache identity from content hashes,
-    single-flight deduplication, and the `metrics.cache_used` signal.
+    single-flight deduplication, the `metrics.cache_used` signal, and
+    surfacing provider-reported cache hit counts in
+    `result["usage"]["cached_tokens"]`.
 
     **You own:** deciding when caching is worth the overhead, tuning TTL to
-    match your reuse window, and checking provider-native usage or billing
-    when you need cache-hit accounting for automatic prompt caching.
+    match your reuse window, and accounting for billing differences by
+    provider when interpreting `cached_tokens`.
 
 ## The Redundant-Context Problem
 
@@ -256,6 +259,32 @@ Check `metrics.cache_used` on subsequent calls:
 Keep prompts and sources stable between runs when comparing warm vs reuse
 behavior. Automatic prompt caching at the provider level can still reduce
 costs even when `cache_used` is `False`.
+
+## Observing Cache Hits
+
+`result["usage"]["cached_tokens"]` reports how many input tokens were served
+from cache. The key is absent when no call in the batch reported it; in a
+fan-out it is summed across all calls:
+
+```python
+# result from any run() or run_many() call with caching active
+cached = result["usage"].get("cached_tokens", 0)
+total_input = result["usage"]["input_tokens"]
+print(f"{cached:,} / {total_input:,} input tokens served from cache")
+```
+
+For a per-call breakdown in a fan-out:
+
+```python
+for i, raw in enumerate(result["diagnostics"]["raw_responses"]):
+    hit = raw["usage"].get("cached_tokens", 0)
+    print(f"  prompt {i}: {hit:,} cached tokens")
+```
+
+**Anthropic billing differs from Gemini and OpenAI.** For Gemini and OpenAI,
+`cached_tokens` is a subset of `input_tokens` — cache reads are billed at a
+discount from the same pool. For Anthropic, `cached_tokens` is additive: the
+total billable input is `input_tokens + cached_tokens`.
 
 ## Tuning Explicit Cache TTL
 

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -229,7 +229,7 @@ provider.
 | `tool_calls` | `list[list[dict]]` | Only with tool calling | Per-prompt list of tool-call requests. See [Conversations](conversations-and-agents.md) |
 | `confidence` | `float` | Yes | Heuristic: `0.9` for ok, `0.5` otherwise |
 | `extraction_method` | `str` | Yes | Always `"text"` |
-| `usage` | `dict[str, int]` | Yes | Token counts (`input_tokens`, `output_tokens`, `total_tokens`, and optional `reasoning_tokens`) |
+| `usage` | `dict[str, int]` | Yes | Token counts (`input_tokens`, `output_tokens`, `total_tokens`, and optional `reasoning_tokens`, `cached_tokens`). See [Observing Cache Hits](caching.md#observing-cache-hits) for `cached_tokens` semantics. |
 | `metrics` | `dict[str, Any]` | Yes | `duration_s`, `n_calls`, `cache_used` ([explicit caching](caching.md#explicit-caching-gemini) only), `finish_reasons` (per-prompt, e.g. `"stop"`, `"max_tokens"`). Deferred results also add `metrics["deferred"] = True`. |
 | `diagnostics` | `dict[str, Any]` | Yes | Low-level diagnostics. All calls include `raw_responses`. Deferred results also add `diagnostics["deferred"]` with `job_id`, timing, and per-request lifecycle items. |
 

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -690,6 +690,10 @@ def _parse_response(
             "output_tokens": output_tokens,
             "total_tokens": input_tokens + output_tokens,
         }
+        # cache_read_input_tokens is additive (not a subset of input_tokens).
+        cached_toks = getattr(usage_raw, "cache_read_input_tokens", None)
+        if cached_toks is not None:
+            usage["cached_tokens"] = int(cached_toks)
 
     # Finish reason mapping.
     stop_reason = getattr(response, "stop_reason", None)

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -1080,6 +1080,9 @@ class GeminiProvider:
                 thoughts_toks = _field(usage_metadata, "thoughts_token_count")
                 if thoughts_toks is not None:
                     usage["reasoning_tokens"] = int(thoughts_toks)
+                cached_toks = _field(usage_metadata, "cached_content_token_count")
+                if cached_toks is not None:
+                    usage["cached_tokens"] = int(cached_toks)
         except Exception:
             usage = {}
 

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -231,6 +231,11 @@ class OpenAIProvider:
                 reasoning_toks = _field(out_details, "reasoning_tokens")
                 if reasoning_toks is not None:
                     usage["reasoning_tokens"] = int(reasoning_toks)
+            in_details = _field(usage_raw, "input_tokens_details")
+            if in_details:
+                cached_toks = _field(in_details, "cached_tokens")
+                if cached_toks is not None:
+                    usage["cached_tokens"] = int(cached_toks)
 
         tool_calls: list[ToolCall] = []
         reasoning_parts: list[str] = []

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -715,6 +715,11 @@ def _parse_response(
             usage["total_tokens"] = total_tokens
         if isinstance(reasoning_tokens, int):
             usage["reasoning_tokens"] = reasoning_tokens
+        prompt_details = usage_raw.get("prompt_tokens_details")
+        if isinstance(prompt_details, Mapping):
+            cached_tokens = prompt_details.get("cached_tokens")
+            if isinstance(cached_tokens, int):
+                usage["cached_tokens"] = cached_tokens
 
     response_id = data.get("id")
     tool_calls = _parse_tool_calls(message.get("tool_calls"))

--- a/src/pollux/result.py
+++ b/src/pollux/result.py
@@ -31,7 +31,12 @@ class ResultEnvelope(TypedDict, total=False):
     #: Always ``"text"`` in v1.0.
     extraction_method: str
     #: Keys: ``input_tokens``, ``output_tokens``, ``total_tokens``,
-    #: and optionally ``reasoning_tokens``.
+    #: and optionally ``reasoning_tokens`` and ``cached_tokens``. Values are
+    #: summed across calls in fan-out; per-call values remain in
+    #: ``diagnostics.raw_responses[i]["usage"]``. ``cached_tokens`` reports
+    #: tokens served from a provider cache hit; it is a subset of
+    #: ``input_tokens`` for Gemini and OpenAI, but reported separately from
+    #: ``input_tokens`` for Anthropic.
     usage: dict[str, int]
     #: Keys: ``duration_s``, ``n_calls``, ``cache_used``, ``finish_reasons``.
     metrics: dict[str, Any]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3462,3 +3462,71 @@ async def test_reasoning_tokens_aggregate_in_result_usage(
 
     assert result["usage"]["reasoning_tokens"] == 8
     assert result["usage"]["total_tokens"] == 17
+
+
+@pytest.mark.asyncio
+async def test_cached_tokens_aggregate_across_fanout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cached_tokens should sum across fan-out calls like other usage keys."""
+    fake = ScriptedProvider(
+        script=[
+            {
+                "text": "A1",
+                "usage": {
+                    "input_tokens": 10_000,
+                    "output_tokens": 20,
+                    "total_tokens": 10_020,
+                    "cached_tokens": 0,
+                },
+            },
+            {
+                "text": "A2",
+                "usage": {
+                    "input_tokens": 10_000,
+                    "output_tokens": 20,
+                    "total_tokens": 10_020,
+                    "cached_tokens": 9_500,
+                },
+            },
+            {
+                "text": "A3",
+                "usage": {
+                    "input_tokens": 10_000,
+                    "output_tokens": 20,
+                    "total_tokens": 10_020,
+                    "cached_tokens": 9_500,
+                },
+            },
+        ],
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+
+    result = await pollux.run_many(("Q1?", "Q2?", "Q3?"), config=cfg)
+
+    assert result["usage"]["cached_tokens"] == 19_000
+    assert result["usage"]["input_tokens"] == 30_000
+    # Per-call values remain accessible under diagnostics for anyone who needs
+    # the per-prompt view (e.g., spotting which call missed the cache).
+    per_call = [r["usage"] for r in result["diagnostics"]["raw_responses"]]
+    assert [u.get("cached_tokens") for u in per_call] == [0, 9_500, 9_500]
+
+
+@pytest.mark.asyncio
+async def test_cached_tokens_absent_when_provider_omits_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cached_tokens should not appear when no provider response reports it."""
+    fake = ScriptedProvider(
+        script=[
+            {"text": "A1", "usage": {"input_tokens": 10, "total_tokens": 15}},
+            {"text": "A2", "usage": {"input_tokens": 10, "total_tokens": 15}},
+        ],
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+
+    result = await pollux.run_many(("Q1?", "Q2?"), config=cfg)
+
+    assert "cached_tokens" not in result["usage"]

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -212,6 +212,7 @@ def test_gemini_parse_response_extracts_text_and_usage() -> None:
     fake_usage.candidates_token_count = 25
     fake_usage.total_token_count = 35
     fake_usage.thoughts_token_count = None
+    fake_usage.cached_content_token_count = None
 
     fake_response = MagicMock()
     fake_response.text = "The answer is 42."
@@ -368,6 +369,49 @@ def test_gemini_parse_response_extracts_reasoning_tokens() -> None:
     result = provider._parse_response(fake_response)
 
     assert result.usage["reasoning_tokens"] == 512
+
+
+def test_gemini_parse_response_extracts_cached_tokens() -> None:
+    """Cached content token count should appear in usage when present."""
+    provider = GeminiProvider("test-key")
+
+    fake_usage = MagicMock()
+    fake_usage.prompt_token_count = 10_000
+    fake_usage.candidates_token_count = 25
+    fake_usage.total_token_count = 10_025
+    fake_usage.thoughts_token_count = None
+    fake_usage.cached_content_token_count = 9_500
+
+    fake_response = MagicMock()
+    fake_response.text = "ok"
+    fake_response.parsed = None
+    fake_response.usage_metadata = fake_usage
+
+    result = provider._parse_response(fake_response)
+
+    assert result.usage["cached_tokens"] == 9_500
+    assert result.usage["input_tokens"] == 10_000
+
+
+def test_gemini_parse_response_omits_cached_tokens_when_absent() -> None:
+    """No cached_content_token_count field should produce no cached_tokens key."""
+    provider = GeminiProvider("test-key")
+
+    fake_usage = MagicMock()
+    fake_usage.prompt_token_count = 10
+    fake_usage.candidates_token_count = 25
+    fake_usage.total_token_count = 35
+    fake_usage.thoughts_token_count = None
+    fake_usage.cached_content_token_count = None
+
+    fake_response = MagicMock()
+    fake_response.text = "ok"
+    fake_response.parsed = None
+    fake_response.usage_metadata = fake_usage
+
+    result = provider._parse_response(fake_response)
+
+    assert "cached_tokens" not in result.usage
 
 
 def test_gemini_parse_response_omits_reasoning_when_no_thought_parts() -> None:
@@ -1231,6 +1275,40 @@ async def test_openai_extracts_reasoning_tokens_from_usage() -> None:
     assert result.usage["reasoning_tokens"] == 1024
     assert result.usage["input_tokens"] == 50
     assert result.usage["output_tokens"] == 200
+
+
+@pytest.mark.asyncio
+async def test_openai_extracts_cached_tokens_from_usage() -> None:
+    """Cached prompt token count should appear in usage when present."""
+    in_details = type("InDetails", (), {"cached_tokens": 8_000})()
+    usage_obj = type(
+        "Usage",
+        (),
+        {
+            "input_tokens": 10_000,
+            "output_tokens": 200,
+            "total_tokens": 10_200,
+            "input_tokens_details": in_details,
+        },
+    )()
+
+    fake_response = type(
+        "Response",
+        (),
+        {"output_text": "ok", "id": "resp_789", "usage": usage_obj, "output": []},
+    )()
+
+    responses = _FakeResponses()
+    responses.create = lambda **_kw: _async_return(fake_response)  # type: ignore[method-assign]
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"responses": responses})()
+
+    result = await provider.generate(
+        ProviderRequest(model=OPENAI_MODEL, parts=["Test"])
+    )
+
+    assert result.usage["cached_tokens"] == 8_000
+    assert result.usage["input_tokens"] == 10_000
 
 
 # =============================================================================
@@ -3244,6 +3322,44 @@ def test_anthropic_parse_text_and_usage() -> None:
     assert result.structured is None
 
 
+def test_anthropic_parse_extracts_cached_tokens() -> None:
+    """cache_read_input_tokens should appear as cached_tokens in usage."""
+    from pollux.providers.anthropic import _parse_response
+
+    usage_obj = type(
+        "Usage",
+        (),
+        {
+            "input_tokens": 50,
+            "output_tokens": 25,
+            "cache_read_input_tokens": 9_000,
+        },
+    )()
+    response = _fake_anthropic_response(
+        content=[_fake_text_block("ok")],
+        usage=usage_obj,
+    )
+
+    result = _parse_response(response, response_schema=None)
+
+    assert result.usage["cached_tokens"] == 9_000
+    # Anthropic semantics: cache reads are reported separately from input_tokens.
+    assert result.usage["input_tokens"] == 50
+
+
+def test_anthropic_parse_omits_cached_tokens_when_absent() -> None:
+    """Missing cache_read_input_tokens should not add cached_tokens."""
+    from pollux.providers.anthropic import _parse_response
+
+    response = _fake_anthropic_response(
+        content=[_fake_text_block("ok")],
+    )
+
+    result = _parse_response(response, response_schema=None)
+
+    assert "cached_tokens" not in result.usage
+
+
 def test_anthropic_parse_structured_from_json_text() -> None:
     """Characterize structured output extraction from JSON text."""
     from pollux.providers.anthropic import _parse_response
@@ -4637,6 +4753,26 @@ async def test_openrouter_parse_response_extracts_tool_calls_and_reasoning_state
             }
         ]
     }
+
+
+def test_openrouter_parse_response_extracts_cached_tokens() -> None:
+    """prompt_tokens_details.cached_tokens should appear as cached_tokens."""
+    result = _parse_response(
+        {
+            "id": "gen_cached_1",
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 5_000,
+                "completion_tokens": 25,
+                "total_tokens": 5_025,
+                "prompt_tokens_details": {"cached_tokens": 4_800},
+            },
+        },
+        response_schema=None,
+    )
+
+    assert result.usage["cached_tokens"] == 4_800
+    assert result.usage["input_tokens"] == 5_000
 
 
 def test_openrouter_parse_response_preserves_reasoning_and_details_for_replay() -> None:


### PR DESCRIPTION
## Summary

Populates `result["usage"]["cached_tokens"]` from provider-reported cache hit data for all four providers (Gemini, OpenAI, Anthropic, OpenRouter). The value is summed across fan-out calls via the existing int-aggregation loop and is absent from the envelope when no call in the batch reported it — consistent with how `reasoning_tokens` is handled.

Anthropic's accounting model differs from the others: its `cache_read_input_tokens` is reported *alongside* `input_tokens` rather than as a subset of it. This is documented in the `ResultEnvelope` docstring and in `caching.md`.

## Related issue

None

## Test plan

Seven new tests added across two files:

**`test_providers.py` — characterization tests (4 providers)**
- Gemini: present (`cached_content_token_count` → `cached_tokens`) and absent (field `None`)
- OpenAI: present (`input_tokens_details.cached_tokens` → `cached_tokens`)
- Anthropic: present (`cache_read_input_tokens` → `cached_tokens`) and absent (field missing)
- OpenRouter: present (`prompt_tokens_details.cached_tokens` → `cached_tokens`)

No explicit "absent" tests for OpenAI and OpenRouter: those providers' existing characterization tests construct plain objects/dicts that naturally omit the optional field, so the absent path is already exercised transitively. Gemini and Anthropic use `MagicMock`, where every attribute returns a truthy mock by default — explicit absent tests (setting the field to `None`) are meaningful there.

**`test_pipeline.py` — pipeline boundary tests**
- Fan-out aggregation: three scripted calls with `cached_tokens` values of 0, 9500, 9500 → aggregate 19000; per-call values verified via `result["diagnostics"]["raw_responses"]`
- Absent case: two calls with no `cached_tokens` in usage → key absent from envelope

`just check` passes: 300 passed, 18 deselected.

## Notes

- Provider variable naming in `anthropic.py` was aligned with the other three providers (`cached_toks` instead of `cache_read`). The original comment re-explaining the Gemini/OpenAI accounting model from inside the Anthropic code was trimmed to one minimal line; the full cross-provider comparison lives in the `ResultEnvelope` docstring.
- `sending-content.md`'s ResultEnvelope reference table was updated to list `cached_tokens` as an optional usage key (the authoritative home per DOCS_STRATEGY "One Topic, One Place"). The detail and billing semantics cross-link to `caching.md#observing-cache-hits`.
- The boundary box in `caching.md` was updated: the old "You own: checking provider-native usage for automatic prompt caching" was outdated; Pollux now surfaces that data.