### PR TITLE
feat(core): deprecate Options.delivery_mode ahead of v1.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ The public API is exposed through `src/pollux/__init__.py`:
 |--------|---------|
 | `config.py` | Immutable `Config` dataclass with API key resolution |
 | `source.py` | `Source` factory with `from_text()`, `from_file()`, `from_youtube()`, `from_arxiv()` |
-| `options.py` | Execution options: `response_schema`, `reasoning_effort`, legacy `delivery_mode` compatibility, and conversation inputs |
+| `options.py` | Execution options: `response_schema`, `reasoning_effort`, deprecated `delivery_mode` shim (removal in v1.8.0), and conversation inputs |
 | `cache.py` | `CacheRegistry` for TTL-based context cache management |
 | `errors.py` | Exception hierarchy with `.hint` attribute for actionable messages |
 | `retry.py` | `RetryPolicy` + bounded async retry used by execution and providers |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ print(result["answers"][0])
 
 To use OpenAI instead: `Config(provider="openai", model="gpt-5-nano")`.<br>
 For Anthropic: `Config(provider="anthropic", model="claude-haiku-4-5")`.<br>
-For OpenRouter: `Config(provider="openrouter", model="google/gemma-3-27b-it:free")`.
+For OpenRouter: `Config(provider="openrouter", model="google/gemma-3-27b-it:free")`.<br>
+For a self-hosted OpenAI-compatible server (text-only):
+`Config(provider="local", model="gemma3:4b", base_url="http://localhost:11434/v1")`.
 
 For a full walkthrough (install, key setup, first result), see
 [Getting Started](https://polluxlib.dev/getting-started/).
@@ -152,6 +154,9 @@ export OPENROUTER_API_KEY="your-key-here"
 ```
 
 Keys from: [Google AI Studio](https://ai.dev/) · [OpenAI](https://platform.openai.com/api-keys) · [Anthropic](https://console.anthropic.com/settings/keys) · [OpenRouter](https://openrouter.ai/keys)
+
+For `provider="local"`, no API key is required; point `base_url` (or
+`POLLUX_LOCAL_BASE_URL`) at a self-hosted OpenAI-compatible server.
 
 ## Documentation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,9 +5,12 @@ This roadmap is intentionally scope-constrained. Pollux is already past the
 trustworthy, more legible, and harder to misuse.
 
 - **Intent**: communicate priorities and scope boundaries, not promises.
-- **Last updated**: 2026-03-16
-- **Current status**: v1.5 is complete. Realtime and deferred APIs are both in
-  scope and shipped.
+- **Last updated**: 2026-04-22
+- **Current status**: v1.7 ships reasoning budget tokens, normalized
+  `cached_tokens` usage reporting across providers, and a text-only `local`
+  provider for self-hosted OpenAI-compatible servers.
+  `Options.delivery_mode` is soft-deprecated and scheduled for removal in
+  v1.8.0.
 - **Status tracking**: Issues and PRs are the source of truth for active work.
 
 ## Product Strategy
@@ -32,67 +35,37 @@ to own:
 - Stable entry points for realtime and deferred execution:
   `run()`, `run_many()`, `defer()`, `defer_many()`,
   `inspect_deferred()`, `collect_deferred()`, `cancel_deferred()`.
-- Multimodal source handling across the supported provider matrix.
+- Multimodal source handling across the supported cloud provider matrix, plus
+  a text-only `local` provider for self-hosted OpenAI-compatible servers.
 - Source patterns: fan-out, fan-in, and broadcast.
 - Context reuse through explicit caching, implicit caching where exposed, and
   provider-managed prompt caching where available.
-- Structured outputs, tool calling, and conversation continuity.
+- Structured outputs, tool calling, conversation continuity, and reasoning
+  controls (`reasoning_effort`, `reasoning_budget_tokens`) where providers
+  support them.
+- Usage surface normalized across providers, including `reasoning_tokens` and
+  `cached_tokens` in the result envelope when providers report them.
 
-That means the roadmap should no longer be "more features by default." The bar
-for new work is now: does it make the existing contract more reliable or more
-usable without expanding Pollux into a framework?
+## Scope Philosophy
 
-## Important Future Work
+Pollux is demand-driven. New features ship when a concrete use case makes
+them necessary, not to pre-empt hypothetical needs or to match capability
+matrices from larger frameworks. Issues and PRs are welcome; the bar for
+expansion is whether a change makes an existing contract stronger or removes
+real downstream boilerplate, not whether it broadens surface area.
 
-### 1. Provider Contract Hardening
+This keeps the roadmap intentionally short. "More features by default" is not
+the goal; the goal is a small core that stays trustworthy under real use.
 
-- Expand characterization and real API coverage for the highest-drift
-  boundaries: multimodal inputs, deferred lifecycle normalization, tool-call
-  continuations, reasoning metadata, and routed-provider variability.
-- Make capability drift easier to detect so the public capability docs stay
-  aligned with real provider behavior.
-- Keep unsupported combinations fail-fast, with concrete hints instead of
-  silent degradation.
+## Current Candidates
 
-### 2. Deferred Delivery Operational Polish
+Concrete items currently on the shortlist. None are commitments, and the list
+is expected to stay short. Discovered follow-ups are tracked in GitHub issues.
 
-- Improve docs and cookbook coverage for the real deferred operating model:
-  handle persistence, polling cadence, collection, cancellation, partial
-  failure handling, and backfill-style workflows.
-- Keep the lifecycle intentionally small: submit, inspect, collect, cancel.
-  Prefer better guarantees and diagnostics over more deferred entry points.
-- Consider narrowly scoped controls for provider-owned deferred artifacts only
-  when they solve a real operational problem without turning Pollux into a
-  background job manager.
-
-### 3. API Simplification After v1.5
-
-- Remove or deprecate migration shims once they have served their purpose
-  (example: legacy `Options.delivery_mode` compatibility).
-- Keep the boundary between realtime and deferred execution explicit and hard
-  to misuse.
-- Continue pruning ambiguous naming and low-value convenience layers.
-
-### 4. Production Ergonomics for Core Patterns
-
-- Add stronger cookbook coverage for common production shapes: resume on
-  failure, structured extraction, tool loops, and provider switching where the
-  switch is truly one line.
-- Improve guidance for adopting Pollux correctly on the first try, especially
-  around caching, deferred delivery, and provider capability differences.
-- Favor examples and documentation that reduce downstream rework over new
-  abstractions in `src/pollux/`.
-
-### 5. Selective Expansion, Not Breadth for Breadth's Sake
-
-- Add new provider support or new capability surface only when it clearly
-  reinforces Pollux's core job: delivering prompts and sources, reusing
-  context, normalizing provider lifecycle behavior, and extracting stable
-  results.
-- Hold a high bar for parity adapters that mask provider differences and add
-  maintenance cost.
-- Prefer additive, low-policy features over broad "one API for everything"
-  designs.
+- **Remove `Options.delivery_mode`** in v1.8.0. The shim is soft-deprecated in
+  v1.7 and emits `DeprecationWarning` on explicit use today.
+- **Gemini flex inference tier** — evaluate provider-specific support for
+  Google's flex inference pricing tier (lower cost, higher latency).
 
 ## High-Bar / Not Planned
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,11 +210,12 @@ options = Options(
     provider default when you omit it. OpenRouter forwards it to the routed
     model. Other providers may ignore it in the current release.
 
-!!! note
-    `Options.delivery_mode` remains available only as a compatibility shim for
-    older code. New code should omit it.
-    Deferred work uses `defer()` / `defer_many()`. Legacy
-    `delivery_mode="deferred"` values still raise `ConfigurationError`, with
+!!! warning "Deprecated: `Options.delivery_mode`"
+    `Options.delivery_mode` is deprecated and scheduled for removal in
+    **v1.8.0**. Passing it explicitly now emits a `DeprecationWarning`.
+    New code should omit it: use `run()` / `run_many()` for realtime work and
+    `defer()` / `defer_many()` for deferred work. Legacy
+    `delivery_mode="deferred"` values still raise `ConfigurationError` with
     guidance that depends on which entry point you called.
 
 !!! warning "Cache handle restrictions"

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal
+import warnings
 
 from pydantic import BaseModel
 
@@ -22,6 +23,12 @@ ReasoningEffort = str
 # the accepted set narrow and provides upgrade guidance.
 DeliveryMode = str
 ResponseSchemaInput = type[BaseModel] | dict[str, Any]
+
+# Sentinel default for ``Options.delivery_mode`` so we can distinguish an
+# explicit (deprecated) user value from the implicit default. The sentinel is
+# normalized back to ``"realtime"`` in ``__post_init__`` so external observers
+# never see it.
+_DELIVERY_MODE_UNSET: Final[str] = "__pollux_delivery_mode_unset__"
 
 
 def response_schema_json(
@@ -79,8 +86,10 @@ class Options:
     reasoning_effort: ReasoningEffort | None = None
     #: Controls provider reasoning token budget where supported.
     reasoning_budget_tokens: int | None = None
-    #: Legacy compatibility shim. Realtime remains the only supported value.
-    delivery_mode: DeliveryMode = "realtime"
+    #: Deprecated compatibility shim. Scheduled for removal in v1.8.0.
+    #: Realtime remains the only supported value; use ``run()`` / ``run_many()``
+    #: for realtime work and ``defer()`` / ``defer_many()`` for deferred work.
+    delivery_mode: DeliveryMode = _DELIVERY_MODE_UNSET
     #: Mutually exclusive with *continue_from*.
     history: list[dict[str, Any]] | None = None
     #: Mutually exclusive with *history*.
@@ -144,16 +153,31 @@ class Options:
                 hint="Choose either qualitative effort or an explicit token budget.",
             )
 
-        # Keep this runtime guard even though ``delivery_mode`` is typed as
+        # delivery_mode is a deprecated shim. Distinguish explicit values from
+        # the sentinel default: explicit-but-valid values emit a
+        # DeprecationWarning; the default is silently normalized to "realtime".
+        # Keep the runtime guard even though ``delivery_mode`` is typed as
         # ``str`` on purpose; the loose annotation is a UX choice for editor
         # autocomplete, not a widening of the supported values.
-        if self.delivery_mode not in {"realtime", "deferred"}:
-            raise ConfigurationError(
-                "delivery_mode must be 'realtime' or 'deferred'",
-                hint=(
-                    "Remove delivery_mode, keep the default realtime mode, "
-                    "or use delivery_mode='deferred' only as a migration shim."
-                ),
+        if self.delivery_mode is _DELIVERY_MODE_UNSET:
+            object.__setattr__(self, "delivery_mode", "realtime")
+        else:
+            if self.delivery_mode not in {"realtime", "deferred"}:
+                raise ConfigurationError(
+                    "delivery_mode must be 'realtime' or 'deferred'",
+                    hint=(
+                        "Remove delivery_mode and keep the default realtime "
+                        "mode, or use defer() / defer_many() for deferred work. "
+                        "delivery_mode is deprecated and will be removed in "
+                        "v1.8.0."
+                    ),
+                )
+            warnings.warn(
+                "Options.delivery_mode is deprecated and will be removed in "
+                "v1.8.0. Use run() / run_many() for realtime work and "
+                "defer() / defer_many() for deferred work.",
+                DeprecationWarning,
+                stacklevel=3,
             )
 
         if self.history is not None and self.continue_from is not None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import dataclass, field
 import json
 from typing import TYPE_CHECKING, Any
+import warnings
 
 from pydantic import BaseModel
 import pytest
@@ -1586,7 +1587,6 @@ async def test_options_are_forwarded_when_provider_supports_features(
             system_instruction="Reply in one sentence.",
             response_schema=ExampleSchema,
             **reasoning_options,
-            delivery_mode="realtime",
         ),
     )
 
@@ -1657,6 +1657,7 @@ async def test_implicit_caching_requires_provider_capability_when_enabled(
     assert exc.value.hint is not None
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.asyncio
 async def test_delivery_mode_deferred_is_explicitly_not_implemented(
     monkeypatch: pytest.MonkeyPatch,
@@ -1684,24 +1685,39 @@ async def test_delivery_mode_deferred_is_explicitly_not_implemented(
         )
 
 
-def test_delivery_mode_realtime_is_accepted_as_legacy_compatibility_shim() -> None:
-    """Explicit realtime mode should remain valid for existing callers."""
-    options = Options(delivery_mode="realtime")
+def test_delivery_mode_default_emits_no_deprecation_warning() -> None:
+    """Constructing Options without delivery_mode should be warning-free."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        options = Options()
 
     assert options.delivery_mode == "realtime"
 
 
-def test_delivery_mode_deferred_is_accepted_as_legacy_compatibility_shim() -> None:
+def test_delivery_mode_realtime_emits_deprecation_warning() -> None:
+    """Explicit realtime remains valid but is soft-deprecated ahead of v1.8.0."""
+    with pytest.warns(DeprecationWarning, match="delivery_mode is deprecated"):
+        options = Options(delivery_mode="realtime")
+
+    assert options.delivery_mode == "realtime"
+
+
+def test_delivery_mode_deferred_emits_deprecation_warning() -> None:
     """Deferred remains constructible so Pollux can raise migration guidance."""
-    options = Options(delivery_mode="deferred")
+    with pytest.warns(DeprecationWarning, match="delivery_mode is deprecated"):
+        options = Options(delivery_mode="deferred")
 
     assert options.delivery_mode == "deferred"
 
 
-def test_delivery_mode_rejects_invalid_values() -> None:
-    """Invalid delivery_mode values should fail fast with a clear error."""
-    with pytest.raises(ConfigurationError, match="must be 'realtime' or 'deferred'"):
-        Options(delivery_mode="bogus")
+def test_delivery_mode_rejects_invalid_values_without_warning() -> None:
+    """Invalid delivery_mode values should raise without emitting a warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(
+            ConfigurationError, match="must be 'realtime' or 'deferred'"
+        ):
+            Options(delivery_mode="bogus")
 
 
 def test_deferred_handle_round_trip_serialization() -> None:
@@ -1769,6 +1785,7 @@ async def test_defer_rejects_global_mock_provider() -> None:
         )
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.asyncio
 async def test_defer_rejects_redundant_legacy_delivery_mode() -> None:
     """Deferred entry points should tell legacy callers to drop delivery_mode."""


### PR DESCRIPTION
## Summary

Pre-release prep for v1.7 in three focused commits: soft-deprecate
`Options.delivery_mode` ahead of its v1.8.0 removal, surface
`provider="local"` on the repo landing page, and refresh the roadmap to
match what v1.7 actually ships. Explicit use of `delivery_mode` now
emits `DeprecationWarning`; default construction is unchanged.

## Related issue

None.

## Test plan

`just check` passes (329 tests, lint + mypy clean).

New and updated tests in `tests/test_pipeline.py` cover the four shim
behaviors directly:

- `test_delivery_mode_default_emits_no_deprecation_warning` — default
  construction is warning-free and normalizes to `"realtime"`.
- `test_delivery_mode_realtime_emits_deprecation_warning` — explicit
  `"realtime"` warns and preserves the value.
- `test_delivery_mode_deferred_emits_deprecation_warning` — explicit
  `"deferred"` warns and preserves the value.
- `test_delivery_mode_rejects_invalid_values_without_warning` — invalid
  values raise `ConfigurationError` with no warning noise.

The two pipeline-level rejection tests
(`test_delivery_mode_deferred_is_explicitly_not_implemented`,
`test_defer_rejects_redundant_legacy_delivery_mode`) keep their
original `ConfigurationError` assertions and use
`@pytest.mark.filterwarnings("ignore::DeprecationWarning")` to stay
focused on the rejection path.

README and ROADMAP changes are non-behavioral (boundary coverage:
documentation-only).

## Notes

- **Sentinel default**: `delivery_mode` now defaults to an internal
  sentinel that `__post_init__` normalizes back to `"realtime"`, so
  observers that read `options.delivery_mode` see no behavior change
  and downstream code in `execute.py` / `deferred.py` is untouched.
  Explicit valid values emit `DeprecationWarning` (stacklevel=3, so the
  warning points at the caller, not the dataclass internals); invalid
  values raise before any warning is emitted.
- **Migration path**: drop the kwarg. If the value was `"deferred"`,
  switch the call to `defer()` / `defer_many()`. The
  `ConfigurationError` hint now names the v1.8.0 target directly.
- **Strict-warnings callers**: anyone running with
  `-W error::DeprecationWarning` will see the warning promoted to an
  error on explicit `delivery_mode` use. That's the expected contract
  for a soft-deprecation cycle and is called out in
  `docs/configuration.md`.
- **README** adds a one-line `Config(provider="local", ...)` example
  and a note that `provider="local"` uses `base_url` /
  `POLLUX_LOCAL_BASE_URL` instead of an API key. The capability
  shipped in #165 but was never visible on the repo landing page.
- **ROADMAP** bumps the status line to v1.7, updates "Current
  Position" to include the local provider, reasoning controls, and
  normalized `reasoning_tokens` / `cached_tokens` usage, replaces the
  five-subsection "Important Future Work" block with a shorter
  "Current Candidates" list (delivery_mode removal, Gemini flex
  inference tier), and adds a "Scope Philosophy" section framing
  Pollux as demand-driven. `High-Bar / Not Planned` is unchanged.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] \`just check\` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)