### PR TITLE
refactor(core): give _conversation_state a typed owner

### DIFF
--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -16,7 +16,7 @@ Public API:
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
@@ -28,6 +28,7 @@ from pollux.config import (
     ProviderName,
     resolve_api_key,
 )
+from pollux.continuation import ConversationState
 from pollux.deferred import (
     DeferredHandle,
     DeferredSnapshot,
@@ -243,11 +244,19 @@ async def continue_tool(
     """
     import copy
 
-    new_state = copy.deepcopy(continue_from.get("_conversation_state", {}))
-    new_state["history"] = new_state.get("history", []) + tool_results
+    prior = ConversationState.from_envelope(continue_from) or ConversationState(
+        history=[]
+    )
+    new_state = replace(prior, history=[*prior.history, *tool_results])
 
-    # Build a synthetic envelope to carry the updated state and response_id
-    synthetic_envelope: ResultEnvelope = {"_conversation_state": new_state}
+    # Deep-copy the serialized state so the synthetic envelope never aliases the
+    # caller's _conversation_state (its nested history/provider_state objects).
+    # cast: TypedDict construction needs a literal key, but ENVELOPE_KEY stays
+    # the single owner of the key string.
+    synthetic_envelope = cast(
+        "ResultEnvelope",
+        {ConversationState.ENVELOPE_KEY: copy.deepcopy(new_state.to_dict())},
+    )
 
     # Merge options, favoring the synthetic continue_from
     # Do not mutate the caller's options object

--- a/src/pollux/continuation.py
+++ b/src/pollux/continuation.py
@@ -4,6 +4,7 @@ Pollux 1.x carries continuation state as a dict under the private
 ``_conversation_state`` key of a ``ResultEnvelope``. This module owns the full
 surface of that mechanism:
 
+- :class:`ConversationState` owns the serialized ``_conversation_state`` shape.
 - :func:`load_continuation` resolves prior-turn state from ``continue_from``.
 - :func:`history_to_messages` translates history dicts into provider messages.
 - :func:`build_conversation_state` assembles the updated state after a response.
@@ -16,14 +17,73 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pollux.errors import ConfigurationError
 from pollux.providers.models import Message, ToolCall, tool_call_to_dict
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from pollux.options import Options
     from pollux.providers.models import ProviderResponse
+
+
+@dataclass(frozen=True)
+class ConversationState:
+    """Serialized state stored under a ResultEnvelope's ``_conversation_state`` key.
+
+    This is the single owner of that dict shape: the magic keys (``history``,
+    ``response_id``, ``provider_state``) and the envelope key itself live here
+    rather than as string literals across the read, write, and continue paths.
+    It is distinct from :class:`ContinuationState`, which is the *resolved*
+    prior-turn working state derived from this serialized form.
+    """
+
+    #: Envelope key under which this state is stored in a ``ResultEnvelope``.
+    ENVELOPE_KEY: ClassVar[str] = "_conversation_state"
+
+    history: list[dict[str, Any]]
+    response_id: str | None = None
+    provider_state: dict[str, Any] | None = None
+
+    @classmethod
+    def from_envelope(cls, envelope: Mapping[str, Any]) -> ConversationState | None:
+        """Parse from a ResultEnvelope, or ``None`` when the key is absent/invalid."""
+        state = envelope.get(cls.ENVELOPE_KEY)
+        if not isinstance(state, dict):
+            return None
+        return cls.from_state_dict(state)
+
+    @classmethod
+    def from_state_dict(cls, state: Mapping[str, Any]) -> ConversationState:
+        """Parse a serialized state dict, type-guarding each facet."""
+        raw_history = state.get("history")
+        history = list(raw_history) if isinstance(raw_history, list) else []
+        raw_response_id = state.get("response_id")
+        response_id = raw_response_id if isinstance(raw_response_id, str) else None
+        raw_provider_state = state.get("provider_state")
+        provider_state = (
+            dict(raw_provider_state) if isinstance(raw_provider_state, dict) else None
+        )
+        return cls(
+            history=history,
+            response_id=response_id,
+            provider_state=provider_state,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the ``_conversation_state`` dict shape.
+
+        Optional facets are omitted when unset so the shape stays compact and
+        matches what ``build_conversation_state`` has always produced.
+        """
+        state: dict[str, Any] = {"history": self.history}
+        if self.provider_state is not None:
+            state["provider_state"] = self.provider_state
+        if self.response_id is not None:
+            state["response_id"] = self.response_id
+        return state
 
 
 @dataclass(frozen=True)
@@ -51,8 +111,8 @@ def load_continuation(options: Options) -> ContinuationState:
     previous_response_id: str | None = None
     provider_state: dict[str, Any] | None = None
     if options.continue_from is not None:
-        state = options.continue_from.get("_conversation_state")
-        if not isinstance(state, dict):
+        state = ConversationState.from_envelope(options.continue_from)
+        if state is None:
             raise ConfigurationError(
                 "continue_from is missing _conversation_state",
                 hint=(
@@ -61,22 +121,16 @@ def load_continuation(options: Options) -> ContinuationState:
                 ),
             )
 
-        state_history = state.get("history")
-        if history is None and isinstance(state_history, list):
+        if history is None:
             conversation_history = [
                 item
-                for item in state_history
+                for item in state.history
                 if isinstance(item, dict) and isinstance(item.get("role"), str)
             ]
-
-        if history is None:
             history = conversation_history
 
-        prev = state.get("response_id")
-        previous_response_id = prev if isinstance(prev, str) else None
-        raw_provider_state = state.get("provider_state")
-        if isinstance(raw_provider_state, dict):
-            provider_state = dict(raw_provider_state)
+        previous_response_id = state.response_id
+        provider_state = state.provider_state
 
     return ContinuationState(
         history=history,
@@ -197,12 +251,13 @@ def build_conversation_state(
         updated_history.append({"role": "user", "content": user_content})
     updated_history.append(assistant_msg)
 
-    conversation_state: dict[str, Any] = {"history": updated_history}
-    if isinstance(provider_msg_state, dict):
-        conversation_state["provider_state"] = provider_msg_state
     response_id = responses[0].response_id
-    if isinstance(response_id, str):
-        conversation_state["response_id"] = response_id
-    elif previous_response_id is not None:
-        conversation_state["response_id"] = previous_response_id
-    return conversation_state
+    return ConversationState(
+        history=updated_history,
+        response_id=response_id
+        if isinstance(response_id, str)
+        else previous_response_id,
+        provider_state=(
+            provider_msg_state if isinstance(provider_msg_state, dict) else None
+        ),
+    ).to_dict()


### PR DESCRIPTION
## Summary

Behavior-preserving cleanup that gives the serialized `_conversation_state` dict a single typed owner. The shape's magic keys (`history`, `response_id`, `provider_state`) and the envelope key itself were spelled as string literals across three sites - `build_conversation_state` (write), `load_continuation` (read), and `continue_tool` (read+write). This introduces a frozen `ConversationState` dataclass in `continuation.py` that owns that shape via `from_envelope` / `from_state_dict` / `to_dict`.

`ConversationState` is the *serialized* form; the existing `ContinuationState` stays the *resolved* prior-turn working state derived from it. The two are cross-referenced in their docstrings.

## Related issue

None - cleanup ahead of the v2 work.

## Test plan

`just check` passes (lint + mypy strict + 329 passed, 18 deselected).

No new tests added - **boundary coverage**. Every method is exercised through the existing conversation suite in `tests/test_pipeline.py`, which stays green unchanged:
- `to_dict` (write) ← `test_conversation_result_includes_conversation_state`, `test_tool_calls_preserved_in_conversation_state`, `test_conversation_state_preserves_provider_state_from_response`
- `from_envelope` / `from_state_dict` (read) ← `test_continue_from_preserves_tool_history_items`, `test_continue_from_forwards_provider_state_with_history_items`
- `from_envelope` None path ← `test_continue_from_requires_conversation_state`
- round-trip through `continue_tool` ← `test_continue_tool_mechanics`

## Notes

Two deliberate, observationally identical changes:
- `continue_tool` now deep-copies the whole serialized state, where previously it deep-copied the prior state but not the appended `tool_results`. This is strictly *more* isolation; nothing mutates these objects downstream.
- `from_envelope` canonicalizes to the three known facets, dropping any stray extra keys - which `build_conversation_state` never emits, so real envelopes are unaffected.
- `cast` is used at the one `ResultEnvelope` construction site in `continue_tool` because TypedDict needs a literal key; `ConversationState.ENVELOPE_KEY` remains the single owner of the key string.
