### PR TITLE
refactor(core): consolidate tool-call and file-part shapes

### DIFF
--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -254,7 +254,11 @@ async def continue_tool(
     if options is None:
         merged_options = Options(continue_from=synthetic_envelope)
     else:
-        # copy dict and strip conflicting fields
+        # TODO(v1.8.0): once Options.delivery_mode is removed, replace this
+        # __dict__ copy with dataclasses.replace(options, history=None,
+        # continue_from=synthetic_envelope). replace() can't be used today
+        # because __post_init__ re-fires the delivery_mode DeprecationWarning
+        # on the already-normalized "realtime" value.
         kwargs = dict(options.__dict__)
         kwargs.pop("history", None)
         kwargs.pop("continue_from", None)

--- a/src/pollux/cache.py
+++ b/src/pollux/cache.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from pollux._singleflight import singleflight_cached
 from pollux.errors import ConfigurationError, InternalError
+from pollux.providers.models import is_file_part
 from pollux.retry import RetryPolicy, retry_async, should_retry_side_effect
 
 if TYPE_CHECKING:
@@ -180,11 +181,7 @@ async def _resolve_file_parts(
     resolved: list[Any] = []
     seen: dict[tuple[str, str], Any] = {}
     for part in parts:
-        if (
-            isinstance(part, dict)
-            and isinstance(part.get("file_path"), str)
-            and isinstance(part.get("mime_type"), str)
-        ):
+        if is_file_part(part):
             fp, mt = part["file_path"], part["mime_type"]
             provider_hints = part.get("provider_hints")
             key = (fp, mt)

--- a/src/pollux/continuation.py
+++ b/src/pollux/continuation.py
@@ -19,7 +19,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from pollux.errors import ConfigurationError
-from pollux.providers.models import Message, ToolCall
+from pollux.providers.models import Message, ToolCall, tool_call_to_dict
 
 if TYPE_CHECKING:
     from pollux.options import Options
@@ -187,10 +187,7 @@ def build_conversation_state(
     }
     tool_calls = responses[0].tool_calls
     if tool_calls:
-        assistant_msg["tool_calls"] = [
-            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-            for tc in tool_calls
-        ]
+        assistant_msg["tool_calls"] = [tool_call_to_dict(tc) for tc in tool_calls]
     provider_msg_state = responses[0].provider_state
     if isinstance(provider_msg_state, dict):
         assistant_msg["provider_state"] = provider_msg_state

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -19,7 +19,12 @@ from pollux.providers.base import (
     ProviderDeferredSnapshot,
     ValidatingProvider,
 )
-from pollux.providers.models import ProviderRequest, ProviderResponse, ToolCall
+from pollux.providers.models import (
+    ProviderRequest,
+    ProviderResponse,
+    ToolCall,
+    is_file_part,
+)
 from pollux.result import build_result_from_responses
 
 if TYPE_CHECKING:
@@ -187,12 +192,7 @@ def _validate_deferred_plan(plan: Plan, provider: Provider) -> None:
                 "an explicit reasoning token budget."
             ),
         )
-    if (not caps.uploads) and any(
-        isinstance(part, dict)
-        and isinstance(part.get("file_path"), str)
-        and isinstance(part.get("mime_type"), str)
-        for part in plan.shared_parts
-    ):
+    if (not caps.uploads) and any(is_file_part(part) for part in plan.shared_parts):
         raise ConfigurationError(
             "Provider does not support file uploads",
             hint="Choose a provider with uploads support, or remove file sources.",

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -24,6 +24,7 @@ from pollux.providers.models import (
     ProviderFileAsset,
     ProviderRequest,
     ProviderResponse,
+    is_file_part,
 )
 from pollux.retry import (
     RetryPolicy,
@@ -109,12 +110,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
             "delivery_mode='deferred' is a legacy compatibility shim and is not supported",
             hint="Use pollux.defer() or pollux.defer_many() for deferred delivery.",
         )
-    has_file_parts = any(
-        isinstance(p, dict)
-        and isinstance(p.get("file_path"), str)
-        and isinstance(p.get("mime_type"), str)
-        for p in plan.shared_parts
-    )
+    has_file_parts = any(is_file_part(p) for p in plan.shared_parts)
     validate_capabilities(
         options,
         caps,
@@ -320,11 +316,7 @@ async def _substitute_upload_parts(
     resolved: list[Any] = []
 
     for part in parts:
-        if (
-            isinstance(part, dict)
-            and isinstance(part.get("file_path"), str)
-            and isinstance(part.get("mime_type"), str)
-        ):
+        if is_file_part(part):
             file_path = part["file_path"]
             mime_type = part["mime_type"]
             provider_hints = part.get("provider_hints")

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -25,6 +25,7 @@ from pollux.providers.models import (
     ProviderRequest,
     ProviderResponse,
     ToolCall,
+    is_file_part,
     provider_response_to_dict,
 )
 
@@ -525,11 +526,7 @@ class AnthropicProvider:
         """Resolve local file parts into provider assets for deferred submission."""
         resolved_parts: list[Any] = []
         for part in request.parts:
-            if (
-                isinstance(part, dict)
-                and isinstance(part.get("file_path"), str)
-                and isinstance(part.get("mime_type"), str)
-            ):
+            if is_file_part(part):
                 file_path = part["file_path"]
                 mime_type = part["mime_type"]
                 cache_key = (file_path, mime_type)

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -28,6 +28,7 @@ from pollux.providers.models import (
     ProviderRequest,
     ProviderResponse,
     ToolCall,
+    is_file_part,
     provider_response_to_dict,
 )
 
@@ -644,11 +645,7 @@ class GeminiProvider:
         """Resolve local file parts into provider assets for deferred submission."""
         resolved_parts: list[Any] = []
         for part in request.parts:
-            if (
-                isinstance(part, dict)
-                and isinstance(part.get("file_path"), str)
-                and isinstance(part.get("mime_type"), str)
-            ):
+            if is_file_part(part):
                 file_path = part["file_path"]
                 mime_type = part["mime_type"]
                 provider_hints = part.get("provider_hints")

--- a/src/pollux/providers/models.py
+++ b/src/pollux/providers/models.py
@@ -15,6 +15,19 @@ class ToolCall:
     arguments: str
 
 
+def tool_call_to_dict(tool_call: ToolCall) -> dict[str, Any]:
+    """Serialize a ToolCall to its normalized ``{id, name, arguments}`` dict.
+
+    This is the single owner of the normalized tool-call dict shape shared by
+    diagnostics (``raw_responses``), result envelopes, and conversation state.
+    """
+    return {
+        "id": tool_call.id,
+        "name": tool_call.name,
+        "arguments": tool_call.arguments,
+    }
+
+
 @dataclass(frozen=True)
 class ProviderFileAsset:
     """A formally tracked remote file asset returned by upload_file."""
@@ -58,6 +71,20 @@ class ProviderRequest:
     implicit_caching: bool = False
 
 
+def is_file_part(part: Any) -> bool:
+    """Return True if *part* is a local-file placeholder awaiting upload.
+
+    File placeholders are built during planning and resolved to provider assets
+    during execution and deferred submission. This predicate is the single
+    definition of that ``ProviderRequest.parts`` shape.
+    """
+    return (
+        isinstance(part, dict)
+        and isinstance(part.get("file_path"), str)
+        and isinstance(part.get("mime_type"), str)
+    )
+
+
 @dataclass
 class ProviderResponse:
     """A standardized response from a provider generation call."""
@@ -85,10 +112,7 @@ def provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
     if response.structured is not None:
         payload["structured"] = response.structured
     if response.tool_calls is not None:
-        payload["tool_calls"] = [
-            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-            for tc in response.tool_calls
-        ]
+        payload["tool_calls"] = [tool_call_to_dict(tc) for tc in response.tool_calls]
     if response.response_id is not None:
         payload["response_id"] = response.response_id
     if response.finish_reason is not None:

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -26,6 +26,7 @@ from pollux.providers.models import (
     ProviderRequest,
     ProviderResponse,
     ToolCall,
+    is_file_part,
     provider_response_to_dict,
 )
 
@@ -619,11 +620,7 @@ class OpenAIProvider:
         self._validate_request_features(request)
         resolved_parts: list[Any] = []
         for part in request.parts:
-            if (
-                isinstance(part, dict)
-                and isinstance(part.get("file_path"), str)
-                and isinstance(part.get("mime_type"), str)
-            ):
+            if is_file_part(part):
                 file_path = part["file_path"]
                 mime_type = part["mime_type"]
                 cache_key = (file_path, mime_type)

--- a/src/pollux/result.py
+++ b/src/pollux/result.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict
 from pydantic import BaseModel
 
 from pollux.options import ResponseSchemaInput, response_schema_model
-from pollux.providers.models import ProviderResponse, provider_response_to_dict
+from pollux.providers.models import (
+    ProviderResponse,
+    provider_response_to_dict,
+    tool_call_to_dict,
+)
 
 if TYPE_CHECKING:
     from pollux.execute import ExecutionTrace
@@ -149,10 +153,7 @@ def build_result(plan: Plan, trace: ExecutionTrace) -> ResultEnvelope:
     all_tool_calls: list[list[dict[str, Any]]] = []
     has_tools = False
     for response in trace.responses:
-        tcs = [
-            {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
-            for tc in (response.tool_calls or [])
-        ]
+        tcs = [tool_call_to_dict(tc) for tc in (response.tool_calls or [])]
         all_tool_calls.append(tcs)
         if tcs:
             has_tools = True


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup that gives two duplicated internal shapes a single owner, isolating seams the upcoming Pollux 2.0 interaction layer will reshape. No public API or behavior change. First of a small 2-3 PR series complementing the v2 sketches in `docs/sketches`.

- **`tool_call_to_dict()`** (`providers/models.py`) replaces the byte-identical `{id, name, arguments}` comprehension in `result.py`, `continuation.py`, and `provider_response_to_dict`. This is where v2's richer `ToolCall` (`arguments_text`, `arguments_error`, `index`) will grow a single serializer instead of three.
- **`is_file_part()`** (`providers/models.py`) replaces the inline triple-`isinstance` detection of the `{file_path, mime_type}` placeholder across `execute.py`, `cache.py`, `deferred.py`, and the gemini/openai/anthropic deferred paths. It lives next to `ProviderRequest.parts` (the field it describes), so every caller is a downward import rather than reaching up into the planning phase.
- Records a **`TODO(v1.8.0)`** at `continue_tool`'s `__dict__` option merge: it can become `dataclasses.replace()` once the `delivery_mode` shim is removed (`replace()` currently re-fires the deprecation warning on already-normalized values).

## Related issue

None - unprompted cleanup ahead of the v2 work.

## Test plan

`just check` passes (lint + mypy strict + 329 passed, 18 deselected).

No new tests added - **trivial delegation** and **non-behavioral change**. Both helpers are direct extractions of existing inline logic, and the existing `tool_calls`, `continue_tool`, deferred-collection, and `tests/characterization/v1` suites cover the affected shapes and stay green unchanged.

## Notes

- `is_file_part`'s home is `providers/models.py` rather than `plan.py`: once provider adapters needed it too, keeping it in the planning module would have meant transport-layer code importing *up* into a pipeline phase. `providers/models.py` owns `ProviderRequest.parts`, so the dependency direction stays clean.
