### PR TITLE
chore(core): remove provider-name check from upload gate

### DIFF
--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -158,20 +158,10 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
         and isinstance(p.get("mime_type"), str)
         for p in plan.shared_parts
     ):
-        # TODO(#166): Provider-specific guidance belongs in ProviderCapabilities,
-        # not here. Fix: add file_rejection_hint to ProviderCapabilities and read
-        # it below instead of branching on config.provider.
-        if config.provider == "local":
-            raise ConfigurationError(
-                "Local provider does not support file or multimodal input",
-                hint=(
-                    "Pass file content as text via Source.from_text(). "
-                    "Images, PDFs, and remote URIs are not supported."
-                ),
-            )
         raise ConfigurationError(
-            "Provider does not support file uploads",
-            hint="Choose a provider with uploads support, or remove file sources.",
+            "Provider does not support file or multimodal input",
+            hint=caps.file_rejection_hint
+            or "Choose a provider with uploads support, or remove file sources.",
         )
 
     schema = options.response_schema_json()

--- a/src/pollux/providers/base.py
+++ b/src/pollux/providers/base.py
@@ -29,6 +29,7 @@ class ProviderCapabilities:
     deferred_delivery: bool = False
     conversation: bool = False
     implicit_caching: bool = False
+    file_rejection_hint: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/pollux/providers/local.py
+++ b/src/pollux/providers/local.py
@@ -60,6 +60,10 @@ class LocalProvider:
             deferred_delivery=False,
             conversation=True,
             implicit_caching=False,
+            file_rejection_hint=(
+                "Pass file content as text via Source.from_text(). "
+                "Images, PDFs, and remote URIs are not supported."
+            ),
         )
 
     def _get_client(self) -> httpx.AsyncClient:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1037,7 +1037,9 @@ async def test_local_file_sources_raise_local_specific_guidance(tmp_path: Any) -
         base_url="http://localhost:8080/v1",
     )
 
-    with pytest.raises(ConfigurationError, match="Local provider") as exc:
+    with pytest.raises(
+        ConfigurationError, match="Provider does not support file or multimodal input"
+    ) as exc:
         await pollux.run(
             "Summarize this.",
             source=Source.from_file(file_path, mime_type="text/plain"),


### PR DESCRIPTION
## Summary

Removes the `config.provider == "local"` string comparison from the upload capability gate in `execute.py`. Provider-specific rejection guidance now travels via `ProviderCapabilities.file_rejection_hint`; the upload gate reads the hint directly and falls back to a generic message when it is `None`.

As a secondary cleanup, the two-branch raise pattern (which had inconsistent error message text) is collapsed to a single raise.

## Related issue

Closes #166

## Test plan

Boundary coverage: `test_local_file_sources_raise_local_specific_guidance` already exercises the affected path end-to-end. Updated the `match` string to reflect the new (consistent) error message and confirmed the hint assertion (`"Source.from_text()" in exc.value.hint`) still holds.

`just check` passes.

## Notes

The collapse from two raises to one is safe: `None or "fallback"` evaluates to the fallback string, so the generic path is unchanged. The error message text is now consistent regardless of provider (`"Provider does not support file or multimodal input"` rather than the old `"file uploads"` variant on the generic branch).