### PR TITLE
refactor(local): share OpenAI-compatible Chat Completions helpers

### DIFF
--- a/src/pollux/providers/_openai_compat.py
+++ b/src/pollux/providers/_openai_compat.py
@@ -1,0 +1,121 @@
+"""Stateless helpers for the OpenAI Chat Completions wire format.
+
+Both the self-hosted ``local`` provider and the ``openrouter`` provider speak
+OpenAI-compatible Chat Completions over httpx. The request shaping and input
+handling differ (local is text-only; OpenRouter handles multimodal parts,
+tools, and reasoning), but the primitives that read a Chat Completions *response*
+are identical. This module owns that shared wire vocabulary so the two adapters
+parse responses, usage, and errors one way.
+
+These helpers are deliberately stateless and provider-neutral. Provider-specific
+behavior (reasoning extraction, tool-call parsing, nested upstream errors) stays
+in the adapters and layers on top of these primitives.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import httpx
+
+
+def first_choice_message(
+    data: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    """Return the first choice and its message, defaulting to ``{}`` when absent."""
+    choices = data.get("choices")
+    choice: Any = choices[0] if isinstance(choices, list) and choices else {}
+    if not isinstance(choice, Mapping):
+        choice = {}
+    message: Any = choice.get("message")
+    if not isinstance(message, Mapping):
+        message = {}
+    return choice, message
+
+
+def extract_message_text(content: Any) -> str:
+    """Extract text from a Chat Completions message ``content`` field.
+
+    Accepts both the plain-string form and the structured content-array form,
+    concatenating ``{"type": "text", ...}`` items.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    text_parts: list[str] = []
+    for item in content:
+        if isinstance(item, Mapping) and item.get("type") == "text":
+            text = item.get("text")
+            if isinstance(text, str):
+                text_parts.append(text)
+    return "\n\n".join(text_parts)
+
+
+def extract_finish_reason(choice: Mapping[str, Any]) -> str | None:
+    """Return the choice's ``finish_reason`` when it is a string."""
+    finish_reason = choice.get("finish_reason")
+    return finish_reason if isinstance(finish_reason, str) else None
+
+
+def extract_response_id(data: Mapping[str, Any]) -> str | None:
+    """Return the response ``id`` when it is a string."""
+    response_id = data.get("id")
+    return response_id if isinstance(response_id, str) else None
+
+
+def parse_usage(usage_raw: Any) -> dict[str, int]:
+    """Normalize a Chat Completions ``usage`` block into Pollux usage keys.
+
+    Maps ``prompt_tokens``/``completion_tokens``/``total_tokens`` to
+    ``input_tokens``/``output_tokens``/``total_tokens``, and surfaces
+    ``reasoning_tokens`` and nested ``prompt_tokens_details.cached_tokens`` when
+    present. Missing fields are simply omitted.
+    """
+    if not isinstance(usage_raw, Mapping):
+        return {}
+    usage: dict[str, int] = {}
+    prompt = usage_raw.get("prompt_tokens")
+    completion = usage_raw.get("completion_tokens")
+    total = usage_raw.get("total_tokens")
+    reasoning = usage_raw.get("reasoning_tokens")
+    if isinstance(prompt, int):
+        usage["input_tokens"] = prompt
+    if isinstance(completion, int):
+        usage["output_tokens"] = completion
+    if isinstance(total, int):
+        usage["total_tokens"] = total
+    if isinstance(reasoning, int):
+        usage["reasoning_tokens"] = reasoning
+    details = usage_raw.get("prompt_tokens_details")
+    if isinstance(details, Mapping):
+        cached = details.get("cached_tokens")
+        if isinstance(cached, int):
+            usage["cached_tokens"] = cached
+    return usage
+
+
+def extract_error_message(response: httpx.Response) -> str:
+    """Extract a useful error message from a Chat Completions HTTP error.
+
+    Tries ``error.message``, then a top-level ``message``, then the raw response
+    text, falling back to ``HTTP <status>``. Providers that nest upstream errors
+    can check those first and delegate here for the common shape.
+    """
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+        message = payload.get("message")
+        if isinstance(message, str) and message:
+            return message
+    text = response.text.strip()
+    return text or f"HTTP {response.status_code}"

--- a/src/pollux/providers/local.py
+++ b/src/pollux/providers/local.py
@@ -19,6 +19,14 @@ import httpx
 
 from pollux.errors import APIError, ConfigurationError, walk_exception_chain
 from pollux.providers._errors import wrap_provider_error
+from pollux.providers._openai_compat import (
+    extract_error_message,
+    extract_finish_reason,
+    extract_message_text,
+    extract_response_id,
+    first_choice_message,
+    parse_usage,
+)
 from pollux.providers._utils import to_strict_schema
 from pollux.providers.base import ProviderCapabilities
 from pollux.providers.models import (
@@ -171,7 +179,7 @@ class LocalProvider:
             response = await client.post("chat/completions", json=payload)
             if response.is_error:
                 raise httpx.HTTPStatusError(
-                    _extract_error_message(response),
+                    extract_error_message(response),
                     request=response.request,
                     response=response,
                 )
@@ -317,16 +325,9 @@ def _parse_response(
     slot is the established Pollux signal for "did not produce structured
     output." Revisit if real-world use shows this silent path confuses users.
     """
-    choices = data.get("choices")
-    choice = choices[0] if isinstance(choices, list) and choices else {}
-    if not isinstance(choice, Mapping):
-        choice = {}
+    choice, message = first_choice_message(data)
 
-    message = choice.get("message")
-    if not isinstance(message, Mapping):
-        message = {}
-
-    text = _extract_message_text(message.get("content"))
+    text = extract_message_text(message.get("content"))
     reasoning_content = message.get("reasoning_content")
     reasoning = (
         reasoning_content
@@ -341,58 +342,14 @@ def _parse_response(
         except Exception:
             structured = None
 
-    finish_reason = choice.get("finish_reason")
-    if not isinstance(finish_reason, str):
-        finish_reason = None
-
-    usage = _parse_usage(data.get("usage"))
-
-    response_id = data.get("id")
     return ProviderResponse(
         text=text,
-        usage=usage,
+        usage=parse_usage(data.get("usage")),
         reasoning=reasoning,
         structured=structured,
-        response_id=response_id if isinstance(response_id, str) else None,
-        finish_reason=finish_reason,
+        response_id=extract_response_id(data),
+        finish_reason=extract_finish_reason(choice),
     )
-
-
-def _extract_message_text(content: Any) -> str:
-    """Extract text from a Chat Completions message content field."""
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return ""
-    text_parts: list[str] = []
-    for item in content:
-        if isinstance(item, Mapping) and item.get("type") == "text":
-            text = item.get("text")
-            if isinstance(text, str):
-                text_parts.append(text)
-    return "\n\n".join(text_parts)
-
-
-def _parse_usage(usage_raw: Any) -> dict[str, int]:
-    """Extract token usage from a Chat Completions response."""
-    if not isinstance(usage_raw, Mapping):
-        return {}
-    usage: dict[str, int] = {}
-    prompt = usage_raw.get("prompt_tokens")
-    completion = usage_raw.get("completion_tokens")
-    total = usage_raw.get("total_tokens")
-    if isinstance(prompt, int):
-        usage["input_tokens"] = prompt
-    if isinstance(completion, int):
-        usage["output_tokens"] = completion
-    if isinstance(total, int):
-        usage["total_tokens"] = total
-    details = usage_raw.get("prompt_tokens_details")
-    if isinstance(details, Mapping):
-        cached = details.get("cached_tokens")
-        if isinstance(cached, int):
-            usage["cached_tokens"] = cached
-    return usage
 
 
 def _hint_for_local_error(exc: BaseException, *, base_url: str) -> str | None:
@@ -424,25 +381,6 @@ def _hint_for_local_error(exc: BaseException, *, base_url: str) -> str | None:
                 "model may have crashed; check server logs."
             )
     return None
-
-
-def _extract_error_message(response: httpx.Response) -> str:
-    """Extract a useful error message from a local server HTTP response."""
-    try:
-        payload = response.json()
-    except Exception:
-        payload = None
-    if isinstance(payload, Mapping):
-        error = payload.get("error")
-        if isinstance(error, Mapping):
-            message = error.get("message")
-            if isinstance(message, str) and message:
-                return message
-        message = payload.get("message")
-        if isinstance(message, str) and message:
-            return message
-    text = response.text.strip()
-    return text or f"HTTP {response.status_code}"
 
 
 def _local_api_error(

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -16,6 +16,14 @@ import httpx
 
 from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import wrap_provider_error
+from pollux.providers._openai_compat import (
+    extract_error_message,
+    extract_finish_reason,
+    extract_message_text,
+    extract_response_id,
+    first_choice_message,
+    parse_usage,
+)
 from pollux.providers._utils import to_strict_schema
 from pollux.providers.base import ProviderCapabilities
 from pollux.providers.models import (
@@ -677,16 +685,9 @@ def _parse_response(
     response_schema: dict[str, Any] | None,
 ) -> ProviderResponse:
     """Parse an OpenRouter chat-completions payload into ProviderResponse."""
-    choices = data.get("choices")
-    choice = choices[0] if isinstance(choices, list) and choices else {}
-    if not isinstance(choice, Mapping):
-        choice = {}
+    choice, message = first_choice_message(data)
 
-    message = choice.get("message")
-    if not isinstance(message, Mapping):
-        message = {}
-
-    text = _extract_message_text(message.get("content"))
+    text = extract_message_text(message.get("content"))
     structured: dict[str, Any] | None = None
     if response_schema is not None and text:
         try:
@@ -696,32 +697,8 @@ def _parse_response(
         if isinstance(parsed, dict):
             structured = parsed
 
-    finish_reason = choice.get("finish_reason")
-    if not isinstance(finish_reason, str):
-        finish_reason = None
+    usage = parse_usage(data.get("usage"))
 
-    usage_raw = data.get("usage")
-    usage: dict[str, int] = {}
-    if isinstance(usage_raw, Mapping):
-        prompt_tokens = usage_raw.get("prompt_tokens")
-        completion_tokens = usage_raw.get("completion_tokens")
-        total_tokens = usage_raw.get("total_tokens")
-        reasoning_tokens = usage_raw.get("reasoning_tokens")
-        if isinstance(prompt_tokens, int):
-            usage["input_tokens"] = prompt_tokens
-        if isinstance(completion_tokens, int):
-            usage["output_tokens"] = completion_tokens
-        if isinstance(total_tokens, int):
-            usage["total_tokens"] = total_tokens
-        if isinstance(reasoning_tokens, int):
-            usage["reasoning_tokens"] = reasoning_tokens
-        prompt_details = usage_raw.get("prompt_tokens_details")
-        if isinstance(prompt_details, Mapping):
-            cached_tokens = prompt_details.get("cached_tokens")
-            if isinstance(cached_tokens, int):
-                usage["cached_tokens"] = cached_tokens
-
-    response_id = data.get("id")
     tool_calls = _parse_tool_calls(message.get("tool_calls"))
     reasoning = message.get("reasoning")
     reasoning_details = _normalize_reasoning_details(message.get("reasoning_details"))
@@ -738,27 +715,10 @@ def _parse_response(
         reasoning=reasoning if isinstance(reasoning, str) and reasoning else None,
         structured=structured,
         tool_calls=tool_calls if tool_calls else None,
-        response_id=response_id if isinstance(response_id, str) else None,
-        finish_reason=finish_reason,
+        response_id=extract_response_id(data),
+        finish_reason=extract_finish_reason(choice),
         provider_state=provider_state,
     )
-
-
-def _extract_message_text(content: Any) -> str:
-    """Extract text from a chat-completions message content field."""
-    if isinstance(content, str):
-        return content
-
-    if not isinstance(content, list):
-        return ""
-
-    text_parts: list[str] = []
-    for item in content:
-        if not isinstance(item, Mapping):
-            continue
-        if item.get("type") == "text" and isinstance(item.get("text"), str):
-            text_parts.append(item["text"])
-    return "\n\n".join(text_parts)
 
 
 def _parse_tool_calls(value: Any) -> list[ToolCall]:
@@ -863,7 +823,12 @@ def _get_history_item_provider_state(
 
 
 def _extract_error_message(response: httpx.Response) -> str:
-    """Extract a useful error message from an OpenRouter HTTP response."""
+    """Extract an error message, preferring OpenRouter's nested upstream error.
+
+    OpenRouter sometimes returns a stub ``error`` whose real message is nested
+    under ``error.metadata.raw``. We surface that first, then fall back to the
+    shared Chat Completions error shape.
+    """
     try:
         payload = response.json()
     except Exception:
@@ -875,17 +840,8 @@ def _extract_error_message(response: httpx.Response) -> str:
             nested_message = _extract_nested_provider_error_message(error)
             if nested_message is not None:
                 return nested_message
-            message = error.get("message")
-            if isinstance(message, str) and message:
-                return message
-        message = payload.get("message")
-        if isinstance(message, str) and message:
-            return message
 
-    text = response.text.strip()
-    if text:
-        return text
-    return f"HTTP {response.status_code}"
+    return extract_error_message(response)
 
 
 def _extract_nested_provider_error_message(error: Mapping[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup that gives the OpenAI-compatible Chat Completions wire format a single owner. The `local` and `openrouter` providers both parse Chat Completions responses, and the response-reading primitives were duplicated byte-for-byte. This extracts them into `providers/_openai_compat.py`.

**Shared** (stateless wire helpers): `first_choice_message`, `extract_message_text`, `extract_finish_reason`, `extract_response_id`, `parse_usage`, `extract_error_message`.

**Deliberately left per-provider** (genuinely different, not duplication): message building, input-part normalization, tool-call parsing, reasoning handling, OpenRouter's model-metadata catalog and modality validation, and OpenRouter's nested upstream-error extraction (which now falls back to the shared base). The HTTP client builders also stay put - their base-URL/limits config diverges enough that sharing would over-parametrize.

## Related issue

None - cleanup ahead of the v2 work.

## Test plan

`just check` passes (lint + mypy strict + 329 passed, 18 deselected).

No new tests added - **trivial delegation** and **boundary coverage**. Every shared helper is a direct extraction of existing logic already exercised through both provider boundaries: the `local` generate suite covers text/usage/cached-tokens/finish-reason/error extraction, and the `openrouter` `_parse_response` and `_extract_error_message` (nested + base fallback) tests stay green unchanged.

## Notes

- **`parse_usage` unification:** it now surfaces both `reasoning_tokens` (previously only openrouter) and `cached_tokens` (previously only local). This is safe because each provider's responses only carry the keys they actually emit, so observable usage is unchanged for both.
- **Honest scope:** this does not gut openrouter - most of its 950 lines are legitimately OpenRouter-specific. The win is removing the exact-duplicate response primitives and establishing the shared seam, not a large LOC drop.
