### PR TITLE
refactor(core): isolate upcoming v2 seams with simplicity-focused cleanups

### DIFF
--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -16,11 +16,18 @@ Public API:
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from pollux.cache import CacheHandle
-from pollux.config import Config, ProviderName, resolve_api_key
+from pollux.config import (
+    _API_KEY_ENV_VARS,
+    _LOCAL_BASE_URL_ENV_VAR,
+    Config,
+    ProviderName,
+    resolve_api_key,
+)
 from pollux.deferred import (
     DeferredHandle,
     DeferredSnapshot,
@@ -50,7 +57,7 @@ from pollux.retry import RetryPolicy
 from pollux.source import Source
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from pollux.providers.base import Provider
 
@@ -316,6 +323,63 @@ async def _close_provider(provider: Provider) -> None:
             logger.warning("Provider cleanup failed: %s", exc)
 
 
+@dataclass(frozen=True)
+class _ProviderSpec:
+    """Registry entry describing how to build and use a provider.
+
+    ``build`` performs a lazy import so provider SDKs stay un-imported until the
+    provider is actually instantiated.
+    """
+
+    build: Callable[[str | None, str | None], Provider]
+    requires_api_key: bool = True
+    requires_base_url: bool = False
+    supports_deferred: bool = False
+
+
+def _build_gemini(api_key: str | None, _base_url: str | None) -> Provider:
+    from pollux.providers.gemini import GeminiProvider
+
+    return GeminiProvider(cast("str", api_key))
+
+
+def _build_openai(api_key: str | None, _base_url: str | None) -> Provider:
+    from pollux.providers.openai import OpenAIProvider
+
+    return OpenAIProvider(cast("str", api_key))
+
+
+def _build_anthropic(api_key: str | None, _base_url: str | None) -> Provider:
+    from pollux.providers.anthropic import AnthropicProvider
+
+    return AnthropicProvider(cast("str", api_key))
+
+
+def _build_openrouter(api_key: str | None, _base_url: str | None) -> Provider:
+    from pollux.providers.openrouter import OpenRouterProvider
+
+    return OpenRouterProvider(cast("str", api_key))
+
+
+def _build_local(api_key: str | None, base_url: str | None) -> Provider:
+    from pollux.providers.local import LocalProvider
+
+    return LocalProvider(base_url=cast("str", base_url), api_key=api_key)
+
+
+# Single source of truth for provider construction and lifecycle traits.
+# Keep keys aligned with config.ProviderName.
+_PROVIDER_REGISTRY: dict[str, _ProviderSpec] = {
+    "gemini": _ProviderSpec(build=_build_gemini, supports_deferred=True),
+    "openai": _ProviderSpec(build=_build_openai, supports_deferred=True),
+    "anthropic": _ProviderSpec(build=_build_anthropic, supports_deferred=True),
+    "openrouter": _ProviderSpec(build=_build_openrouter, supports_deferred=True),
+    "local": _ProviderSpec(
+        build=_build_local, requires_api_key=False, requires_base_url=True
+    ),
+}
+
+
 def _create_provider(
     provider: str,
     api_key: str | None,
@@ -329,56 +393,32 @@ def _create_provider(
 
         return MockProvider()
 
-    if provider == "local":
-        from pollux.providers.local import LocalProvider
+    spec = _PROVIDER_REGISTRY.get(provider)
+    if spec is None:
+        raise ConfigurationError(
+            f"Unknown provider: {provider!r}",
+            hint="Supported providers: "
+            + ", ".join(repr(name) for name in _PROVIDER_REGISTRY),
+        )
 
-        if not base_url:
-            raise ConfigurationError(
-                "base_url required for provider='local'",
-                hint=(
-                    "Pass base_url='http://localhost:...' or set POLLUX_LOCAL_BASE_URL."
-                ),
-            )
-        return LocalProvider(base_url=base_url, api_key=api_key)
-
-    if provider == "openai":
-        from pollux.providers.openai import OpenAIProvider
-
-        if not api_key:
-            raise ConfigurationError(
-                "api_key required for real API",
-                hint="Set OPENAI_API_KEY or pass Config(api_key=...).",
-            )
-        return OpenAIProvider(api_key)
-
-    if provider == "anthropic":
-        from pollux.providers.anthropic import AnthropicProvider
-
-        if not api_key:
-            raise ConfigurationError(
-                "api_key required for real API",
-                hint="Set ANTHROPIC_API_KEY or pass Config(api_key=...).",
-            )
-        return AnthropicProvider(api_key)
-
-    if provider == "openrouter":
-        from pollux.providers.openrouter import OpenRouterProvider
-
-        if not api_key:
-            raise ConfigurationError(
-                "api_key required for real API",
-                hint="Set OPENROUTER_API_KEY or pass Config(api_key=...).",
-            )
-        return OpenRouterProvider(api_key)
-
-    from pollux.providers.gemini import GeminiProvider
-
-    if not api_key:
+    if spec.requires_base_url and not base_url:
+        raise ConfigurationError(
+            f"base_url required for provider={provider!r}",
+            hint=(
+                "Pass base_url='http://localhost:...' or set "
+                f"{_LOCAL_BASE_URL_ENV_VAR}."
+            ),
+        )
+    if spec.requires_api_key and not api_key:
+        env_var = _API_KEY_ENV_VARS.get(
+            cast("ProviderName", provider), "the provider API key"
+        )
         raise ConfigurationError(
             "api_key required for real API",
-            hint="Set GEMINI_API_KEY or pass Config(api_key=...).",
+            hint=f"Set {env_var} or pass Config(api_key=...).",
         )
-    return GeminiProvider(api_key)
+
+    return spec.build(api_key, base_url)
 
 
 def _get_provider(config: Config) -> Provider:
@@ -393,7 +433,8 @@ def _get_provider(config: Config) -> Provider:
 
 def _resolve_deferred_provider(handle: DeferredHandle) -> Provider:
     """Resolve a provider client for deferred lifecycle calls from the handle."""
-    if handle.provider not in {"gemini", "openai", "anthropic", "openrouter"}:
+    spec = _PROVIDER_REGISTRY.get(handle.provider)
+    if spec is None or not spec.supports_deferred:
         raise ConfigurationError(
             f"Unknown provider on deferred handle: {handle.provider!r}",
             hint="Persist Pollux DeferredHandle values without modifying their provider field.",

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -43,6 +43,7 @@ from pollux.errors import (
 from pollux.execute import execute_plan
 from pollux.options import Options
 from pollux.plan import build_plan
+from pollux.providers.base import CloseableProvider
 from pollux.request import normalize_request
 from pollux.result import ResultEnvelope, build_result
 from pollux.retry import RetryPolicy
@@ -306,10 +307,9 @@ async def create_cache(
 
 async def _close_provider(provider: Provider) -> None:
     """Close provider resources without masking primary errors."""
-    aclose = getattr(provider, "aclose", None)
-    if callable(aclose):
+    if isinstance(provider, CloseableProvider):
         try:
-            await aclose()
+            await provider.aclose()
         except asyncio.CancelledError:
             raise
         except Exception as exc:

--- a/src/pollux/capabilities.py
+++ b/src/pollux/capabilities.py
@@ -1,0 +1,112 @@
+"""Validation of a planned interaction against provider capabilities.
+
+This is the capability-resolution seam: given the requested ``Options`` and a
+provider's ``ProviderCapabilities``, reject combinations the provider cannot
+serve before any network I/O. Providers may still perform finer model-specific
+validation at their boundary (see ``ValidatingProvider``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pollux.errors import ConfigurationError
+
+if TYPE_CHECKING:
+    from pollux.options import Options
+    from pollux.providers.base import ProviderCapabilities
+
+
+def validate_capabilities(
+    options: Options,
+    caps: ProviderCapabilities,
+    *,
+    n_prompts: int,
+    has_file_parts: bool,
+    cache_requested: bool,
+) -> None:
+    """Reject requested features the provider does not support.
+
+    Args:
+        options: Normalized execution options for the interaction.
+        caps: The provider's declared capabilities.
+        n_prompts: Number of prompts in the plan (conversation is single-prompt).
+        has_file_parts: Whether the plan carries local file parts to upload.
+        cache_requested: Whether a persistent cache handle is in play.
+
+    Raises:
+        ConfigurationError: If a requested feature is unsupported. Order is
+            preserved so callers see a deterministic first failure.
+    """
+    wants_conversation = (
+        options.history is not None or options.continue_from is not None
+    )
+
+    # Uniform "feature requested but provider lacks the capability" checks.
+    # Each row: (requested, supported, message, hint).
+    uniform_checks: tuple[tuple[bool, bool, str, str], ...] = (
+        (
+            options.response_schema is not None,
+            caps.structured_outputs,
+            "Provider does not support structured outputs",
+            "Remove response_schema or choose a provider with schema support.",
+        ),
+        (
+            options.reasoning_effort is not None,
+            caps.reasoning,
+            "Provider does not support reasoning controls",
+            "Remove reasoning_effort or choose a provider with reasoning "
+            "controls. Some providers may still surface model-native "
+            "reasoning output without this option.",
+        ),
+        (
+            options.reasoning_budget_tokens is not None,
+            caps.reasoning_budget_tokens,
+            "Provider does not support reasoning_budget_tokens",
+            "Use reasoning_effort, or choose a provider that accepts "
+            "an explicit reasoning token budget.",
+        ),
+        (
+            options.implicit_caching is True,
+            caps.implicit_caching,
+            "Provider does not support implicit caching",
+            "Remove implicit_caching=True or choose a provider with implicit "
+            "caching support.",
+        ),
+        (
+            wants_conversation,
+            caps.conversation,
+            "Provider does not support conversation continuity",
+            "Remove history/continue_from or choose a provider with "
+            "conversation support.",
+        ),
+    )
+    for requested, supported, message, hint in uniform_checks:
+        if requested and not supported:
+            raise ConfigurationError(message, hint=hint)
+
+    if wants_conversation and n_prompts != 1:
+        raise ConfigurationError(
+            "Conversation continuity currently supports exactly one prompt per call",
+            hint="Use run() or run_many() with a single prompt when passing "
+            "history/continue_from.",
+        )
+
+    # Runtime safety net: reject hand-built handles targeting providers that
+    # lack persistent caching (the planner already validates other cache
+    # conflicts).
+    if cache_requested and not caps.persistent_cache:
+        raise ConfigurationError(
+            "Provider does not support persistent caching",
+            hint=(
+                "Remove options.cache or choose a provider with "
+                "persistent_cache support."
+            ),
+        )
+
+    if has_file_parts and not caps.uploads:
+        raise ConfigurationError(
+            "Provider does not support file or multimodal input",
+            hint=caps.file_rejection_hint
+            or "Choose a provider with uploads support, or remove file sources.",
+        )

--- a/src/pollux/continuation.py
+++ b/src/pollux/continuation.py
@@ -1,0 +1,211 @@
+"""The v1.x conversation-continuation mechanism.
+
+Pollux 1.x carries continuation state as a dict under the private
+``_conversation_state`` key of a ``ResultEnvelope``. This module owns the full
+surface of that mechanism:
+
+- :func:`load_continuation` resolves prior-turn state from ``continue_from``.
+- :func:`history_to_messages` translates history dicts into provider messages.
+- :func:`build_conversation_state` assembles the updated state after a response.
+- :func:`history_text_from_parts` derives a replayable user text turn.
+
+It is the single seam the v2 ``Continuation`` primitive will replace.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import TYPE_CHECKING, Any
+
+from pollux.errors import ConfigurationError
+from pollux.providers.models import Message, ToolCall
+
+if TYPE_CHECKING:
+    from pollux.options import Options
+    from pollux.providers.models import ProviderResponse
+
+
+@dataclass(frozen=True)
+class ContinuationState:
+    """Resolved prior-turn state for the current interaction.
+
+    ``history`` is the effective message history (explicit or recovered from
+    ``continue_from``). ``conversation_history`` is the base history that the
+    updated state will be appended to.
+    """
+
+    history: list[dict[str, Any]] | None
+    conversation_history: list[dict[str, Any]]
+    previous_response_id: str | None
+    provider_state: dict[str, Any] | None
+
+
+def load_continuation(options: Options) -> ContinuationState:
+    """Resolve prior conversation state from ``history`` / ``continue_from``."""
+    history = options.history
+    conversation_history: list[dict[str, Any]] = []
+    if history is not None:
+        conversation_history = [dict(item) for item in history]
+
+    previous_response_id: str | None = None
+    provider_state: dict[str, Any] | None = None
+    if options.continue_from is not None:
+        state = options.continue_from.get("_conversation_state")
+        if not isinstance(state, dict):
+            raise ConfigurationError(
+                "continue_from is missing _conversation_state",
+                hint=(
+                    "Pass a prior Pollux ResultEnvelope produced with conversation "
+                    "support."
+                ),
+            )
+
+        state_history = state.get("history")
+        if history is None and isinstance(state_history, list):
+            conversation_history = [
+                item
+                for item in state_history
+                if isinstance(item, dict) and isinstance(item.get("role"), str)
+            ]
+
+        if history is None:
+            history = conversation_history
+
+        prev = state.get("response_id")
+        previous_response_id = prev if isinstance(prev, str) else None
+        raw_provider_state = state.get("provider_state")
+        if isinstance(raw_provider_state, dict):
+            provider_state = dict(raw_provider_state)
+
+    return ContinuationState(
+        history=history,
+        conversation_history=conversation_history,
+        previous_response_id=previous_response_id,
+        provider_state=provider_state,
+    )
+
+
+def history_text_from_parts(parts: list[Any]) -> str | None:
+    """Return a replayable text history message when all parts are text."""
+    texts: list[str] = []
+    for part in parts:
+        if isinstance(part, str):
+            texts.append(part)
+            continue
+        if isinstance(part, dict):
+            text = part.get("text")
+            if isinstance(text, str):
+                texts.append(text)
+                continue
+        return None
+    return "\n\n".join(texts) if texts else None
+
+
+def history_to_messages(
+    history: list[dict[str, Any]],
+) -> tuple[list[Message], list[dict[str, Any] | None] | None]:
+    """Translate history dicts into provider ``Message`` objects.
+
+    Returns the messages plus the per-message provider states when any are
+    present (so the caller can fold them into the request provider state under
+    a ``"history"`` key), or ``None`` when no message carried provider state.
+    """
+    messages: list[Message] = []
+    item_states: list[dict[str, Any] | None] = []
+    has_item_states = False
+    for h in history:
+        role = h.get("role", "user")
+        content = h.get("content", "")
+        tc_id = h.get("tool_call_id")
+        msg_provider_state = h.get("provider_state")
+        tcs = None
+        raw_tcs = h.get("tool_calls")
+        if isinstance(raw_tcs, list):
+            tcs = []
+            for tc in raw_tcs:
+                if isinstance(tc, dict):
+                    raw_args = tc.get("arguments", "")
+                    args_str = (
+                        json.dumps(raw_args)
+                        if isinstance(raw_args, dict)
+                        else str(raw_args)
+                    )
+                    tcs.append(
+                        ToolCall(
+                            id=str(tc.get("id", "")),
+                            name=str(tc.get("name", "")),
+                            arguments=args_str,
+                        )
+                    )
+        if isinstance(msg_provider_state, dict):
+            item_states.append(dict(msg_provider_state))
+            has_item_states = True
+        else:
+            item_states.append(None)
+        messages.append(
+            Message(
+                role=str(role),
+                content=content if isinstance(content, str) else str(content),
+                tool_call_id=tc_id if isinstance(tc_id, str) else None,
+                tool_calls=tcs,
+            )
+        )
+    return messages, (item_states if has_item_states else None)
+
+
+def build_conversation_state(
+    responses: list[ProviderResponse],
+    *,
+    first_prompt: str | None,
+    first_user_content: str | None,
+    conversation_history: list[dict[str, Any]],
+    previous_response_id: str | None,
+    wants_conversation: bool,
+) -> dict[str, Any] | None:
+    """Assemble updated ``_conversation_state`` after a response.
+
+    Built when the caller opted into conversation continuity, or when the
+    response carries tool calls the caller may need to continue. Returns
+    ``None`` when neither applies.
+    """
+    has_tool_calls = bool(responses and responses[0].tool_calls)
+    if not ((wants_conversation or has_tool_calls) and responses):
+        return None
+
+    prompt = (
+        first_prompt
+        if isinstance(first_prompt, str)
+        else str(first_prompt)
+        if first_prompt is not None
+        else None
+    )
+    user_content = first_user_content or prompt
+    assistant_msg: dict[str, Any] = {
+        "role": "assistant",
+        "content": responses[0].text,
+    }
+    tool_calls = responses[0].tool_calls
+    if tool_calls:
+        assistant_msg["tool_calls"] = [
+            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+            for tc in tool_calls
+        ]
+    provider_msg_state = responses[0].provider_state
+    if isinstance(provider_msg_state, dict):
+        assistant_msg["provider_state"] = provider_msg_state
+
+    updated_history: list[dict[str, Any]] = [*conversation_history]
+    if user_content is not None:
+        updated_history.append({"role": "user", "content": user_content})
+    updated_history.append(assistant_msg)
+
+    conversation_state: dict[str, Any] = {"history": updated_history}
+    if isinstance(provider_msg_state, dict):
+        conversation_state["provider_state"] = provider_msg_state
+    response_id = responses[0].response_id
+    if isinstance(response_id, str):
+        conversation_state["response_id"] = response_id
+    elif previous_response_id is not None:
+        conversation_state["response_id"] = previous_response_id
+    return conversation_state

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -19,7 +19,7 @@ from pollux.providers.base import (
     ProviderDeferredSnapshot,
     ValidatingProvider,
 )
-from pollux.providers.models import ProviderRequest
+from pollux.providers.models import ProviderRequest, ProviderResponse, ToolCall
 from pollux.result import build_result_from_responses
 
 if TYPE_CHECKING:
@@ -324,36 +324,47 @@ def _validate_collect_schema(
         )
 
 
-def _aggregate_usage(responses: list[dict[str, Any]]) -> dict[str, int]:
+def _aggregate_usage(responses: list[ProviderResponse]) -> dict[str, int]:
     total_usage: dict[str, int] = {}
     for response in responses:
-        usage = response.get("usage", {})
-        if not isinstance(usage, dict):
-            continue
-        for key, value in usage.items():
+        for key, value in response.usage.items():
             if isinstance(value, int):
                 total_usage[key] = total_usage.get(key, 0) + value
     return total_usage
 
 
-def _response_from_item(item: ProviderDeferredItem) -> dict[str, Any]:
+def _response_from_item(item: ProviderDeferredItem) -> ProviderResponse:
     if item.status != "succeeded":
-        response: dict[str, Any] = {"text": "", "usage": {}}
-        if item.finish_reason is not None:
-            response["finish_reason"] = item.finish_reason
-        return response
+        return ProviderResponse(text="", usage={}, finish_reason=item.finish_reason)
     if item.response is None:
         raise InternalError(
             f"Deferred item {item.request_id!r} succeeded without a response payload",
             hint="Deferred providers must return a response for succeeded items.",
         )
-    response = dict(item.response)
-    response.setdefault("text", "")
-    if "usage" not in response or not isinstance(response["usage"], dict):
-        response["usage"] = {}
-    if item.finish_reason is not None:
-        response.setdefault("finish_reason", item.finish_reason)
-    return response
+    payload = item.response
+    raw_text = payload.get("text", "")
+    raw_usage = payload.get("usage")
+    raw_tool_calls = payload.get("tool_calls")
+    tool_calls: list[ToolCall] | None = None
+    if isinstance(raw_tool_calls, list):
+        tool_calls = [
+            ToolCall(
+                id=str(tc.get("id", "")),
+                name=str(tc.get("name", "")),
+                arguments=str(tc.get("arguments", "")),
+            )
+            for tc in raw_tool_calls
+            if isinstance(tc, dict)
+        ]
+    return ProviderResponse(
+        text=raw_text if isinstance(raw_text, str) else "",
+        usage=raw_usage if isinstance(raw_usage, dict) else {},
+        reasoning=payload.get("reasoning"),
+        structured=payload.get("structured"),
+        tool_calls=tool_calls,
+        response_id=payload.get("response_id"),
+        finish_reason=payload.get("finish_reason", item.finish_reason),
+    )
 
 
 async def collect_deferred_handle(
@@ -384,7 +395,7 @@ async def collect_deferred_handle(
         items_by_id[item.request_id] = item
 
     request_ids = _request_ids(handle.request_count)
-    responses: list[dict[str, Any]] = []
+    responses: list[ProviderResponse] = []
     deferred_items: list[dict[str, Any]] = []
     for request_id in request_ids:
         collected_item = items_by_id.get(request_id)
@@ -418,9 +429,9 @@ async def collect_deferred_handle(
     # When no schema was provided at collect time but providers returned
     # structured payloads, surface them as plain dicts.
     if response_schema is None and any(
-        "structured" in response for response in responses
+        response.structured is not None for response in responses
     ):
-        result["structured"] = [response.get("structured") for response in responses]
+        result["structured"] = [response.structured for response in responses]
 
     result["metrics"]["deferred"] = True
     result["diagnostics"]["deferred"] = {

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field, replace
-import json
 import logging
 from pathlib import Path
 import time
@@ -12,6 +11,12 @@ from typing import TYPE_CHECKING, Any
 
 from pollux._singleflight import singleflight_cached
 from pollux.capabilities import validate_capabilities
+from pollux.continuation import (
+    build_conversation_state,
+    history_text_from_parts,
+    history_to_messages,
+    load_continuation,
+)
 from pollux.errors import APIError, ConfigurationError, InternalError, PolluxError
 from pollux.providers.base import FileDeletingProvider, ValidatingProvider
 from pollux.providers.models import (
@@ -19,7 +24,6 @@ from pollux.providers.models import (
     ProviderFileAsset,
     ProviderRequest,
     ProviderResponse,
-    ToolCall,
 )
 from pollux.retry import (
     RetryPolicy,
@@ -121,40 +125,11 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
 
     schema = options.response_schema_json()
 
-    history = options.history
-    conversation_history: list[dict[str, Any]] = []
-    if history is not None:
-        conversation_history = [dict(item) for item in history]
-
-    previous_response_id: str | None = None
-    provider_state: dict[str, Any] | None = None
-    if options.continue_from is not None:
-        state = options.continue_from.get("_conversation_state")
-        if not isinstance(state, dict):
-            raise ConfigurationError(
-                "continue_from is missing _conversation_state",
-                hint=(
-                    "Pass a prior Pollux ResultEnvelope produced with conversation "
-                    "support."
-                ),
-            )
-
-        state_history = state.get("history")
-        if history is None and isinstance(state_history, list):
-            conversation_history = [
-                item
-                for item in state_history
-                if isinstance(item, dict) and isinstance(item.get("role"), str)
-            ]
-
-        if history is None:
-            history = conversation_history
-
-        prev = state.get("response_id")
-        previous_response_id = prev if isinstance(prev, str) else None
-        raw_provider_state = state.get("provider_state")
-        if isinstance(raw_provider_state, dict):
-            provider_state = dict(raw_provider_state)
+    continuation = load_continuation(options)
+    history = continuation.history
+    conversation_history = continuation.conversation_history
+    previous_response_id = continuation.previous_response_id
+    provider_state = continuation.provider_state
 
     upload_cache: dict[tuple[str, str], ProviderFileAsset] = {}
     upload_inflight: dict[tuple[str, str], asyncio.Future[ProviderFileAsset]] = {}
@@ -196,7 +171,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                         if prompt_part is not None
                         else [*shared_parts]
                     )
-                    conversation_user_contents[call_idx] = _history_text_from_parts(
+                    conversation_user_contents[call_idx] = history_text_from_parts(
                         raw_parts
                     )
                     history_msgs: list[Message] | None = None
@@ -206,51 +181,8 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                         else None
                     )
                     if history is not None:
-                        history_msgs = []
-                        history_item_states: list[dict[str, Any] | None] = []
-                        has_history_item_states = False
-                        for h in history:
-                            role = h.get("role", "user")
-                            content = h.get("content", "")
-                            tc_id = h.get("tool_call_id")
-                            msg_provider_state = h.get("provider_state")
-                            tcs = None
-                            raw_tcs = h.get("tool_calls")
-                            if isinstance(raw_tcs, list):
-                                tcs = []
-                                for tc in raw_tcs:
-                                    if isinstance(tc, dict):
-                                        raw_args = tc.get("arguments", "")
-                                        args_str = (
-                                            json.dumps(raw_args)
-                                            if isinstance(raw_args, dict)
-                                            else str(raw_args)
-                                        )
-                                        tcs.append(
-                                            ToolCall(
-                                                id=str(tc.get("id", "")),
-                                                name=str(tc.get("name", "")),
-                                                arguments=args_str,
-                                            )
-                                        )
-                            if isinstance(msg_provider_state, dict):
-                                history_item_states.append(dict(msg_provider_state))
-                                has_history_item_states = True
-                            else:
-                                history_item_states.append(None)
-                            history_msgs.append(
-                                Message(
-                                    role=str(role),
-                                    content=content
-                                    if isinstance(content, str)
-                                    else str(content),
-                                    tool_call_id=tc_id
-                                    if isinstance(tc_id, str)
-                                    else None,
-                                    tool_calls=tcs,
-                                )
-                            )
-                        if has_history_item_states:
+                        history_msgs, history_item_states = history_to_messages(history)
+                        if history_item_states is not None:
                             if request_provider_state is None:
                                 request_provider_state = {}
                             request_provider_state["history"] = history_item_states
@@ -349,40 +281,16 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
         # Build conversation state when either (a) the caller opted in via
         # history/continue_from, or (b) the response contains tool calls that
         # the caller may need to continue via continue_tool/continue_from.
-        has_tool_calls = bool(responses and responses[0].tool_calls)
-        if (wants_conversation or has_tool_calls) and responses:
-            prompt = (
-                prompts[0]
-                if isinstance(prompts[0], str)
-                else str(prompts[0])
-                if prompts[0] is not None
-                else None
-            )
-            user_content = conversation_user_contents[0] or prompt
-            reply = responses[0].text
-            assistant_msg: dict[str, Any] = {"role": "assistant", "content": reply}
-            tool_calls = responses[0].tool_calls
-            if tool_calls:
-                assistant_msg["tool_calls"] = [
-                    {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-                    for tc in tool_calls
-                ]
-            provider_msg_state = responses[0].provider_state
-            if isinstance(provider_msg_state, dict):
-                assistant_msg["provider_state"] = provider_msg_state
-
-            updated_history: list[dict[str, Any]] = [*conversation_history]
-            if user_content is not None:
-                updated_history.append({"role": "user", "content": user_content})
-            updated_history.append(assistant_msg)
-            conversation_state = {"history": updated_history}
-            if isinstance(provider_msg_state, dict):
-                conversation_state["provider_state"] = provider_msg_state
-            response_id = responses[0].response_id
-            if isinstance(response_id, str):
-                conversation_state["response_id"] = response_id
-            elif previous_response_id is not None:
-                conversation_state["response_id"] = previous_response_id
+        conversation_state = build_conversation_state(
+            responses,
+            first_prompt=prompts[0] if prompts else None,
+            first_user_content=conversation_user_contents[0]
+            if conversation_user_contents
+            else None,
+            conversation_history=conversation_history,
+            previous_response_id=previous_response_id,
+            wants_conversation=wants_conversation,
+        )
     finally:
         # Clean up uploaded files (best-effort; server-side TTL is the backstop).
         await _cleanup_uploads(upload_cache, provider)
@@ -396,22 +304,6 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
         usage=total_usage,
         conversation_state=conversation_state,
     )
-
-
-def _history_text_from_parts(parts: list[Any]) -> str | None:
-    """Return a replayable text history message when all parts are text."""
-    texts: list[str] = []
-    for part in parts:
-        if isinstance(part, str):
-            texts.append(part)
-            continue
-        if isinstance(part, dict):
-            text = part.get("text")
-            if isinstance(text, str):
-                texts.append(text)
-                continue
-        return None
-    return "\n\n".join(texts) if texts else None
 
 
 async def _substitute_upload_parts(

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -18,6 +18,7 @@ from pollux.providers.models import (
     Message,
     ProviderFileAsset,
     ProviderRequest,
+    ProviderResponse,
     ToolCall,
 )
 from pollux.retry import (
@@ -71,7 +72,7 @@ def _with_call_idx(err: APIError, call_idx: int | None) -> APIError:
 class ExecutionTrace:
     """Trace of execution with responses and metrics."""
 
-    responses: list[dict[str, Any]] = field(default_factory=list)
+    responses: list[ProviderResponse] = field(default_factory=list)
     cache_name: str | None = None
     duration_s: float = 0.0
     usage: dict[str, int] = field(default_factory=dict)
@@ -159,7 +160,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
     upload_inflight: dict[tuple[str, str], asyncio.Future[ProviderFileAsset]] = {}
     upload_lock = asyncio.Lock()
     retry_policy = config.retry
-    responses: list[dict[str, Any]] = []
+    responses: list[ProviderResponse] = []
     implicit_caching = (
         options.implicit_caching
         if options.implicit_caching is not None
@@ -182,7 +183,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
             cache_name or "disabled",
         )
 
-        async def _execute_call(call_idx: int) -> dict[str, Any]:
+        async def _execute_call(call_idx: int) -> ProviderResponse:
             async with sem:
                 try:
                     # Build parts: shared context + prompt
@@ -292,23 +293,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                             should_retry=should_retry_generate,
                         )
 
-                    out: dict[str, Any] = {"text": resp.text, "usage": resp.usage}
-                    if resp.reasoning is not None:
-                        out["reasoning"] = resp.reasoning
-                    if resp.structured is not None:
-                        out["structured"] = resp.structured
-                    if resp.tool_calls is not None:
-                        out["tool_calls"] = [
-                            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-                            for tc in resp.tool_calls
-                        ]
-                    if resp.response_id is not None:
-                        out["response_id"] = resp.response_id
-                    if resp.finish_reason is not None:
-                        out["finish_reason"] = resp.finish_reason
-                    if resp.provider_state is not None:
-                        out["provider_state"] = resp.provider_state
-                    return out
+                    return resp
 
                 except asyncio.CancelledError:
                     raise
@@ -348,24 +333,23 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                 raise item
 
         for item in results:
-            if not isinstance(item, dict):
+            if not isinstance(item, ProviderResponse):
                 raise InternalError(
                     f"Provider returned invalid response type: {type(item).__name__}",
-                    hint="Providers must return dict payloads with at least a 'text' field.",
+                    hint="Providers must return a ProviderResponse.",
                 )
             responses.append(item)
 
         # Aggregate usage
         for resp in responses:
-            usage = resp.get("usage", {})
-            for k, v in usage.items():
+            for k, v in resp.usage.items():
                 if isinstance(v, int):
                     total_usage[k] = total_usage.get(k, 0) + v
 
         # Build conversation state when either (a) the caller opted in via
         # history/continue_from, or (b) the response contains tool calls that
         # the caller may need to continue via continue_tool/continue_from.
-        has_tool_calls = bool(responses and responses[0].get("tool_calls"))
+        has_tool_calls = bool(responses and responses[0].tool_calls)
         if (wants_conversation or has_tool_calls) and responses:
             prompt = (
                 prompts[0]
@@ -375,13 +359,15 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                 else None
             )
             user_content = conversation_user_contents[0] or prompt
-            answer = responses[0].get("text")
-            reply = answer if isinstance(answer, str) else ""
+            reply = responses[0].text
             assistant_msg: dict[str, Any] = {"role": "assistant", "content": reply}
-            tool_calls = responses[0].get("tool_calls")
+            tool_calls = responses[0].tool_calls
             if tool_calls:
-                assistant_msg["tool_calls"] = tool_calls
-            provider_msg_state = responses[0].get("provider_state")
+                assistant_msg["tool_calls"] = [
+                    {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+                    for tc in tool_calls
+                ]
+            provider_msg_state = responses[0].provider_state
             if isinstance(provider_msg_state, dict):
                 assistant_msg["provider_state"] = provider_msg_state
 
@@ -392,7 +378,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
             conversation_state = {"history": updated_history}
             if isinstance(provider_msg_state, dict):
                 conversation_state["provider_state"] = provider_msg_state
-            response_id = responses[0].get("response_id")
+            response_id = responses[0].response_id
             if isinstance(response_id, str):
                 conversation_state["response_id"] = response_id
             elif previous_response_id is not None:

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -11,6 +11,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from pollux._singleflight import singleflight_cached
+from pollux.capabilities import validate_capabilities
 from pollux.errors import APIError, ConfigurationError, InternalError, PolluxError
 from pollux.providers.base import FileDeletingProvider, ValidatingProvider
 from pollux.providers.models import (
@@ -103,66 +104,19 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
             "delivery_mode='deferred' is a legacy compatibility shim and is not supported",
             hint="Use pollux.defer() or pollux.defer_many() for deferred delivery.",
         )
-    if options.response_schema is not None and not caps.structured_outputs:
-        raise ConfigurationError(
-            "Provider does not support structured outputs",
-            hint="Remove response_schema or choose a provider with schema support.",
-        )
-    if options.reasoning_effort is not None and not caps.reasoning:
-        raise ConfigurationError(
-            "Provider does not support reasoning controls",
-            hint=(
-                "Remove reasoning_effort or choose a provider with reasoning "
-                "controls. Some providers may still surface model-native "
-                "reasoning output without this option."
-            ),
-        )
-    if options.reasoning_budget_tokens is not None and not caps.reasoning_budget_tokens:
-        raise ConfigurationError(
-            "Provider does not support reasoning_budget_tokens",
-            hint=(
-                "Use reasoning_effort, or choose a provider that accepts "
-                "an explicit reasoning token budget."
-            ),
-        )
-    if options.implicit_caching is True and not caps.implicit_caching:
-        raise ConfigurationError(
-            "Provider does not support implicit caching",
-            hint="Remove implicit_caching=True or choose a provider with implicit caching support.",
-        )
-    if wants_conversation and not caps.conversation:
-        raise ConfigurationError(
-            "Provider does not support conversation continuity",
-            hint="Remove history/continue_from or choose a provider with conversation support.",
-        )
-    if wants_conversation and len(prompts) != 1:
-        raise ConfigurationError(
-            "Conversation continuity currently supports exactly one prompt per call",
-            hint="Use run() or run_many() with a single prompt when passing history/continue_from.",
-        )
-    # Runtime safety net: reject hand-built handles targeting providers
-    # that lack persistent caching (the planner already validates other
-    # cache conflicts).
-    if plan.cache_name is not None and not caps.persistent_cache:
-        raise ConfigurationError(
-            "Provider does not support persistent caching",
-            hint=(
-                "Remove options.cache or choose a provider with "
-                "persistent_cache support."
-            ),
-        )
-
-    if (not provider.capabilities.uploads) and any(
+    has_file_parts = any(
         isinstance(p, dict)
         and isinstance(p.get("file_path"), str)
         and isinstance(p.get("mime_type"), str)
         for p in plan.shared_parts
-    ):
-        raise ConfigurationError(
-            "Provider does not support file or multimodal input",
-            hint=caps.file_rejection_hint
-            or "Choose a provider with uploads support, or remove file sources.",
-        )
+    )
+    validate_capabilities(
+        options,
+        caps,
+        n_prompts=len(prompts),
+        has_file_parts=has_file_parts,
+        cache_requested=plan.cache_name is not None,
+    )
 
     schema = options.response_schema_json()
 

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from pollux._singleflight import singleflight_cached
 from pollux.errors import APIError, ConfigurationError, InternalError, PolluxError
-from pollux.providers.base import ValidatingProvider
+from pollux.providers.base import FileDeletingProvider, ValidatingProvider
 from pollux.providers.models import (
     Message,
     ProviderFileAsset,
@@ -561,8 +561,7 @@ async def _cleanup_uploads(
     OpenAI). Failures are logged but never raised—the server-side TTL is the
     backstop.
     """
-    delete_fn = getattr(provider, "delete_file", None)
-    if delete_fn is None or not callable(delete_fn):
+    if not isinstance(provider, FileDeletingProvider):
         return
 
     file_ids: list[str] = []
@@ -572,7 +571,7 @@ async def _cleanup_uploads(
 
     for file_id in file_ids:
         try:
-            await delete_fn(file_id)
+            await provider.delete_file(file_id)
             logger.debug("Deleted uploaded file: %s", file_id)
         except Exception as exc:
             logger.debug("Failed to delete uploaded file %s: %s", file_id, exc)

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -25,6 +25,7 @@ from pollux.providers.models import (
     ProviderRequest,
     ProviderResponse,
     ToolCall,
+    provider_response_to_dict,
 )
 
 if TYPE_CHECKING:
@@ -788,25 +789,6 @@ def _requests_have_response_schema(requests: list[ProviderRequest]) -> bool:
     return any(request.response_schema is not None for request in requests)
 
 
-def _provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
-    """Convert ProviderResponse into the normalized deferred response shape."""
-    payload: dict[str, Any] = {"text": response.text, "usage": response.usage}
-    if response.reasoning is not None:
-        payload["reasoning"] = response.reasoning
-    if response.structured is not None:
-        payload["structured"] = response.structured
-    if response.tool_calls is not None:
-        payload["tool_calls"] = [
-            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-            for tc in response.tool_calls
-        ]
-    if response.response_id is not None:
-        payload["response_id"] = response.response_id
-    if response.finish_reason is not None:
-        payload["finish_reason"] = response.finish_reason
-    return payload
-
-
 def _batch_request_count(batch: Any, *, handle: ProviderDeferredHandle) -> int:
     """Return the total request count for an Anthropic message batch."""
     request_counts = getattr(batch, "request_counts", None)
@@ -877,7 +859,7 @@ def _parse_batch_result(
         return ProviderDeferredItem(
             request_id=request_id,
             status="succeeded",
-            response=_provider_response_to_dict(parsed),
+            response=provider_response_to_dict(parsed),
             provider_status="succeeded",
             finish_reason=parsed.finish_reason,
         )

--- a/src/pollux/providers/base.py
+++ b/src/pollux/providers/base.py
@@ -102,6 +102,24 @@ class Provider(Protocol):
 
 
 @runtime_checkable
+class CloseableProvider(Protocol):
+    """Optional provider hook for releasing transport resources."""
+
+    async def aclose(self) -> None:
+        """Close client resources (HTTP clients, sessions)."""
+        ...
+
+
+@runtime_checkable
+class FileDeletingProvider(Protocol):
+    """Optional provider hook for deleting provider-managed uploaded files."""
+
+    async def delete_file(self, file_id: str) -> None:
+        """Delete a previously uploaded file by its provider id."""
+        ...
+
+
+@runtime_checkable
 class ValidatingProvider(Protocol):
     """Optional provider hook for request validation before side effects."""
 

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -28,6 +28,7 @@ from pollux.providers.models import (
     ProviderRequest,
     ProviderResponse,
     ToolCall,
+    provider_response_to_dict,
 )
 
 logger = logging.getLogger(__name__)
@@ -897,7 +898,7 @@ class GeminiProvider:
                 ProviderDeferredItem(
                     request_id=request_id,
                     status="succeeded",
-                    response=_provider_response_to_dict(parsed),
+                    response=provider_response_to_dict(parsed),
                     provider_status="succeeded",
                     finish_reason=parsed.finish_reason,
                 )
@@ -942,7 +943,7 @@ class GeminiProvider:
                 ProviderDeferredItem(
                     request_id=request_id,
                     status="succeeded",
-                    response=_provider_response_to_dict(parsed),
+                    response=provider_response_to_dict(parsed),
                     provider_status="succeeded",
                     finish_reason=parsed.finish_reason,
                 )
@@ -1365,25 +1366,6 @@ def _job_error_code(error: Any) -> str | None:
     if isinstance(code, str) and code:
         return code
     return None
-
-
-def _provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
-    """Convert ProviderResponse into the normalized deferred response shape."""
-    payload: dict[str, Any] = {"text": response.text, "usage": response.usage}
-    if response.reasoning is not None:
-        payload["reasoning"] = response.reasoning
-    if response.structured is not None:
-        payload["structured"] = response.structured
-    if response.tool_calls is not None:
-        payload["tool_calls"] = [
-            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-            for tc in response.tool_calls
-        ]
-    if response.response_id is not None:
-        payload["response_id"] = response.response_id
-    if response.finish_reason is not None:
-        payload["finish_reason"] = response.finish_reason
-    return payload
 
 
 def _batch_level_item_status(raw_state: str) -> DeferredItemStatus | None:

--- a/src/pollux/providers/models.py
+++ b/src/pollux/providers/models.py
@@ -70,3 +70,29 @@ class ProviderResponse:
     response_id: str | None = None
     finish_reason: str | None = None
     provider_state: dict[str, Any] | None = None
+
+
+def provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
+    """Flatten a ProviderResponse into the normalized response dict shape.
+
+    This is the single serialization form shared by execution diagnostics
+    (``raw_responses``) and deferred item payloads. Optional facets are omitted
+    when unset so the dict stays compact.
+    """
+    payload: dict[str, Any] = {"text": response.text, "usage": response.usage}
+    if response.reasoning is not None:
+        payload["reasoning"] = response.reasoning
+    if response.structured is not None:
+        payload["structured"] = response.structured
+    if response.tool_calls is not None:
+        payload["tool_calls"] = [
+            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+            for tc in response.tool_calls
+        ]
+    if response.response_id is not None:
+        payload["response_id"] = response.response_id
+    if response.finish_reason is not None:
+        payload["finish_reason"] = response.finish_reason
+    if response.provider_state is not None:
+        payload["provider_state"] = response.provider_state
+    return payload

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -26,6 +26,7 @@ from pollux.providers.models import (
     ProviderRequest,
     ProviderResponse,
     ToolCall,
+    provider_response_to_dict,
 )
 
 logger = logging.getLogger(__name__)
@@ -701,7 +702,7 @@ class OpenAIProvider:
                 ProviderDeferredItem(
                     request_id=request_id,
                     status="succeeded",
-                    response=_provider_response_to_dict(parsed),
+                    response=provider_response_to_dict(parsed),
                     provider_status=_field(body, "status"),
                     finish_reason=parsed.finish_reason,
                 )
@@ -960,25 +961,6 @@ def _batch_terminal_timestamp(batch: Any) -> float | None:
         if value is not None:
             return value
     return None
-
-
-def _provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
-    """Convert ProviderResponse into the normalized response dict shape."""
-    payload: dict[str, Any] = {"text": response.text, "usage": response.usage}
-    if response.reasoning is not None:
-        payload["reasoning"] = response.reasoning
-    if response.structured is not None:
-        payload["structured"] = response.structured
-    if response.tool_calls is not None:
-        payload["tool_calls"] = [
-            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-            for tc in response.tool_calls
-        ]
-    if response.response_id is not None:
-        payload["response_id"] = response.response_id
-    if response.finish_reason is not None:
-        payload["finish_reason"] = response.finish_reason
-    return payload
 
 
 def _batch_error_entries(batch: Any) -> list[Any]:

--- a/src/pollux/result.py
+++ b/src/pollux/result.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict
 from pydantic import BaseModel
 
 from pollux.options import ResponseSchemaInput, response_schema_model
+from pollux.providers.models import ProviderResponse, provider_response_to_dict
 
 if TYPE_CHECKING:
     from pollux.execute import ExecutionTrace
@@ -46,7 +47,7 @@ class ResultEnvelope(TypedDict, total=False):
 
 
 def build_result_from_responses(
-    responses: list[dict[str, Any]],
+    responses: list[ProviderResponse],
     *,
     schema: ResponseSchemaInput | None = None,
     duration_s: float,
@@ -64,10 +65,10 @@ def build_result_from_responses(
     wants_structured = schema is not None
 
     for response in responses:
-        text = _extract_text(response)
+        text = response.text
         answers.append(text)
         if wants_structured:
-            raw_structured = _extract_structured(response, text=text)
+            raw_structured = _extract_structured(response)
             if (
                 raw_structured is not None
                 and isinstance(schema_model, type)
@@ -85,8 +86,8 @@ def build_result_from_responses(
     reasoning_texts: list[str | None] = []
     has_reasoning = False
     for response in responses:
-        if "reasoning" in response:
-            reasoning_texts.append(response["reasoning"])
+        if response.reasoning is not None:
+            reasoning_texts.append(response.reasoning)
             has_reasoning = True
         else:
             reasoning_texts.append(None)
@@ -101,7 +102,7 @@ def build_result_from_responses(
 
     # Extract finish reasons forwarded from providers.
     finish_reasons: list[str | None] = [
-        response.get("finish_reason") for response in responses
+        response.finish_reason for response in responses
     ]
 
     envelope = ResultEnvelope(
@@ -117,7 +118,7 @@ def build_result_from_responses(
             "finish_reasons": finish_reasons,
         },
         diagnostics={
-            "raw_responses": responses,
+            "raw_responses": [provider_response_to_dict(r) for r in responses],
         },
     )
     if wants_structured:
@@ -148,7 +149,10 @@ def build_result(plan: Plan, trace: ExecutionTrace) -> ResultEnvelope:
     all_tool_calls: list[list[dict[str, Any]]] = []
     has_tools = False
     for response in trace.responses:
-        tcs = response.get("tool_calls", [])
+        tcs = [
+            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+            for tc in (response.tool_calls or [])
+        ]
         all_tool_calls.append(tcs)
         if tcs:
             has_tools = True
@@ -158,31 +162,13 @@ def build_result(plan: Plan, trace: ExecutionTrace) -> ResultEnvelope:
     return envelope
 
 
-def _extract_text(response: dict[str, Any]) -> str:
-    """Extract text from API response."""
-    if "text" in response and isinstance(response["text"], str):
-        return response["text"]
-
-    try:
-        candidates = response.get("candidates", [])
-        if candidates:
-            content = candidates[0].get("content", {})
-            parts = content.get("parts", [])
-            if parts:
-                return str(parts[0].get("text", ""))
-    except (KeyError, IndexError, TypeError):
-        pass
-
-    return ""
-
-
-def _extract_structured(response: dict[str, Any], *, text: str) -> Any:
+def _extract_structured(response: ProviderResponse) -> Any:
     """Extract structured payload from a provider response."""
-    if "structured" in response:
-        return response["structured"]
-    if text:
+    if response.structured is not None:
+        return response.structured
+    if response.text:
         try:
-            return json.loads(text)
+            return json.loads(response.text)
         except Exception:
             return None
     return None


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup that isolates the seams Pollux 2.0 will cut, so v1.x reads better now and the upcoming v2 migration becomes a move rather than an untangle. Pulls capability validation, the continuation mechanism, and a typed response path out of `execute_plan`, and replaces duck-typing/duplication at the provider boundary. No public API or behavior change.

Five separable commits:

- **Structural protocols** - `CloseableProvider` / `FileDeletingProvider` `@runtime_checkable` protocols replace two `getattr` duck-typing sites, matching the existing `DeferredProvider` / `ValidatingProvider` pattern.
- **Provider registry** - `_PROVIDER_REGISTRY` (lazy factory + `requires_api_key` / `requires_base_url` / `supports_deferred`) collapses the if/elif ladder and the hardcoded deferred-provider set; "local isn't deferrable" is now data, not an omitted string.
- **Capability validation** - `capabilities.py::validate_capabilities()` moves the ~65-line wall out of `execute_plan`; messages, hints, and failure order preserved.
- **Typed trace** - `ExecutionTrace` carries `ProviderResponse` end-to-end instead of a dict round-trip; removes the dead Gemini `candidates` text fallback; one canonical `provider_response_to_dict` in `providers/models.py` replaces three byte-identical adapter copies. `diagnostics.raw_responses` keeps its documented `list[dict]` shape.
- **Continuation** - `continuation.py` owns `load_continuation`, `history_to_messages`, `build_conversation_state`, and the relocated `history_text_from_parts`; `execute_plan` is now orchestration (semaphore + gather + request build).

## Related issue

None

## Test plan

`just check` passes (lint + mypy strict on 40 files + 329 tests, 18 skipped).

No new tests added - every change is a non-behavioral refactor covered by existing boundary tests. The proof of behavior preservation is that `tests/characterization/v1` (pins v1 output shapes) and the `tests/test_pipeline.py` capability-rejection, deferred-collection, `continue_tool`, and tool-call suites stay green **unchanged**. Each commit was verified independently green; the typed-trace and continuation commits (the only behaviorally subtle ones) were checked against the deferred + tool-call paths specifically.

## Notes

- **Deliberately deferred:** `Options.delivery_mode` removal stays out - it's a planned breaking change gated on the v1.8.0 version cut, not part of this non-breaking bundle.
- `deferred.py::_validate_deferred_plan` keeps its own overlapping capability checks: it encodes a *different* policy (rejecting conversation/tools/cache for the deferred timeline), so it's intentionally not folded into `capabilities.py`. Unifying the two validation surfaces would muddy distinct policies.
- New modules (`capabilities.py`, `continuation.py`) are named after the upcoming v2 primitives (`Capability`, `Continuation`) they isolate, so the eventual v2 types have an obvious home.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [ ] Docs updated (if this changes public API or user-facing behavior) - N/A, no public API or user-facing change
