### PR TITLE
feat(local): add self-hosted text provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 OPENROUTER_API_KEY=
 
+# === Self-Hosted Local Models ===
+# Optional base URL for Config(provider="local").
+# Example: http://localhost:11434/v1 or http://localhost:8080/v1
+POLLUX_LOCAL_BASE_URL=
+
 # === Test-Only Contributor Flags ===
 # Not used by the Pollux runtime library.
 # Only affects pytest API test collection (see tests/conftest.py).

--- a/cookbook/getting-started/run-against-local-model.py
+++ b/cookbook/getting-started/run-against-local-model.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Recipe: Run a prompt against a self-hosted OpenAI-compatible model.
+
+Problem:
+    You want to iterate on prompts locally for speed, privacy, or cost without
+    changing pipeline code when you later swap in a cloud provider.
+
+Key idea:
+    `Config(provider="local", model=..., base_url=...)` points Pollux at any
+    OpenAI Chat Completions-compatible server (Ollama, llama.cpp, vLLM,
+    LM Studio, TGI). The `run()` call is identical to any cloud provider —
+    only the `Config` changes.
+
+When to use:
+    - You are prototyping against a quantized model on local hardware.
+    - You need to validate a pipeline on private data before sending it to a
+      cloud provider.
+
+When not to use:
+    - You rely on file inputs, URLs, tool calling, reasoning controls, or
+      context caching. The local provider is text-only by design; see
+      docs/reference/provider-capabilities.md for the full matrix.
+
+Run (against a real local server):
+    export POLLUX_LOCAL_BASE_URL="http://localhost:11434/v1"
+    python -m cookbook getting-started/run-against-local-model \\
+        --no-mock --model gemma3:4b
+
+Run (mock mode, no server needed):
+    python -m cookbook getting-started/run-against-local-model
+
+Success check:
+    - Status is "ok".
+    - Output includes an answer excerpt from the local model (or a mock echo
+      in mock mode).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from cookbook.utils.presentation import (
+    print_excerpt,
+    print_header,
+    print_kv_rows,
+    print_learning_hints,
+    print_section,
+    print_usage,
+)
+from pollux import Config, Source, run
+from pollux.errors import ConfigurationError
+
+DEFAULT_MODEL = "gemma3:4b"
+DEFAULT_CONTEXT = (
+    "Pollux is a Python library for multimodal orchestration on LLM APIs. "
+    "It provides source patterns (fan-out, fan-in, broadcast), context "
+    "caching, and an async execution pipeline."
+)
+DEFAULT_PROMPT = "Summarize the passage in 2 sentences."
+
+
+async def main_async(context: str, prompt: str, *, config: Config) -> None:
+    envelope = await run(prompt, source=Source.from_text(context), config=config)
+
+    status = envelope.get("status", "ok")
+    answers = envelope.get("answers", [])
+    answer = str(answers[0]) if answers else ""
+
+    print_section("Result")
+    print_kv_rows(
+        [
+            ("Status", status),
+            ("Provider", config.provider),
+            ("Model", config.model),
+            ("Base URL", config.base_url or "(mock)"),
+        ]
+    )
+    print_excerpt("Answer excerpt", answer, limit=600)
+    print_usage(envelope)
+
+    hints = []
+    if config.use_mock:
+        hints.append(
+            "Next: set POLLUX_LOCAL_BASE_URL (or pass --base-url) and rerun "
+            "with --no-mock to hit your local server."
+        )
+    hints.append(
+        "Next: keep the same prompt and swap Config to "
+        '`Config(provider="gemini", model="gemini-2.5-flash-lite")` — the '
+        "call site does not change."
+    )
+    if len(answer.strip()) < 80:
+        hints.append(
+            "Next: tighten the prompt and context if the answer is thin; "
+            "local models benefit from more explicit instructions."
+        )
+    print_learning_hints(hints)
+
+
+def build_config_or_exit(args: argparse.Namespace) -> Config:
+    """Build a local Config, translating ConfigurationError into a clean exit.
+
+    The local provider is fixed for this recipe, so we do not reuse the shared
+    ``add_runtime_args`` / ``build_config_or_exit`` helpers: those expose
+    ``--provider`` choices for cloud providers only. Here we surface the two
+    local-specific knobs (``--base-url`` and ``--model``) directly.
+    """
+    try:
+        return Config(
+            provider="local",
+            model=args.model,
+            base_url=args.base_url,
+            api_key=args.api_key,
+            use_mock=bool(args.mock),
+        )
+    except ConfigurationError as exc:
+        hint = f" Hint: {exc.hint}" if exc.hint else ""
+        print(f"Configuration error: {exc}.{hint}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a single prompt against a self-hosted OpenAI-compatible model."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=(
+            "Model identifier as exposed by the local server "
+            "(e.g. 'gemma3:4b' for Ollama, or a repo id for vLLM)."
+        ),
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help=(
+            "OpenAI-compatible endpoint, e.g. http://localhost:11434/v1. "
+            "Falls back to POLLUX_LOCAL_BASE_URL. Not required in mock mode."
+        ),
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="Optional token; most local servers ignore it.",
+    )
+    parser.add_argument(
+        "--mock",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run in mock mode (default: enabled). Use --no-mock to hit the server.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=DEFAULT_PROMPT,
+        help="Prompt to run against the context.",
+    )
+    parser.add_argument(
+        "--text",
+        default=DEFAULT_CONTEXT,
+        help="Plain text context to send alongside the prompt.",
+    )
+    args = parser.parse_args()
+
+    config = build_config_or_exit(args)
+
+    print_header("Local model: text-only swap-in", config=config)
+    asyncio.run(main_async(args.text, args.prompt, config=config))
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbook/getting-started/run-against-local-model.py
+++ b/cookbook/getting-started/run-against-local-model.py
@@ -6,10 +6,9 @@ Problem:
     changing pipeline code when you later swap in a cloud provider.
 
 Key idea:
-    `Config(provider="local", model=..., base_url=...)` points Pollux at any
-    OpenAI Chat Completions-compatible server (Ollama, llama.cpp, vLLM,
-    LM Studio, TGI). The `run()` call is identical to any cloud provider —
-    only the `Config` changes.
+    `Config(provider="local", model=..., base_url=...)` points Pollux at a
+    self-hosted server that speaks OpenAI Chat Completions. The `run()` call is
+    identical to any cloud provider; only the `Config` changes.
 
 When to use:
     - You are prototyping against a quantized model on local hardware.
@@ -88,7 +87,7 @@ async def main_async(context: str, prompt: str, *, config: Config) -> None:
         )
     hints.append(
         "Next: keep the same prompt and swap Config to "
-        '`Config(provider="gemini", model="gemini-2.5-flash-lite")` — the '
+        '`Config(provider="gemini", model="gemini-2.5-flash-lite")`; the '
         "call site does not change."
     )
     if len(answer.strip()) < 80:
@@ -132,7 +131,7 @@ def main() -> None:
         default=DEFAULT_MODEL,
         help=(
             "Model identifier as exposed by the local server "
-            "(e.g. 'gemma3:4b' for Ollama, or a repo id for vLLM)."
+            "(for example, 'gemma3:4b' or a GGUF filename)."
         ),
     )
     parser.add_argument(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,9 +66,8 @@ project root for local development, but never commit it.
 
 ## Self-Hosted Models (`provider="local"`)
 
-Pollux supports any self-hosted server that speaks the OpenAI Chat Completions
-wire format (Ollama, llama.cpp, vLLM, LM Studio, TGI). Point `base_url` at the
-server; `api_key` is optional.
+Pollux supports self-hosted servers that speak the OpenAI Chat Completions wire
+format. Point `base_url` at the server; `api_key` is optional.
 
 ```python
 config = Config(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,9 +31,10 @@ All fields and their defaults:
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `provider` | `"gemini" \| "openai" \| "anthropic" \| "openrouter"` | *(required)* | Provider to use |
+| `provider` | `"gemini" \| "openai" \| "anthropic" \| "openrouter" \| "local"` | *(required)* | Provider to use |
 | `model` | `str` | *(required)* | Model identifier |
-| `api_key` | `str \| None` | `None` | Explicit key; auto-resolved from env if omitted |
+| `api_key` | `str \| None` | `None` | Explicit key; auto-resolved from env if omitted. Optional for `provider="local"` |
+| `base_url` | `str \| None` | `None` | Required for `provider="local"`; rejected for cloud providers. Falls back to `POLLUX_LOCAL_BASE_URL` |
 | `use_mock` | `bool` | `False` | Use mock provider (no network calls) |
 | `request_concurrency` | `int` | `6` | Max concurrent API calls in multi-prompt execution |
 | `retry` | `RetryPolicy` | `RetryPolicy()` | Retry configuration |
@@ -62,6 +63,38 @@ config = Config(provider="openai", model="gpt-5-nano", api_key="sk-...")
 
 Pollux auto-loads `.env` files via `python-dotenv`. Create a `.env` in your
 project root for local development, but never commit it.
+
+## Self-Hosted Models (`provider="local"`)
+
+Pollux supports any self-hosted server that speaks the OpenAI Chat Completions
+wire format (Ollama, llama.cpp, vLLM, LM Studio, TGI). Point `base_url` at the
+server; `api_key` is optional.
+
+```python
+config = Config(
+    provider="local",
+    model="gemma3:4b",
+    base_url="http://localhost:11434/v1",
+)
+```
+
+Or set `POLLUX_LOCAL_BASE_URL` in your environment and omit the kwarg:
+
+```bash
+export POLLUX_LOCAL_BASE_URL="http://localhost:11434/v1"
+```
+
+```python
+config = Config(provider="local", model="gemma3:4b")
+```
+
+The supported surface is narrow by design: text in, text or JSON out. Pollux
+also surfaces model-native reasoning text when the local server returns it.
+File uploads, tool calling, reasoning controls, context caching, and deferred
+delivery are not supported. See
+[Provider Capabilities](reference/provider-capabilities.md#local) for the full
+matrix and [Writing Portable Code Across Providers](portable-code.md#running-against-a-self-hosted-model)
+for swap patterns.
 
 ## Mock Mode
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -242,7 +242,7 @@ asyncio.run(process_collection("./papers", "Summarize the key findings."))
 | `APIError: Model not found on the local server` | Model not loaded on local server | Pull or load the model (e.g. `ollama pull <model>`), or verify the model slug matches what the server exposes |
 | `APIError: Local inference timed out` | Model is too slow for available hardware | Choose a smaller or more-quantized model, or reduce prompt/output length |
 | `ConfigurationError: Local provider does not support ...` | Feature unavailable on local provider | Remove the unsupported option, or switch to a cloud provider |
-| `structured=[None]` on local calls | Server returned non-JSON or schema-failing text despite JSON mode | JSON-mode fidelity varies by server; simplify the schema, adjust the prompt, or try a different local model |
+| `structured=[None]` on local calls | Server returned non-JSON text, or a Pydantic response failed validation | JSON-mode fidelity varies by server; reduce output length pressure, simplify the schema, adjust the prompt, or try a different local model |
 | Import errors | Missing dependencies | Use Python `>=3.10,<3.15` with `uv sync --all-extras` |
 
 ## Variations

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -238,6 +238,11 @@ asyncio.run(process_collection("./papers", "Summarize the key findings."))
 | `status: "partial"` | Some prompts returned empty answers | Check individual entries in `answers` to identify which prompts failed |
 | Remote source rejected | Unsupported MIME type on OpenAI | OpenAI remote URL support is limited to PDFs and images |
 | Keys show as `***redacted***` | Intentional redaction | Your key is still being used. `Config` hides it from string representations |
+| `APIError: Cannot reach local server` | Local server not running, or wrong `base_url` | Start the server and confirm its URL; check `POLLUX_LOCAL_BASE_URL` and the `/v1` suffix |
+| `APIError: Model not found on the local server` | Model not loaded on local server | Pull or load the model (e.g. `ollama pull <model>`), or verify the model slug matches what the server exposes |
+| `APIError: Local inference timed out` | Model is too slow for available hardware | Choose a smaller or more-quantized model, or reduce prompt/output length |
+| `ConfigurationError: Local provider does not support ...` | Feature unavailable on local provider | Remove the unsupported option, or switch to a cloud provider |
+| `structured=[None]` on local calls | Server returned non-JSON or schema-failing text despite JSON mode | JSON-mode fidelity varies by server; simplify the schema, adjust the prompt, or try a different local model |
 | Import errors | Missing dependencies | Use Python `>=3.10,<3.15` with `uv sync --all-extras` |
 
 ## Variations

--- a/docs/portable-code.md
+++ b/docs/portable-code.md
@@ -259,6 +259,36 @@ async def analyze_with_reasoning(
         return result["answers"][0], None
 ```
 
+### Running against a self-hosted model
+
+Point Pollux at a locally hosted model for iteration or privacy-sensitive work,
+then swap back to a cloud provider for production. The pipeline code does not
+change:
+
+```python
+LOCAL = Config(
+    provider="local",
+    model="gemma3:4b",
+    base_url="http://localhost:11434/v1",
+)
+CLOUD = Config(provider="gemini", model="gemini-2.5-flash-lite")
+
+result = await run(
+    "Summarize this.",
+    source=Source.from_text("Test content."),
+    config=LOCAL,  # swap with CLOUD to go remote
+)
+```
+
+The local provider's surface is deliberately narrow: text in, text or JSON
+out. Pollux passively surfaces model-native reasoning text when a local server
+returns it, but it does not send portable reasoning controls to local servers.
+If your pipeline uses file inputs, URLs, tool calling, reasoning controls, or
+context caching, keep those on a cloud provider and treat local as a fallback
+for the text-only subset. See
+[Provider Capabilities](reference/provider-capabilities.md#local) for the
+full matrix.
+
 ### Testing portability
 
 Use mock mode to validate pipeline logic without API calls, then test each
@@ -301,6 +331,12 @@ async def test_analyze_document_mock(provider: str) -> None:
   the error.
 - **Test with mock first.** `use_mock=True` validates your pipeline structure
   without API calls. All providers return synthetic responses in mock mode.
+- **Local is text-only by design.** `provider="local"` targets self-hosted
+  OpenAI-compatible servers for the text subset of Pollux. It can surface
+  model-native reasoning output, but it does not send reasoning controls. If
+  your pipeline relies on file inputs, URLs, tools, reasoning controls, or
+  context caching, keep those paths on a cloud provider and treat local as a
+  fallback.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -140,7 +140,7 @@ py -m cookbook production.resume_on_failure --limit 1
 
 ## Recipe Catalog
 
-All recipes support `--mock / --no-mock`, `--provider`, `--model`, and `--api-key` flags. Start in `--mock` to validate flow, switch to `--no-mock` when prompts are stable.
+Most recipes support `--mock / --no-mock`, `--provider`, `--model`, and `--api-key` flags. Start in `--mock` to validate flow, switch to `--no-mock` when prompts are stable. `run-against-local-model` is the deliberate exception: it fixes `provider="local"` and exposes `--base-url` instead of `--provider`.
 
 | Recipe | Spec | Use it when you want to... | Learn the concept in docs |
 |---|---|---|---|
@@ -148,6 +148,7 @@ All recipes support `--mock / --no-mock`, `--provider`, `--model`, and `--api-ke
 | Broadcast Process Files | `getting-started/broadcast-process-files` | process a directory with the same analysis prompts per file | [Analyzing Collections with Source Patterns](../source-patterns.md) |
 | Structured Output Extraction | `getting-started/structured-output-extraction` | return typed objects instead of parsing JSON by hand | [Extracting Structured Data](../structured-data.md) |
 | Extract Media Insights | `getting-started/extract-media-insights` | analyze one image, audio file, or video with the same entry point | [Sending Content to Models](../sending-content.md) |
+| Run Against Local Model | `getting-started/run-against-local-model` | point Pollux at a self-hosted OpenAI-compatible server without changing call-site code | [Writing Portable Code Across Providers](../portable-code.md) |
 | Fridge Raid | `projects/fridge-raid` | turn fridge photos and pantry notes into a small meal plan with shopping delta | [Extracting Structured Data](../structured-data.md) |
 | Paper-to-Workshop Kit | `projects/paper-to-workshop-kit` | turn one paper into a discussion-ready packet with slides, questions, objections, and actions | [Reducing Costs with Context Caching](../caching.md) |
 | PokeDex Analyst | `projects/pokedex-analyst` | fetch canonical Pokemon facts and turn a short roster into a scouting report | [Continuing Conversations Across Turns](../conversations-and-agents.md) |

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -29,7 +29,7 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Explicit caching (`create_cache`) | ✅ | ❌ | ❌ | ❌ | ❌ | Persistent cache handles are Gemini-only |
 | Implicit caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | ❌ | Anthropic-only; see [caching docs](../caching.md#implicit-caching-anthropic) |
 | Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | ⚠️ server-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
-| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (JSON schema mode) | Local sends `json_schema`; schema enforcement quality varies by server, so Pollux validates downstream |
+| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (JSON schema mode) | Local sends `json_schema`; schema enforcement quality varies by server |
 | Reasoning output (`result["reasoning"]`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ⚠️ server/model-dependent | Pollux surfaces reasoning text when providers return it |
 | `reasoning_effort` | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.); exact model support remains provider-defined |
 | `reasoning_budget_tokens` | ✅ | ❌ | ✅ | ❌ | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
@@ -161,9 +161,9 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 ### Local
 
 - The local provider targets self-hosted servers that speak the OpenAI Chat
-  Completions wire format (Ollama, llama.cpp, vLLM, LM Studio, TGI). It is
-  Pollux's orchestration layer pointed at a local inference engine — not a
-  general compatibility shim for every OpenAI-compatible API.
+  Completions wire format. It is Pollux's orchestration layer pointed at a
+  local inference engine, not a general compatibility shim for every
+  OpenAI-compatible API.
 - `base_url` is required (via `Config(base_url=...)` or the
   `POLLUX_LOCAL_BASE_URL` environment variable). `api_key` is optional; most
   self-hosted servers ignore it.
@@ -175,9 +175,10 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   Requesting any of them raises `ConfigurationError` before dispatch.
 - Structured outputs use OpenAI-compatible JSON schema mode
   (`response_format={"type": "json_schema", ...}`). Server-side schema
-  enforcement quality varies, so Pollux validates the parsed response against
-  the caller's schema downstream. When a server returns non-JSON text or
-  content that fails schema validation, the corresponding entry in
+  enforcement quality varies. Pydantic schema inputs are validated downstream
+  when building `ResultEnvelope.structured`; raw JSON Schema dicts rely on the
+  local server's schema enforcement. When a server returns non-JSON text, or a
+  Pydantic response fails model validation, the corresponding entry in
   `ResultEnvelope.structured` is `None`.
 - Automatic prompt caching depends entirely on the backing inference engine.
   Pollux does not expose a toggle for it.

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -18,24 +18,25 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 
 ## Capability Matrix
 
-| Capability | Gemini | OpenAI | Anthropic | OpenRouter | Notes |
-|---|---|---|---|---|---|
-| Text generation | ✅ | ✅ | ✅ | ✅ | Core feature |
-| Multi-prompt execution (`run_many`) | ✅ | ✅ | ✅ | ✅ | One call per prompt, shared context |
-| Local file inputs | ✅ | ✅ | ✅ | ✅ (images and PDFs) | OpenRouter keeps the local file subset narrow |
-| PDF URL inputs | ✅ (via URI part) | ✅ (native `input_file.file_url`) | ✅ (native `document` URL block) | ⚠️ best-effort | Prefer local PDFs when reliability matters |
-| Image URL inputs | ✅ (via URI part) | ✅ (native `input_image.image_url`) | ✅ (native `image` URL block) | ⚠️ best-effort on supported models | Remote fetch behavior can vary by route |
-| YouTube URL inputs | ✅ | ⚠️ limited | ⚠️ limited | ❌ | OpenAI/Anthropic parity layers (download/re-upload) are out of scope |
-| Explicit caching (`create_cache`) | ✅ | ❌ | ❌ | ❌ | Persistent cache handles are Gemini-only |
-| Implicit caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | Anthropic-only; see [caching docs](../caching.md#implicit-caching-anthropic) |
-| Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
-| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `response_format` or `structured_outputs` |
-| `reasoning_effort` | ✅ | ✅ | ✅ | ⚠️ model-dependent | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.); exact model support remains provider-defined |
-| `reasoning_budget_tokens` | ✅ | ❌ | ✅ | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
-| Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | Use the deferred API directly. |
-| Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | Requires an OpenRouter model that supports `tools`; forced tool use may also require `tool_choice` |
-| Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | Works on OpenRouter models that support tool calling |
-| Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
+| Capability | Gemini | OpenAI | Anthropic | OpenRouter | Local | Notes |
+|---|---|---|---|---|---|---|
+| Text generation | ✅ | ✅ | ✅ | ✅ | ✅ | Core feature |
+| Multi-prompt execution (`run_many`) | ✅ | ✅ | ✅ | ✅ | ✅ | One call per prompt, shared context |
+| Local file inputs | ✅ | ✅ | ✅ | ✅ (images and PDFs) | ❌ | OpenRouter keeps the local file subset narrow; local provider is text-only |
+| PDF URL inputs | ✅ (via URI part) | ✅ (native `input_file.file_url`) | ✅ (native `document` URL block) | ⚠️ best-effort | ❌ | Prefer local PDFs when reliability matters |
+| Image URL inputs | ✅ (via URI part) | ✅ (native `input_image.image_url`) | ✅ (native `image` URL block) | ⚠️ best-effort on supported models | ❌ | Remote fetch behavior can vary by route |
+| YouTube URL inputs | ✅ | ⚠️ limited | ⚠️ limited | ❌ | ❌ | OpenAI/Anthropic parity layers (download/re-upload) are out of scope |
+| Explicit caching (`create_cache`) | ✅ | ❌ | ❌ | ❌ | ❌ | Persistent cache handles are Gemini-only |
+| Implicit caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | ❌ | Anthropic-only; see [caching docs](../caching.md#implicit-caching-anthropic) |
+| Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | ⚠️ server-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
+| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (JSON schema mode) | Local sends `json_schema`; schema enforcement quality varies by server, so Pollux validates downstream |
+| Reasoning output (`result["reasoning"]`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ⚠️ server/model-dependent | Pollux surfaces reasoning text when providers return it |
+| `reasoning_effort` | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.); exact model support remains provider-defined |
+| `reasoning_budget_tokens` | ✅ | ❌ | ✅ | ❌ | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
+| Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | ❌ | Use the deferred API directly. |
+| Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Requires an OpenRouter model that supports `tools`; forced tool use may also require `tool_choice` |
+| Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Works on OpenRouter models that support tool calling |
+| Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
 For when deferred delivery is a fit and how to structure code around provider
 jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.md).
@@ -156,6 +157,34 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   `ResultEnvelope.usage["reasoning_tokens"]` when available. OpenRouter does
   not accept `reasoning_budget_tokens`; Pollux raises `ConfigurationError`
   before dispatch.
+
+### Local
+
+- The local provider targets self-hosted servers that speak the OpenAI Chat
+  Completions wire format (Ollama, llama.cpp, vLLM, LM Studio, TGI). It is
+  Pollux's orchestration layer pointed at a local inference engine — not a
+  general compatibility shim for every OpenAI-compatible API.
+- `base_url` is required (via `Config(base_url=...)` or the
+  `POLLUX_LOCAL_BASE_URL` environment variable). `api_key` is optional; most
+  self-hosted servers ignore it.
+- The supported surface is intentionally narrow: text in, text or JSON out.
+  Pollux passively surfaces model-native reasoning text when the server returns
+  `reasoning_content`, but it does not send portable reasoning controls.
+  File uploads, remote URLs, multimodal parts, tool calling, reasoning controls,
+  explicit and implicit caching, and deferred delivery are not supported.
+  Requesting any of them raises `ConfigurationError` before dispatch.
+- Structured outputs use OpenAI-compatible JSON schema mode
+  (`response_format={"type": "json_schema", ...}`). Server-side schema
+  enforcement quality varies, so Pollux validates the parsed response against
+  the caller's schema downstream. When a server returns non-JSON text or
+  content that fails schema validation, the corresponding entry in
+  `ResultEnvelope.structured` is `None`.
+- Automatic prompt caching depends entirely on the backing inference engine.
+  Pollux does not expose a toggle for it.
+- Conversation continuity uses `history`; there is no server-side session ID
+  equivalent to OpenAI's `previous_response_id`.
+- For swap patterns between local and cloud providers, see
+  [Writing Portable Code Across Providers](../portable-code.md#running-against-a-self-hosted-model).
 
 ## Error Semantics
 

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -317,13 +317,29 @@ async def _close_provider(provider: Provider) -> None:
 
 
 def _create_provider(
-    provider: str, api_key: str | None, *, use_mock: bool = False
+    provider: str,
+    api_key: str | None,
+    *,
+    use_mock: bool = False,
+    base_url: str | None = None,
 ) -> Provider:
     """Instantiate a provider client from explicit parameters."""
     if use_mock:
         from pollux.providers.mock import MockProvider
 
         return MockProvider()
+
+    if provider == "local":
+        from pollux.providers.local import LocalProvider
+
+        if not base_url:
+            raise ConfigurationError(
+                "base_url required for provider='local'",
+                hint=(
+                    "Pass base_url='http://localhost:...' or set POLLUX_LOCAL_BASE_URL."
+                ),
+            )
+        return LocalProvider(base_url=base_url, api_key=api_key)
 
     if provider == "openai":
         from pollux.providers.openai import OpenAIProvider
@@ -367,7 +383,12 @@ def _create_provider(
 
 def _get_provider(config: Config) -> Provider:
     """Get the appropriate provider based on configuration."""
-    return _create_provider(config.provider, config.api_key, use_mock=config.use_mock)
+    return _create_provider(
+        config.provider,
+        config.api_key,
+        use_mock=config.use_mock,
+        base_url=config.base_url,
+    )
 
 
 def _resolve_deferred_provider(handle: DeferredHandle) -> Provider:

--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -11,9 +11,10 @@ import dotenv
 from pollux.errors import ConfigurationError
 from pollux.retry import RetryPolicy
 
-ProviderName = Literal["gemini", "openai", "anthropic", "openrouter"]
+ProviderName = Literal["gemini", "openai", "anthropic", "openrouter", "local"]
 
-# Provider-specific API key environment variable names
+# Provider-specific API key environment variable names.
+# "local" is intentionally absent — self-hosted servers do not require a key.
 _API_KEY_ENV_VARS: dict[ProviderName, str] = {
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
@@ -21,15 +22,36 @@ _API_KEY_ENV_VARS: dict[ProviderName, str] = {
     "openrouter": "OPENROUTER_API_KEY",
 }
 
+_LOCAL_BASE_URL_ENV_VAR = "POLLUX_LOCAL_BASE_URL"
+
+_SUPPORTED_PROVIDERS: tuple[ProviderName, ...] = (
+    "gemini",
+    "openai",
+    "anthropic",
+    "openrouter",
+    "local",
+)
+
 
 def resolve_api_key(provider: ProviderName) -> str | None:
     """Resolve an API key for *provider* using env vars and lazy dotenv loading."""
-    env_var = _API_KEY_ENV_VARS[provider]
+    env_var = _API_KEY_ENV_VARS.get(provider)
+    if env_var is None:
+        return None
     resolved_key = os.environ.get(env_var)
     if not resolved_key:
         dotenv.load_dotenv()
         resolved_key = os.environ.get(env_var)
     return resolved_key
+
+
+def _resolve_local_base_url() -> str | None:
+    """Resolve POLLUX_LOCAL_BASE_URL with lazy dotenv loading."""
+    resolved = os.environ.get(_LOCAL_BASE_URL_ENV_VAR)
+    if not resolved:
+        dotenv.load_dotenv()
+        resolved = os.environ.get(_LOCAL_BASE_URL_ENV_VAR)
+    return resolved
 
 
 @dataclass(frozen=True)
@@ -42,24 +64,32 @@ class Config:
     Example:
         config = Config(provider="gemini", model="gemini-2.0-flash")
         # API key is automatically resolved from GEMINI_API_KEY
+
+    For self-hosted OpenAI-compatible servers, use ``provider="local"`` with
+    a ``base_url`` (or set ``POLLUX_LOCAL_BASE_URL``). No API key is required.
     """
 
     provider: ProviderName
     model: str
     #: Auto-resolved from the provider-specific API key env var when *None*.
+    #: Optional for ``provider="local"``.
     api_key: str | None = None
+    #: Required for ``provider="local"``; rejected for cloud providers.
+    #: Falls back to ``POLLUX_LOCAL_BASE_URL`` when unset.
+    base_url: str | None = None
     use_mock: bool = False
     request_concurrency: int = 6
     retry: RetryPolicy = field(default_factory=RetryPolicy)
 
     def __post_init__(self) -> None:
-        """Auto-resolve API key and validate configuration."""
+        """Auto-resolve credentials and validate configuration."""
         # Validate provider
-        if self.provider not in ("gemini", "openai", "anthropic", "openrouter"):
+        if self.provider not in _SUPPORTED_PROVIDERS:
             raise ConfigurationError(
                 f"Unknown provider: {self.provider!r}",
                 hint=(
-                    "Supported providers: 'gemini', 'openai', 'anthropic', 'openrouter'"
+                    "Supported providers: "
+                    + ", ".join(repr(p) for p in _SUPPORTED_PROVIDERS)
                 ),
             )
 
@@ -73,6 +103,29 @@ class Config:
             raise ConfigurationError(
                 f"request_concurrency must be ≥ 1, got {self.request_concurrency}",
                 hint="This controls how many API calls run in parallel.",
+            )
+
+        if self.provider == "local":
+            # Local: resolve base_url, skip API-key resolution entirely.
+            if self.base_url is None:
+                env_url = _resolve_local_base_url()
+                if env_url:
+                    object.__setattr__(self, "base_url", env_url)
+            if not self.use_mock and not self.base_url:
+                raise ConfigurationError(
+                    "base_url required for provider='local'",
+                    hint=(
+                        "Pass base_url='http://localhost:...' or set "
+                        f"{_LOCAL_BASE_URL_ENV_VAR}."
+                    ),
+                )
+            return
+
+        # Cloud providers: base_url is not a meaningful override here.
+        if self.base_url is not None:
+            raise ConfigurationError(
+                f"base_url is only valid for provider='local', not {self.provider!r}",
+                hint="Remove base_url, or switch to provider='local'.",
             )
 
         # Auto-resolve API key from environment if not provided
@@ -91,7 +144,8 @@ class Config:
         """Return a redacted, developer-friendly representation."""
         return (
             f"Config(provider={self.provider!r}, model={self.model!r}, "
-            f"api_key={'[REDACTED]' if self.api_key else None}, use_mock={self.use_mock})"
+            f"api_key={'[REDACTED]' if self.api_key else None}, "
+            f"base_url={self.base_url!r}, use_mock={self.use_mock})"
         )
 
     __repr__ = __str__

--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -106,8 +106,8 @@ class Config:
             )
 
         if self.provider == "local":
-            # Local: resolve base_url, skip API-key resolution entirely.
-            if self.base_url is None:
+            # Local: resolve base_url for real calls, skip API-key resolution entirely.
+            if self.base_url is None and not self.use_mock:
                 env_url = _resolve_local_base_url()
                 if env_url:
                     object.__setattr__(self, "base_url", env_url)

--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import os
-from typing import Literal
+from typing import Literal, get_args
 
 import dotenv
 
@@ -24,13 +24,7 @@ _API_KEY_ENV_VARS: dict[ProviderName, str] = {
 
 _LOCAL_BASE_URL_ENV_VAR = "POLLUX_LOCAL_BASE_URL"
 
-_SUPPORTED_PROVIDERS: tuple[ProviderName, ...] = (
-    "gemini",
-    "openai",
-    "anthropic",
-    "openrouter",
-    "local",
-)
+_SUPPORTED_PROVIDERS = get_args(ProviderName)
 
 
 def resolve_api_key(provider: ProviderName) -> str | None:

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -173,7 +173,11 @@ def _validate_deferred_plan(plan: Plan, provider: Provider) -> None:
     if options.reasoning_effort is not None and not caps.reasoning:
         raise ConfigurationError(
             "Provider does not support reasoning controls",
-            hint="Remove reasoning_effort or choose a provider with reasoning support.",
+            hint=(
+                "Remove reasoning_effort or choose a provider with reasoning "
+                "controls. Some providers may still surface model-native "
+                "reasoning output without this option."
+            ),
         )
     if options.reasoning_budget_tokens is not None and not caps.reasoning_budget_tokens:
         raise ConfigurationError(

--- a/src/pollux/errors.py
+++ b/src/pollux/errors.py
@@ -79,7 +79,7 @@ class DeferredNotReadyError(PolluxError):
         self.snapshot = snapshot
 
 
-def _walk_exception_chain(exc: BaseException) -> Iterator[BaseException]:
+def walk_exception_chain(exc: BaseException) -> Iterator[BaseException]:
     """Yield *exc* and its ``__cause__``/``__context__`` chain, with cycle protection."""
     seen: set[int] = set()
     stack: list[BaseException] = [exc]

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -158,6 +158,19 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
         and isinstance(p.get("mime_type"), str)
         for p in plan.shared_parts
     ):
+        # TODO: Provider-specific guidance belongs in provider validation, not
+        # execution. Local needs this branch because the generic upload gate
+        # currently runs before LocalProvider.validate_request() can emit its
+        # text-only hint. A cleaner design would preflight provider validation
+        # before generic upload capability checks without starting side effects.
+        if config.provider == "local":
+            raise ConfigurationError(
+                "Local provider does not support file or multimodal input",
+                hint=(
+                    "Pass file content as text via Source.from_text(). "
+                    "Images, PDFs, and remote URIs are not supported."
+                ),
+            )
         raise ConfigurationError(
             "Provider does not support file uploads",
             hint="Choose a provider with uploads support, or remove file sources.",
@@ -212,6 +225,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
     )
     total_usage: dict[str, int] = {}
     conversation_state: dict[str, Any] | None = None
+    conversation_user_contents: list[str | None] = [None] * len(prompts)
 
     try:
         cache_name = plan.cache_name
@@ -238,6 +252,9 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                         [*shared_parts, prompt_part]
                         if prompt_part is not None
                         else [*shared_parts]
+                    )
+                    conversation_user_contents[call_idx] = _history_text_from_parts(
+                        raw_parts
                     )
                     history_msgs: list[Message] | None = None
                     request_provider_state = (
@@ -415,6 +432,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                 if prompts[0] is not None
                 else None
             )
+            user_content = conversation_user_contents[0] or prompt
             answer = responses[0].get("text")
             reply = answer if isinstance(answer, str) else ""
             assistant_msg: dict[str, Any] = {"role": "assistant", "content": reply}
@@ -426,8 +444,8 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                 assistant_msg["provider_state"] = provider_msg_state
 
             updated_history: list[dict[str, Any]] = [*conversation_history]
-            if prompt is not None:
-                updated_history.append({"role": "user", "content": prompt})
+            if user_content is not None:
+                updated_history.append({"role": "user", "content": user_content})
             updated_history.append(assistant_msg)
             conversation_state = {"history": updated_history}
             if isinstance(provider_msg_state, dict):
@@ -450,6 +468,22 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
         usage=total_usage,
         conversation_state=conversation_state,
     )
+
+
+def _history_text_from_parts(parts: list[Any]) -> str | None:
+    """Return a replayable text history message when all parts are text."""
+    texts: list[str] = []
+    for part in parts:
+        if isinstance(part, str):
+            texts.append(part)
+            continue
+        if isinstance(part, dict):
+            text = part.get("text")
+            if isinstance(text, str):
+                texts.append(text)
+                continue
+        return None
+    return "\n\n".join(texts) if texts else None
 
 
 async def _substitute_upload_parts(

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -158,11 +158,9 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
         and isinstance(p.get("mime_type"), str)
         for p in plan.shared_parts
     ):
-        # TODO: Provider-specific guidance belongs in provider validation, not
-        # execution. Local needs this branch because the generic upload gate
-        # currently runs before LocalProvider.validate_request() can emit its
-        # text-only hint. A cleaner design would preflight provider validation
-        # before generic upload capability checks without starting side effects.
+        # TODO(#166): Provider-specific guidance belongs in ProviderCapabilities,
+        # not here. Fix: add file_rejection_hint to ProviderCapabilities and read
+        # it below instead of branching on config.provider.
         if config.provider == "local":
             raise ConfigurationError(
                 "Local provider does not support file or multimodal input",

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -111,7 +111,11 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
     if options.reasoning_effort is not None and not caps.reasoning:
         raise ConfigurationError(
             "Provider does not support reasoning controls",
-            hint="Remove reasoning_effort or choose a provider with reasoning support.",
+            hint=(
+                "Remove reasoning_effort or choose a provider with reasoning "
+                "controls. Some providers may still surface model-native "
+                "reasoning output without this option."
+            ),
         )
     if options.reasoning_budget_tokens is not None and not caps.reasoning_budget_tokens:
         raise ConfigurationError(

--- a/src/pollux/providers/__init__.py
+++ b/src/pollux/providers/__init__.py
@@ -3,12 +3,14 @@
 from .anthropic import AnthropicProvider
 from .base import Provider, ProviderCapabilities
 from .gemini import GeminiProvider
+from .local import LocalProvider
 from .openai import OpenAIProvider
 from .openrouter import OpenRouterProvider
 
 __all__ = [
     "AnthropicProvider",
     "GeminiProvider",
+    "LocalProvider",
     "OpenAIProvider",
     "OpenRouterProvider",
     "Provider",

--- a/src/pollux/providers/_errors.py
+++ b/src/pollux/providers/_errors.py
@@ -18,13 +18,13 @@ from pollux.errors import (
     CacheError,
     ConfigurationError,
     RateLimitError,
-    _walk_exception_chain,
+    walk_exception_chain,
 )
 
 
 def extract_status_code(exc: BaseException) -> int | None:
     """Walk the exception chain to find an HTTP status code."""
-    for e in _walk_exception_chain(exc):
+    for e in walk_exception_chain(exc):
         for attr in ("status_code", "status"):
             value = getattr(e, attr, None)
             if isinstance(value, int) and 100 <= value <= 599:
@@ -76,7 +76,7 @@ def _extract_retry_info_seconds(exc: BaseException) -> float | None:
 
 def extract_retry_after_s(exc: BaseException) -> float | None:
     """Walk the exception chain to find a retry-after delay in seconds."""
-    for e in _walk_exception_chain(exc):
+    for e in walk_exception_chain(exc):
         value = getattr(e, "retry_after", None)
         if isinstance(value, (int, float)) and value >= 0:
             return float(value)
@@ -163,7 +163,7 @@ def wrap_provider_error(
     if isinstance(status_code, int) and status_code in RETRYABLE_STATUS_CODES:
         retryable = True
     elif allow_network_errors:
-        for e in _walk_exception_chain(exc):
+        for e in walk_exception_chain(exc):
             if isinstance(e, (httpx.TimeoutException, httpx.RequestError)):
                 retryable = True
                 break

--- a/src/pollux/providers/local.py
+++ b/src/pollux/providers/local.py
@@ -1,12 +1,11 @@
-"""Local OpenAI-compatible Chat Completions provider.
+"""Local Chat Completions provider for self-hosted inference servers.
 
-Supports any self-hosted server exposing the OpenAI Chat Completions wire
-format (Ollama, llama.cpp, vLLM, LM Studio, TGI). The supported surface is
-deliberately narrow: text in, text or JSON out. Model-native reasoning text is
-surfaced when returned, but reasoning controls, file uploads, context caching,
-tool calling, and deferred delivery are intentionally unsupported — they belong
-to the cloud providers or to the inference server itself, not to Pollux's
-orchestration layer.
+Pollux targets the OpenAI Chat Completions wire format here, not a specific
+inference engine. The supported surface is deliberately narrow: text in, text or
+JSON out. Model-native reasoning text is surfaced when returned, but reasoning
+controls, file uploads, context caching, tool calling, and deferred delivery are
+intentionally unsupported. Those belong to cloud providers, inference servers,
+or application code, not to Pollux's orchestration layer.
 """
 
 from __future__ import annotations
@@ -20,6 +19,7 @@ import httpx
 
 from pollux.errors import APIError, ConfigurationError, walk_exception_chain
 from pollux.providers._errors import wrap_provider_error
+from pollux.providers._utils import to_strict_schema
 from pollux.providers.base import ProviderCapabilities
 from pollux.providers.models import (
     Message,
@@ -150,13 +150,14 @@ class LocalProvider:
         if request.max_tokens is not None:
             payload["max_tokens"] = request.max_tokens
         if request.response_schema is not None:
-            # Modern local servers (llama.cpp, Ollama, vLLM) map this natively
-            # to their grammar engines for strict enforcement.
+            strict_schema = to_strict_schema(request.response_schema)
+            # Servers that support Chat Completions JSON schema mode can map this
+            # to their own constrained decoding implementation.
             payload["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {
-                    "name": "schema",
-                    "schema": request.response_schema,
+                    "name": "pollux_structured_output",
+                    "schema": strict_schema,
                     "strict": True,
                 },
             }
@@ -189,13 +190,13 @@ class LocalProvider:
             raise _local_api_error(
                 "Local server returned a non-object response",
                 phase="generate",
-                hint="Check your server's logs — the response shape is unexpected.",
+                hint="Check your server's logs; the response shape is unexpected.",
             )
 
         return _parse_response(data, response_schema=request.response_schema)
 
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
-        """Reject uploads — local provider takes inline content only."""
+        """Reject uploads because local provider takes inline content only."""
         _ = path, mime_type
         raise _local_api_error(
             "Local provider does not support file uploads",
@@ -212,7 +213,7 @@ class LocalProvider:
         tools: list[dict[str, Any]] | list[Any] | None = None,
         ttl_seconds: int = 3600,
     ) -> str:
-        """Reject cache creation — local provider has no persistent cache."""
+        """Reject cache creation because local provider has no persistent cache."""
         _ = model, parts, system_instruction, tools, ttl_seconds
         raise _local_api_error(
             "Local provider does not support context caching",
@@ -308,7 +309,7 @@ def _parse_response(
     produces ``structured=None`` (matching OpenRouter). result.py then
     surfaces this as a ``None`` entry in the envelope's ``structured``
     list and marks status accordingly. We deliberately do not raise here
-    — local servers vary in their JSON-mode fidelity, and a structured=None
+    because local servers vary in their JSON-mode fidelity, and a structured=None
     slot is the established Pollux signal for "did not produce structured
     output." Revisit if real-world use shows this silent path confuses users.
     """
@@ -329,14 +330,12 @@ def _parse_response(
         else None
     )
 
-    structured: dict[str, Any] | None = None
+    structured: Any = None
     if response_schema is not None and text:
         try:
-            parsed = json.loads(text)
+            structured = json.loads(text)
         except Exception:
-            parsed = None
-        if isinstance(parsed, dict):
-            structured = parsed
+            structured = None
 
     finish_reason = choice.get("finish_reason")
     if not isinstance(finish_reason, str):
@@ -418,7 +417,7 @@ def _hint_for_local_error(exc: BaseException, *, base_url: str) -> str | None:
         if status >= 500:
             return (
                 "Local server error. The server may be overloaded or the "
-                "model may have crashed — check server logs."
+                "model may have crashed; check server logs."
             )
     return None
 

--- a/src/pollux/providers/local.py
+++ b/src/pollux/providers/local.py
@@ -1,0 +1,452 @@
+"""Local OpenAI-compatible Chat Completions provider.
+
+Supports any self-hosted server exposing the OpenAI Chat Completions wire
+format (Ollama, llama.cpp, vLLM, LM Studio, TGI). The supported surface is
+deliberately narrow: text in, text or JSON out. Model-native reasoning text is
+surfaced when returned, but reasoning controls, file uploads, context caching,
+tool calling, and deferred delivery are intentionally unsupported — they belong
+to the cloud providers or to the inference server itself, not to Pollux's
+orchestration layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+import json
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+
+from pollux.errors import APIError, ConfigurationError, walk_exception_chain
+from pollux.providers._errors import wrap_provider_error
+from pollux.providers.base import ProviderCapabilities
+from pollux.providers.models import (
+    Message,
+    ProviderFileAsset,
+    ProviderRequest,
+    ProviderResponse,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_LOCAL_TIMEOUT_S = 300.0
+
+
+class LocalProvider:
+    """Chat Completions provider for self-hosted OpenAI-compatible servers."""
+
+    def __init__(self, base_url: str, api_key: str | None = None) -> None:
+        """Initialize with the server's base URL and an optional auth token.
+
+        Most local servers ignore the Authorization header; some require
+        *any* value. We default to the literal ``"local"`` so both cases
+        behave the same.
+        """
+        self._base_url = base_url
+        self._api_key = api_key or "local"
+        self._client: Any = None
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        """Return supported feature flags (narrow by design)."""
+        return ProviderCapabilities(
+            persistent_cache=False,
+            uploads=False,
+            structured_outputs=True,
+            reasoning=False,
+            reasoning_budget_tokens=False,
+            deferred_delivery=False,
+            conversation=True,
+            implicit_caching=False,
+        )
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Lazily initialize the shared async HTTP client."""
+        if self._client is None:
+            base_url = self._base_url
+            if not base_url.endswith("/"):
+                base_url += "/"
+            self._client = httpx.AsyncClient(
+                base_url=base_url,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=_LOCAL_TIMEOUT_S,
+                limits=httpx.Limits(
+                    max_connections=None, max_keepalive_connections=None
+                ),
+            )
+        return cast("httpx.AsyncClient", self._client)
+
+    async def validate_request(self, request: ProviderRequest) -> None:
+        """Fail fast on features the local provider does not support."""
+        if request.reasoning_budget_tokens is not None:
+            raise ConfigurationError(
+                "Local provider does not support reasoning_budget_tokens",
+                hint="Remove reasoning_budget_tokens.",
+            )
+        if request.reasoning_effort is not None:
+            raise ConfigurationError(
+                "Local provider does not support reasoning_effort controls",
+                hint=(
+                    "Local can surface model-native reasoning when the server "
+                    "returns it, but Pollux does not send portable local "
+                    "reasoning controls. Remove reasoning_effort."
+                ),
+            )
+        if request.tools is not None or request.tool_choice is not None:
+            raise ConfigurationError(
+                "Local provider does not support tool calling",
+                hint=(
+                    "Tool calling is out of scope for the local provider. "
+                    "Use OpenAI, Gemini, or OpenRouter for tool use."
+                ),
+            )
+        if request.history is not None:
+            for item in request.history:
+                if (
+                    item.role == "tool"
+                    or item.tool_call_id is not None
+                    or item.tool_calls is not None
+                ):
+                    raise ConfigurationError(
+                        "Local provider does not support tool-call history",
+                        hint=(
+                            "Start a fresh text-only local conversation, summarize "
+                            "tool results into plain text, or use a provider with "
+                            "tool calling."
+                        ),
+                    )
+        for part in request.parts:
+            if not _is_text_part(part):
+                raise ConfigurationError(
+                    "Local provider does not support file or multimodal input",
+                    hint=(
+                        "Pass file content as text via Source.from_text(). "
+                        "Images, PDFs, and remote URIs are not supported."
+                    ),
+                )
+
+    async def generate(self, request: ProviderRequest) -> ProviderResponse:
+        """Generate a response via OpenAI-compatible Chat Completions."""
+        await self.validate_request(request)
+
+        messages = _build_messages(
+            request.parts,
+            request.history,
+            system_instruction=request.system_instruction,
+        )
+        payload: dict[str, Any] = {
+            "model": request.model,
+            "messages": messages,
+        }
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
+        if request.top_p is not None:
+            payload["top_p"] = request.top_p
+        if request.max_tokens is not None:
+            payload["max_tokens"] = request.max_tokens
+        if request.response_schema is not None:
+            # Modern local servers (llama.cpp, Ollama, vLLM) map this natively
+            # to their grammar engines for strict enforcement.
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "schema",
+                    "schema": request.response_schema,
+                    "strict": True,
+                },
+            }
+
+        client = self._get_client()
+        try:
+            response = await client.post("chat/completions", json=payload)
+            if response.is_error:
+                raise httpx.HTTPStatusError(
+                    _extract_error_message(response),
+                    request=response.request,
+                    response=response,
+                )
+            data = response.json()
+        except asyncio.CancelledError:
+            raise
+        except (ConfigurationError, APIError):
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="local",
+                phase="generate",
+                allow_network_errors=True,
+                message="Local provider generate failed",
+                hint=_hint_for_local_error(e, base_url=self._base_url),
+            ) from e
+
+        if not isinstance(data, dict):
+            raise _local_api_error(
+                "Local server returned a non-object response",
+                phase="generate",
+                hint="Check your server's logs — the response shape is unexpected.",
+            )
+
+        return _parse_response(data, response_schema=request.response_schema)
+
+    async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
+        """Reject uploads — local provider takes inline content only."""
+        _ = path, mime_type
+        raise _local_api_error(
+            "Local provider does not support file uploads",
+            phase="upload",
+            hint="Pass file content as text via Source.from_text().",
+        )
+
+    async def create_cache(
+        self,
+        *,
+        model: str,
+        parts: list[Any],
+        system_instruction: str | None = None,
+        tools: list[dict[str, Any]] | list[Any] | None = None,
+        ttl_seconds: int = 3600,
+    ) -> str:
+        """Reject cache creation — local provider has no persistent cache."""
+        _ = model, parts, system_instruction, tools, ttl_seconds
+        raise _local_api_error(
+            "Local provider does not support context caching",
+            phase="cache",
+        )
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client."""
+        client = self._client
+        if client is None:
+            return
+        self._client = None
+        await client.aclose()
+
+
+def _is_text_part(part: Any) -> bool:
+    """Return True when *part* is plain text the local provider can send inline.
+
+    Mirrors OpenRouter's input-part discrimination: strings and
+    text-only dicts pass; ProviderFileAsset and dicts carrying
+    ``uri``/``mime_type`` are rejected.
+    """
+    if part is None:
+        return True
+    if isinstance(part, str):
+        return True
+    if isinstance(part, ProviderFileAsset):
+        return False
+    if isinstance(part, Mapping):
+        if "uri" in part or "mime_type" in part:
+            return False
+        return isinstance(part.get("text"), str)
+    return False
+
+
+def _build_messages(
+    parts: list[Any],
+    history: list[Message] | None,
+    *,
+    system_instruction: str | None,
+) -> list[dict[str, Any]]:
+    """Build Chat Completions messages from history and text parts."""
+    messages: list[dict[str, Any]] = []
+
+    if system_instruction is not None:
+        messages.append({"role": "system", "content": system_instruction})
+
+    if history is not None:
+        for item in history:
+            message = _history_message(item)
+            if message is not None:
+                messages.append(message)
+
+    user_text = _join_text_parts(parts)
+    if user_text or not messages:
+        messages.append({"role": "user", "content": user_text})
+
+    return messages
+
+
+def _history_message(item: Message) -> dict[str, Any] | None:
+    """Map a Pollux history message to Chat Completions format.
+
+    Tool-call history is unsupported and rejected by ``validate_request`` before
+    dispatch; this helper only maps text-only conversation turns.
+    """
+    if item.role == "tool":
+        return None
+    if not item.content:
+        return None
+    return {"role": item.role, "content": item.content}
+
+
+def _join_text_parts(parts: list[Any]) -> str:
+    """Concatenate text parts into a single user message body."""
+    texts: list[str] = []
+    for part in parts:
+        if isinstance(part, str):
+            texts.append(part)
+        elif isinstance(part, Mapping) and isinstance(part.get("text"), str):
+            texts.append(cast("str", part["text"]))
+    return "\n\n".join(texts)
+
+
+def _parse_response(
+    data: Mapping[str, Any],
+    *,
+    response_schema: dict[str, Any] | None,
+) -> ProviderResponse:
+    """Parse a Chat Completions payload into ProviderResponse.
+
+    JSON parsing is opportunistic: a non-JSON response despite JSON mode
+    produces ``structured=None`` (matching OpenRouter). result.py then
+    surfaces this as a ``None`` entry in the envelope's ``structured``
+    list and marks status accordingly. We deliberately do not raise here
+    — local servers vary in their JSON-mode fidelity, and a structured=None
+    slot is the established Pollux signal for "did not produce structured
+    output." Revisit if real-world use shows this silent path confuses users.
+    """
+    choices = data.get("choices")
+    choice = choices[0] if isinstance(choices, list) and choices else {}
+    if not isinstance(choice, Mapping):
+        choice = {}
+
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        message = {}
+
+    text = _extract_message_text(message.get("content"))
+    reasoning_content = message.get("reasoning_content")
+    reasoning = (
+        reasoning_content
+        if isinstance(reasoning_content, str) and reasoning_content
+        else None
+    )
+
+    structured: dict[str, Any] | None = None
+    if response_schema is not None and text:
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            parsed = None
+        if isinstance(parsed, dict):
+            structured = parsed
+
+    finish_reason = choice.get("finish_reason")
+    if not isinstance(finish_reason, str):
+        finish_reason = None
+
+    usage = _parse_usage(data.get("usage"))
+
+    response_id = data.get("id")
+    return ProviderResponse(
+        text=text,
+        usage=usage,
+        reasoning=reasoning,
+        structured=structured,
+        response_id=response_id if isinstance(response_id, str) else None,
+        finish_reason=finish_reason,
+    )
+
+
+def _extract_message_text(content: Any) -> str:
+    """Extract text from a Chat Completions message content field."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    text_parts: list[str] = []
+    for item in content:
+        if isinstance(item, Mapping) and item.get("type") == "text":
+            text = item.get("text")
+            if isinstance(text, str):
+                text_parts.append(text)
+    return "\n\n".join(text_parts)
+
+
+def _parse_usage(usage_raw: Any) -> dict[str, int]:
+    """Extract token usage from a Chat Completions response."""
+    if not isinstance(usage_raw, Mapping):
+        return {}
+    usage: dict[str, int] = {}
+    prompt = usage_raw.get("prompt_tokens")
+    completion = usage_raw.get("completion_tokens")
+    total = usage_raw.get("total_tokens")
+    if isinstance(prompt, int):
+        usage["input_tokens"] = prompt
+    if isinstance(completion, int):
+        usage["output_tokens"] = completion
+    if isinstance(total, int):
+        usage["total_tokens"] = total
+    details = usage_raw.get("prompt_tokens_details")
+    if isinstance(details, Mapping):
+        cached = details.get("cached_tokens")
+        if isinstance(cached, int):
+            usage["cached_tokens"] = cached
+    return usage
+
+
+def _hint_for_local_error(exc: BaseException, *, base_url: str) -> str | None:
+    """Return a local-specific hint for common failure shapes."""
+    for e in walk_exception_chain(exc):
+        if isinstance(e, (httpx.ConnectError, httpx.ConnectTimeout)):
+            return (
+                f"Cannot reach local server at {base_url}. "
+                f"Is it running? Check POLLUX_LOCAL_BASE_URL."
+            )
+        if isinstance(e, httpx.ReadTimeout):
+            return (
+                f"Local inference timed out after {_LOCAL_TIMEOUT_S:.0f}s. "
+                f"The model may be too slow for your hardware."
+            )
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        body = (exc.response.text or "").lower()
+        if status == 404 or ("model" in body and "not found" in body):
+            return (
+                "Model not found on the local server. "
+                "Load the model (e.g., 'ollama pull <model>') or check the "
+                "model name."
+            )
+        if status >= 500:
+            return (
+                "Local server error. The server may be overloaded or the "
+                "model may have crashed — check server logs."
+            )
+    return None
+
+
+def _extract_error_message(response: httpx.Response) -> str:
+    """Extract a useful error message from a local server HTTP response."""
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+        message = payload.get("message")
+        if isinstance(message, str) and message:
+            return message
+    text = response.text.strip()
+    return text or f"HTTP {response.status_code}"
+
+
+def _local_api_error(
+    message: str,
+    *,
+    phase: str,
+    hint: str | None = None,
+) -> APIError:
+    """Return a local-attributed APIError for direct boundary failures."""
+    return APIError(message, hint=hint, provider="local", phase=phase)

--- a/src/pollux/providers/models.py
+++ b/src/pollux/providers/models.py
@@ -65,7 +65,7 @@ class ProviderResponse:
     text: str = ""
     usage: dict[str, int] = field(default_factory=dict)
     reasoning: str | None = None
-    structured: Any = None
+    structured: dict[str, Any] | list[Any] | None = None
     tool_calls: list[ToolCall] | None = None
     response_id: str | None = None
     finish_reason: str | None = None

--- a/src/pollux/providers/models.py
+++ b/src/pollux/providers/models.py
@@ -65,7 +65,7 @@ class ProviderResponse:
     text: str = ""
     usage: dict[str, int] = field(default_factory=dict)
     reasoning: str | None = None
-    structured: dict[str, Any] | None = None
+    structured: Any = None
     tool_calls: list[ToolCall] | None = None
     response_id: str | None = None
     finish_reason: str | None = None

--- a/src/pollux/retry.py
+++ b/src/pollux/retry.py
@@ -15,7 +15,7 @@ import random
 import time
 from typing import TYPE_CHECKING, TypeVar
 
-from pollux.errors import APIError, _walk_exception_chain
+from pollux.errors import APIError, walk_exception_chain
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -73,7 +73,7 @@ def _is_transient_network_error(exc: BaseException) -> bool:
     except Exception:
         httpx = None
 
-    for e in _walk_exception_chain(exc):
+    for e in walk_exception_chain(exc):
         if isinstance(e, (TimeoutError, asyncio.TimeoutError)):
             return True
         if httpx is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ GEMINI_MODEL = "gemini-2.0-flash"
 OPENAI_MODEL = "gpt-5-nano"
 ANTHROPIC_MODEL = "claude-haiku-4-5"
 OPENROUTER_MODEL = "google/gemma-3-27b-it:free"
+LOCAL_MODEL = "gemma3:4b"
 CACHE_MODEL = "cache-model"
 GEMINI_API_TEST_MODEL = "gemini-2.5-flash-lite"
 OPENAI_API_TEST_MODEL = OPENAI_MODEL
@@ -123,6 +124,7 @@ def isolate_provider_env(request, monkeypatch):
                 "ANTHROPIC_",
                 "OPENROUTER_",
                 "POLLUX_COOKBOOK_DATA_",
+                "POLLUX_LOCAL_",
             )
         ):
             monkeypatch.delenv(key, raising=False)
@@ -212,6 +214,12 @@ def anthropic_model() -> str:
 def openrouter_model() -> str:
     """Return the canonical OpenRouter model for non-API tests."""
     return OPENROUTER_MODEL
+
+
+@pytest.fixture
+def local_model() -> str:
+    """Return the canonical local model for testing."""
+    return LOCAL_MODEL
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,6 +198,104 @@ def test_non_integer_request_concurrency_raises_clear_error(gemini_model: str) -
     assert exc.value.hint is not None
 
 
+def test_local_requires_base_url_without_mock(
+    monkeypatch: pytest.MonkeyPatch,
+    local_model: str,
+) -> None:
+    """Local provider without base_url (env or kwarg) must fail fast."""
+    monkeypatch.delenv("POLLUX_LOCAL_BASE_URL", raising=False)
+
+    with pytest.raises(ConfigurationError, match="base_url required") as exc:
+        Config(provider="local", model=local_model)
+    assert exc.value.hint is not None
+    assert "POLLUX_LOCAL_BASE_URL" in exc.value.hint
+
+
+def test_local_resolves_base_url_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+    local_model: str,
+) -> None:
+    """POLLUX_LOCAL_BASE_URL should populate base_url when kwarg is omitted."""
+    monkeypatch.setenv("POLLUX_LOCAL_BASE_URL", "http://example.local:11434/v1")
+
+    cfg = Config(provider="local", model=local_model)
+
+    assert cfg.base_url == "http://example.local:11434/v1"
+
+
+def test_local_explicit_base_url_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    local_model: str,
+) -> None:
+    """Explicit base_url kwarg should override POLLUX_LOCAL_BASE_URL."""
+    monkeypatch.setenv("POLLUX_LOCAL_BASE_URL", "http://env.local:11434/v1")
+
+    cfg = Config(
+        provider="local",
+        model=local_model,
+        base_url="http://explicit.local:11434/v1",
+    )
+
+    assert cfg.base_url == "http://explicit.local:11434/v1"
+
+
+def test_local_mock_mode_does_not_require_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+    local_model: str,
+) -> None:
+    """Mock mode should skip the base_url requirement."""
+    monkeypatch.delenv("POLLUX_LOCAL_BASE_URL", raising=False)
+
+    cfg = Config(provider="local", model=local_model, use_mock=True)
+
+    assert cfg.use_mock is True
+    assert cfg.base_url is None
+
+
+def test_local_does_not_require_api_key(local_model: str) -> None:
+    """Local provider should work without an API key."""
+    cfg = Config(
+        provider="local",
+        model=local_model,
+        base_url="http://localhost:11434/v1",
+    )
+
+    assert cfg.api_key is None
+
+
+def test_local_does_not_read_provider_env_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    local_model: str,
+) -> None:
+    """Cloud provider API key env vars must not leak into a local Config."""
+    monkeypatch.setenv("GEMINI_API_KEY", "should-not-be-used")
+    monkeypatch.setenv("OPENAI_API_KEY", "should-not-be-used")
+
+    cfg = Config(
+        provider="local",
+        model=local_model,
+        base_url="http://localhost:11434/v1",
+    )
+
+    assert cfg.api_key is None
+
+
+def test_cloud_provider_rejects_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+    gemini_model: str,
+) -> None:
+    """base_url is local-only; cloud providers must reject it."""
+    monkeypatch.setenv("GEMINI_API_KEY", "env-key")
+
+    with pytest.raises(ConfigurationError, match="base_url is only valid") as exc:
+        Config(
+            provider="gemini",
+            model=gemini_model,
+            base_url="http://should-not-allow:11434/v1",
+        )
+    assert exc.value.hint is not None
+
+
 def test_config_str_and_repr_redact_api_key(gemini_model: str) -> None:
     """String representations must not leak secrets."""
     secret = "top-secret-key"
@@ -206,3 +304,13 @@ def test_config_str_and_repr_redact_api_key(gemini_model: str) -> None:
     assert secret not in str(cfg)
     assert secret not in repr(cfg)
     assert "[REDACTED]" in str(cfg)
+
+
+def test_config_str_surfaces_base_url_for_local(local_model: str) -> None:
+    """Local configs surface base_url in str() so users can spot wiring issues."""
+    cfg = Config(
+        provider="local",
+        model=local_model,
+        base_url="http://localhost:11434/v1",
+    )
+    assert "http://localhost:11434/v1" in str(cfg)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -243,8 +243,8 @@ def test_local_mock_mode_does_not_require_base_url(
     monkeypatch: pytest.MonkeyPatch,
     local_model: str,
 ) -> None:
-    """Mock mode should skip the base_url requirement."""
-    monkeypatch.delenv("POLLUX_LOCAL_BASE_URL", raising=False)
+    """Mock mode should skip the base_url requirement and env resolution."""
+    monkeypatch.setenv("POLLUX_LOCAL_BASE_URL", "http://env.local:11434/v1")
 
     cfg = Config(provider="local", model=local_model, use_mock=True)
 

--- a/tests/test_cookbook_contract.py
+++ b/tests/test_cookbook_contract.py
@@ -264,6 +264,7 @@ def test_all_recipes_run_in_mock_mode(tmp_path: Path) -> None:
         f"python -m cookbook getting-started/extract-media-insights --input {image} --mock",
         f"python -m cookbook getting-started/extract-media-insights --input {video} --mock",
         f"python -m cookbook getting-started/extract-media-insights --input {audio} --mock",
+        "python -m cookbook getting-started/run-against-local-model --mock",
         f"python -m cookbook projects/fridge-raid {image} --note 'eggs, rice' --mock",
         f"python -m cookbook projects/paper-to-workshop-kit --input {input_txt} --mock",
         "python -m cookbook projects/pokedex-analyst pikachu gyarados ferrothorn --mock",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -46,6 +46,7 @@ from tests.conftest import (
     ANTHROPIC_MODEL,
     CACHE_MODEL,
     GEMINI_MODEL,
+    LOCAL_MODEL,
     OPENAI_MODEL,
     FakeProvider,
 )
@@ -1022,6 +1023,29 @@ async def test_provider_validation_runs_before_uploads(
 
     assert fake.upload_calls == 0
     assert len(fake.validation_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_local_file_sources_raise_local_specific_guidance(tmp_path: Any) -> None:
+    """Local file inputs should fail with the text-only local provider guidance."""
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    cfg = Config(
+        provider="local",
+        model=LOCAL_MODEL,
+        base_url="http://localhost:8080/v1",
+    )
+
+    with pytest.raises(ConfigurationError, match="Local provider") as exc:
+        await pollux.run(
+            "Summarize this.",
+            source=Source.from_file(file_path, mime_type="text/plain"),
+            config=cfg,
+        )
+
+    assert exc.value.hint is not None
+    assert "Source.from_text()" in exc.value.hint
 
 
 @pytest.mark.asyncio
@@ -2856,6 +2880,51 @@ async def test_conversation_result_includes_conversation_state(
         {"role": "user", "content": "Next question?"},
         {"role": "assistant", "content": "Assistant reply."},
     ]
+
+
+@pytest.mark.asyncio
+async def test_conversation_state_preserves_text_source_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Text sources should remain in replayed history for local continuations."""
+    fake = FakeProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=False,
+            uploads=False,
+            structured_outputs=False,
+            reasoning=False,
+            deferred_delivery=False,
+            conversation=True,
+        )
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+    cfg = Config(provider="local", model=LOCAL_MODEL, use_mock=True)
+
+    first = await pollux.run(
+        "What is the project code?",
+        source=Source.from_text("The project code is K9-ORBIT."),
+        config=cfg,
+        options=Options(history=[]),
+    )
+
+    state = first.get("_conversation_state")
+    assert isinstance(state, dict)
+    assert state["history"][0] == {
+        "role": "user",
+        "content": "The project code is K9-ORBIT.\n\nWhat is the project code?",
+    }
+
+    await pollux.run(
+        "Repeat it.",
+        config=cfg,
+        options=Options(continue_from=first),
+    )
+
+    assert fake.last_generate_kwargs is not None
+    assert fake.last_generate_kwargs["history"][0] == Message(
+        role="user",
+        content="The project code is K9-ORBIT.\n\nWhat is the project code?",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -5319,17 +5319,49 @@ async def test_local_generate_sets_json_mode_when_schema_present() -> None:
     assert fake.last_json["response_format"] == {
         "type": "json_schema",
         "json_schema": {
-            "name": "schema",
+            "name": "pollux_structured_output",
             "schema": {
                 "type": "object",
                 "properties": {"secret_code": {"type": "string"}},
                 "required": ["secret_code"],
+                "additionalProperties": False,
             },
             "strict": True,
         },
     }
     assert "tools" not in fake.last_json
     assert result.structured == {"secret_code": "K9-ORBIT"}
+
+
+@pytest.mark.asyncio
+async def test_local_generate_preserves_non_object_structured_json() -> None:
+    """Structured output parsing should preserve valid non-object JSON values."""
+    fake = _FakeLocalClient(
+        payload={
+            "id": "chatcmpl_local_schema_array",
+            "choices": [
+                {
+                    "message": {"content": '["alpha","beta"]'},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"total_tokens": 5},
+        }
+    )
+    provider = _make_local_provider(fake)
+
+    result = await provider.generate(
+        ProviderRequest(
+            model=LOCAL_MODEL,
+            parts=["Need tags."],
+            response_schema={
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        )
+    )
+
+    assert result.structured == ["alpha", "beta"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -27,6 +27,7 @@ from pollux.providers._utils import to_strict_schema
 from pollux.providers.anthropic import AnthropicProvider
 from pollux.providers.base import ProviderDeferredHandle, ProviderDeferredItem
 from pollux.providers.gemini import GeminiProvider
+from pollux.providers.local import LocalProvider
 from pollux.providers.models import (
     Message,
     ProviderFileAsset,
@@ -39,7 +40,13 @@ from pollux.providers.openrouter import (
     _extract_error_message,
     _parse_response,
 )
-from tests.conftest import ANTHROPIC_MODEL, GEMINI_MODEL, OPENAI_MODEL, OPENROUTER_MODEL
+from tests.conftest import (
+    ANTHROPIC_MODEL,
+    GEMINI_MODEL,
+    LOCAL_MODEL,
+    OPENAI_MODEL,
+    OPENROUTER_MODEL,
+)
 
 pytestmark = pytest.mark.contract
 
@@ -5160,5 +5167,432 @@ async def test_openrouter_provider_configures_timeout() -> None:
     assert client.timeout.read == 300.0
     assert client.timeout.write == 300.0
     assert client.timeout.pool == 300.0
+
+    await provider.aclose()
+
+
+# =============================================================================
+# Local Provider Request / Response Characterization
+# =============================================================================
+
+
+_LOCAL_BASE_URL = "http://localhost:11434/v1"
+
+
+class _FakeLocalClient:
+    """Captures payloads passed to a local OpenAI-compatible server."""
+
+    def __init__(
+        self,
+        *,
+        payload: Any = None,
+        status_code: int = 200,
+        error_body: Any = None,
+    ) -> None:
+        self.last_json: dict[str, Any] | None = None
+        self.closed = False
+        self._status_code = status_code
+        self._error_body = error_body
+        self._payload = payload or {
+            "id": "chatcmpl_local_1",
+            "choices": [
+                {
+                    "message": {"content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        }
+
+    async def post(self, path: str, json: dict[str, Any]) -> Any:
+        self.last_json = json
+        request = httpx.Request("POST", f"{_LOCAL_BASE_URL}{path}")
+        if self._status_code >= 400:
+            return httpx.Response(
+                self._status_code,
+                json=self._error_body,
+                request=request,
+            )
+        return httpx.Response(self._status_code, json=self._payload, request=request)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _make_local_provider(client: _FakeLocalClient) -> LocalProvider:
+    provider = LocalProvider(base_url=_LOCAL_BASE_URL)
+    provider._client = client
+    return provider
+
+
+def test_local_capabilities_are_narrow() -> None:
+    """Capabilities advertise only what the local provider actually supports."""
+    caps = LocalProvider(base_url=_LOCAL_BASE_URL).capabilities
+
+    assert caps.persistent_cache is False
+    assert caps.uploads is False
+    assert caps.structured_outputs is True
+    assert caps.reasoning is False
+    assert caps.reasoning_budget_tokens is False
+    assert caps.deferred_delivery is False
+    assert caps.conversation is True
+    assert caps.implicit_caching is False
+
+
+@pytest.mark.asyncio
+async def test_local_generate_builds_chat_completions_payload() -> None:
+    """Local should send system + history + user text as Chat Completions messages."""
+    fake = _FakeLocalClient()
+    provider = _make_local_provider(fake)
+
+    result = await provider.generate(
+        ProviderRequest(
+            model=LOCAL_MODEL,
+            parts=["Current prompt"],
+            system_instruction="Be concise.",
+            history=[
+                Message(role="user", content="Earlier question"),
+                Message(role="assistant", content="Earlier answer"),
+            ],
+            temperature=0.2,
+            top_p=0.9,
+            max_tokens=128,
+        )
+    )
+
+    assert fake.last_json == {
+        "model": LOCAL_MODEL,
+        "messages": [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Earlier question"},
+            {"role": "assistant", "content": "Earlier answer"},
+            {"role": "user", "content": "Current prompt"},
+        ],
+        "temperature": 0.2,
+        "top_p": 0.9,
+        "max_tokens": 128,
+    }
+    assert result.text == "ok"
+    assert result.finish_reason == "stop"
+    assert result.response_id == "chatcmpl_local_1"
+    assert result.usage == {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+    }
+
+
+@pytest.mark.asyncio
+async def test_local_generate_sets_json_mode_when_schema_present() -> None:
+    """Response schemas should turn into response_format={"type": "json_schema"}."""
+    fake = _FakeLocalClient(
+        payload={
+            "id": "chatcmpl_local_schema",
+            "choices": [
+                {
+                    "message": {"content": '{"secret_code":"K9-ORBIT"}'},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"total_tokens": 5},
+        }
+    )
+    provider = _make_local_provider(fake)
+
+    result = await provider.generate(
+        ProviderRequest(
+            model=LOCAL_MODEL,
+            parts=["Need orbit code."],
+            response_schema={
+                "type": "object",
+                "properties": {"secret_code": {"type": "string"}},
+                "required": ["secret_code"],
+            },
+        )
+    )
+
+    assert fake.last_json is not None
+    assert fake.last_json["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "schema",
+            "schema": {
+                "type": "object",
+                "properties": {"secret_code": {"type": "string"}},
+                "required": ["secret_code"],
+            },
+            "strict": True,
+        },
+    }
+    assert "tools" not in fake.last_json
+    assert result.structured == {"secret_code": "K9-ORBIT"}
+
+
+@pytest.mark.asyncio
+async def test_local_generate_extracts_reasoning_content() -> None:
+    """reasoning_content should surface as reasoning in the ProviderResponse."""
+    fake = _FakeLocalClient(
+        payload={
+            "id": "chatcmpl_local_reasoning",
+            "choices": [
+                {
+                    "message": {
+                        "content": "4",
+                        "reasoning_content": "2+2=4",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"total_tokens": 5},
+        }
+    )
+    provider = _make_local_provider(fake)
+
+    result = await provider.generate(
+        ProviderRequest(
+            model=LOCAL_MODEL,
+            parts=["2+2?"],
+        )
+    )
+
+    assert result.text == "4"
+    assert result.reasoning == "2+2=4"
+
+
+@pytest.mark.asyncio
+async def test_local_generate_returns_structured_none_when_response_is_not_json() -> (
+    None
+):
+    """Non-JSON text despite JSON mode should surface as structured=None (not raise)."""
+    fake = _FakeLocalClient(
+        payload={
+            "id": "chatcmpl_local_bad_json",
+            "choices": [
+                {
+                    "message": {"content": "Sorry, I could not comply."},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"total_tokens": 4},
+        }
+    )
+    provider = _make_local_provider(fake)
+
+    result = await provider.generate(
+        ProviderRequest(
+            model=LOCAL_MODEL,
+            parts=["Need orbit code."],
+            response_schema={
+                "type": "object",
+                "properties": {"secret_code": {"type": "string"}},
+            },
+        )
+    )
+
+    assert result.text == "Sorry, I could not comply."
+    assert result.structured is None
+
+
+@pytest.mark.asyncio
+async def test_local_generate_extracts_cached_tokens() -> None:
+    """prompt_tokens_details.cached_tokens should surface as cached_tokens."""
+    fake = _FakeLocalClient(
+        payload={
+            "id": "chatcmpl_local_cached",
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 5_000,
+                "completion_tokens": 25,
+                "total_tokens": 5_025,
+                "prompt_tokens_details": {"cached_tokens": 4_800},
+            },
+        }
+    )
+    provider = _make_local_provider(fake)
+
+    result = await provider.generate(
+        ProviderRequest(model=LOCAL_MODEL, parts=["hi"]),
+    )
+
+    assert result.usage["cached_tokens"] == 4_800
+    assert result.usage["input_tokens"] == 5_000
+
+
+@pytest.mark.asyncio
+async def test_local_generate_rejects_reasoning_effort() -> None:
+    """Reasoning controls are unsupported even though reasoning output is parsed."""
+    fake = _FakeLocalClient()
+    provider = _make_local_provider(fake)
+
+    with pytest.raises(ConfigurationError, match="reasoning_effort"):
+        await provider.generate(
+            ProviderRequest(
+                model=LOCAL_MODEL,
+                parts=["hi"],
+                reasoning_effort="medium",
+            )
+        )
+
+    assert fake.last_json is None
+
+
+@pytest.mark.asyncio
+async def test_local_generate_rejects_reasoning_budget_tokens() -> None:
+    """Token-budget reasoning is explicitly unsupported on local."""
+    provider = _make_local_provider(_FakeLocalClient())
+
+    with pytest.raises(ConfigurationError, match="reasoning_budget_tokens"):
+        await provider.generate(
+            ProviderRequest(
+                model=LOCAL_MODEL,
+                parts=["hi"],
+                reasoning_budget_tokens=1024,
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_local_generate_rejects_tools() -> None:
+    """Tool calling is out of scope for the local provider."""
+    provider = _make_local_provider(_FakeLocalClient())
+
+    with pytest.raises(ConfigurationError, match="tool calling"):
+        await provider.generate(
+            ProviderRequest(
+                model=LOCAL_MODEL,
+                parts=["hi"],
+                tools=[{"name": "get_weather"}],
+            )
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "history",
+    [
+        [Message(role="tool", content="tool result", tool_call_id="call_1")],
+        [
+            Message(
+                role="assistant",
+                tool_calls=[
+                    ToolCall(id="call_1", name="lookup", arguments='{"q":"x"}')
+                ],
+            )
+        ],
+    ],
+    ids=["tool_message", "assistant_tool_calls"],
+)
+async def test_local_generate_rejects_tool_call_history(
+    history: list[Message],
+) -> None:
+    """Tool-call history must fail fast instead of dropping context."""
+    fake = _FakeLocalClient()
+    provider = _make_local_provider(fake)
+
+    with pytest.raises(ConfigurationError, match="tool-call history"):
+        await provider.generate(
+            ProviderRequest(
+                model=LOCAL_MODEL,
+                parts=["continue"],
+                history=history,
+            )
+        )
+
+    assert fake.last_json is None
+
+
+@pytest.mark.asyncio
+async def test_local_generate_rejects_non_text_parts() -> None:
+    """Multimodal / file parts are explicitly unsupported on local."""
+    provider = _make_local_provider(_FakeLocalClient())
+
+    with pytest.raises(ConfigurationError, match="file or multimodal input"):
+        await provider.generate(
+            ProviderRequest(
+                model=LOCAL_MODEL,
+                parts=[
+                    "Describe this image.",
+                    {"uri": "https://example.com/photo.jpg", "mime_type": "image/jpeg"},
+                ],
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_local_upload_file_raises_api_error(tmp_path: Any) -> None:
+    """Uploads are unsupported; should raise APIError, not silently noop."""
+    provider = LocalProvider(base_url=_LOCAL_BASE_URL)
+    text_path = tmp_path / "note.txt"
+    text_path.write_text("hello", encoding="utf-8")
+
+    with pytest.raises(APIError, match="does not support file uploads") as exc:
+        await provider.upload_file(text_path, "text/plain")
+
+    err = exc.value
+    assert err.provider == "local"
+    assert err.phase == "upload"
+
+
+@pytest.mark.asyncio
+async def test_local_create_cache_raises_api_error() -> None:
+    """Persistent caches are unsupported; should raise APIError."""
+    provider = LocalProvider(base_url=_LOCAL_BASE_URL)
+
+    with pytest.raises(APIError, match="does not support context caching") as exc:
+        await provider.create_cache(model=LOCAL_MODEL, parts=["test"])
+
+    err = exc.value
+    assert err.provider == "local"
+    assert err.phase == "cache"
+
+
+@pytest.mark.asyncio
+async def test_local_generate_surfaces_http_error_as_api_error() -> None:
+    """Non-2xx responses should turn into APIError attributed to 'local'."""
+    fake = _FakeLocalClient(
+        status_code=404,
+        error_body={"error": {"message": f"model '{LOCAL_MODEL}' not found"}},
+    )
+    provider = _make_local_provider(fake)
+
+    with pytest.raises(APIError) as exc:
+        await provider.generate(
+            ProviderRequest(model=LOCAL_MODEL, parts=["hi"]),
+        )
+
+    err = exc.value
+    assert err.provider == "local"
+    assert err.phase == "generate"
+    assert err.status_code == 404
+    assert err.hint is not None
+    assert "Model not found" in err.hint
+
+
+@pytest.mark.asyncio
+async def test_local_aclose_closes_client() -> None:
+    """aclose must close the underlying httpx client and be idempotent."""
+    fake = _FakeLocalClient()
+    provider = _make_local_provider(fake)
+
+    await provider.aclose()
+    assert fake.closed is True
+
+    # Second call must not raise even after the client was cleared.
+    await provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_local_provider_configures_timeout() -> None:
+    """The local provider HTTP client must configure an explicit timeout."""
+    provider = LocalProvider(base_url=_LOCAL_BASE_URL)
+    client = provider._get_client()
+
+    assert isinstance(client.timeout, httpx.Timeout)
+    assert client.timeout.connect == 300.0
+    assert client.timeout.read == 300.0
 
     await provider.aclose()


### PR DESCRIPTION
## Summary

Adds a `local` provider for self-hosted OpenAI-compatible Chat Completions servers, including config wiring, a text-only provider adapter, structured JSON output support, usage normalization, docs, and a cookbook recipe. The intent is to let existing Pollux text integrations swap to local models without turning Pollux into an agentic harness.

## Related issue

None

## Test plan

- `uv run pytest tests/test_config.py tests/test_providers.py::test_local_capabilities_are_narrow tests/test_providers.py::test_local_generate_builds_chat_completions_payload tests/test_providers.py::test_local_generate_sets_json_mode_when_schema_present tests/test_providers.py::test_local_generate_preserves_non_object_structured_json tests/test_providers.py::test_local_generate_returns_structured_none_when_response_is_not_json tests/test_providers.py::test_local_generate_rejects_non_text_parts -q`
- `uv run pytest tests/test_providers.py -q`
- `uv run pytest tests/test_pipeline.py -q`
- `uv run pytest tests/test_pipeline.py::test_conversation_state_preserves_text_source_context tests/test_pipeline.py::test_conversation_result_includes_conversation_state tests/test_pipeline.py::test_local_file_sources_raise_local_specific_guidance tests/test_config.py::test_local_mock_mode_does_not_require_base_url -q`
- `uv run ruff format --check src/pollux/config.py src/pollux/execute.py tests/test_config.py tests/test_pipeline.py`
- `uv run ruff check src/pollux/config.py src/pollux/execute.py tests/test_config.py tests/test_pipeline.py`
- `uv run mypy src/pollux tests/test_config.py tests/test_pipeline.py`
- `just check`
- Manual smoke against `http://192.168.2.52:8080/v1` with `gemma-4-E4B-it-Q5_K_M.gguf`: `/v1/models`, plain `pollux.run()`, Pydantic structured output, and `continue_from` with `Source.from_text()` context.

## Notes

The local provider is intentionally text-only: no file uploads, remote URLs, tool calling, context caching, reasoning controls, or deferred delivery. Live local-server CI is intentionally omitted; the boundary coverage uses fake-client provider characterization and public pipeline tests, with manual local smoke verification when a server is available.

One small TODO remains in `execute.py`: local-specific file-source guidance currently lives at the generic upload gate because provider validation runs after that gate. The comment documents a future cleanup path to preflight provider validation before generic upload capability checks without starting side effects.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)