### PR TITLE
refactor(core): cache-conflict table, drop dead constant, document deferred gates

### DIFF
--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -446,6 +446,11 @@ def _get_provider(config: Config) -> Provider:
 
 def _resolve_deferred_provider(handle: DeferredHandle) -> Provider:
     """Resolve a provider client for deferred lifecycle calls from the handle."""
+    # Gate on the registry flag, not provider.capabilities.deferred_delivery:
+    # this runs before instantiation, keyed only by the persisted provider name.
+    # A handle carries no base_url, so e.g. ``local`` cannot even be built to
+    # inspect its capabilities. The registry flag is the pre-instantiation gate;
+    # deferred.py applies the instance-level capability + protocol checks.
     spec = _PROVIDER_REGISTRY.get(handle.provider)
     if spec is None or not spec.supports_deferred:
         raise ConfigurationError(

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -109,6 +109,11 @@ class DeferredSnapshot:
 
 
 def _get_deferred_provider(provider: Provider) -> DeferredProvider:
+    # Two distinct instance-level gates (see also the pre-instantiation registry
+    # gate in __init__._resolve_deferred_provider):
+    #  - the capability flag is the user-facing "not supported" contract;
+    #  - the protocol check verifies the declaration matches the implementation,
+    #    so a flag set without the lifecycle methods is a programming error.
     if not provider.capabilities.deferred_delivery:
         raise ConfigurationError(
             "Provider does not support deferred delivery",

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -372,9 +372,6 @@ async def _substitute_upload_parts(
     return resolved
 
 
-_OPENAI_FILE_PREFIX = "openai://file/"
-
-
 async def _cleanup_uploads(
     upload_cache: dict[tuple[str, str], ProviderFileAsset],
     provider: Provider,

--- a/src/pollux/plan.py
+++ b/src/pollux/plan.py
@@ -61,38 +61,36 @@ def build_plan(request: Request) -> Plan:
                     "with the same model."
                 ),
             )
-        if request.options.system_instruction is not None:
-            raise ConfigurationError(
+        # Inputs that conflict with a cache handle because the cache already
+        # bakes in this context. Each row: (conflicting, message, hint). Order is
+        # preserved so callers see a deterministic first failure.
+        conflict_checks: tuple[tuple[bool, str, str], ...] = (
+            (
+                request.options.system_instruction is not None,
                 "system_instruction cannot be used with a cache handle",
-                hint=(
-                    "Bake the system instruction into create_cache() instead, "
-                    "or remove the cache handle."
-                ),
-            )
-        if request.options.tools is not None:
-            raise ConfigurationError(
+                "Bake the system instruction into create_cache() instead, "
+                "or remove the cache handle.",
+            ),
+            (
+                request.options.tools is not None,
                 "tools cannot be used with a cache handle",
-                hint=(
-                    "Bake tools into create_cache() instead, "
-                    "or remove the cache handle."
-                ),
-            )
-        if request.options.tool_choice is not None:
-            raise ConfigurationError(
+                "Bake tools into create_cache() instead, or remove the cache handle.",
+            ),
+            (
+                request.options.tool_choice is not None,
                 "tool_choice cannot be used with a cache handle",
-                hint=(
-                    "Remove tool_choice when using a cache handle, "
-                    "or remove the cache handle."
-                ),
-            )
-        if shared_parts:
-            raise ConfigurationError(
+                "Remove tool_choice when using a cache handle, "
+                "or remove the cache handle.",
+            ),
+            (
+                bool(shared_parts),
                 "sources cannot be used with a cache handle",
-                hint=(
-                    "Bake sources into create_cache() instead, "
-                    "or remove the cache handle."
-                ),
-            )
+                "Bake sources into create_cache() instead, or remove the cache handle.",
+            ),
+        )
+        for conflicting, message, hint in conflict_checks:
+            if conflicting:
+                raise ConfigurationError(message, hint=hint)
         cache_name = cache.name
 
     return Plan(

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1123,6 +1123,55 @@ async def test_cached_context_rejects_sources(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("conflict_options", "expected_match"),
+    [
+        ({"system_instruction": "Be brief."}, "system_instruction cannot be used"),
+        (
+            {
+                "tools": [
+                    {
+                        "name": "f",
+                        "description": "d",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                ]
+            },
+            "tools cannot be used",
+        ),
+        ({"tool_choice": "auto"}, "tool_choice cannot be used"),
+    ],
+)
+async def test_cached_context_rejects_conflicting_options(
+    monkeypatch: pytest.MonkeyPatch,
+    conflict_options: dict[str, Any],
+    expected_match: str,
+) -> None:
+    """A cache handle conflicts with options the cache already bakes in."""
+    import time
+
+    fake = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+
+    cfg = Config(provider="gemini", model=CACHE_MODEL, use_mock=True)
+    handle = CacheHandle(
+        name="cachedContents/test",
+        model=CACHE_MODEL,
+        provider="gemini",
+        expires_at=time.time() + 3600,
+    )
+
+    with pytest.raises(ConfigurationError, match=expected_match):
+        await pollux.run(
+            "prompt",
+            config=cfg,
+            options=Options(cache=handle, **conflict_options),
+        )
+
+    assert fake.last_parts is None
+
+
+@pytest.mark.asyncio
 async def test_options_cache_requires_persistent_cache_capability(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up cleanup bundling the two low-priority items flagged during the v2-seam series (#170/#171/#172), plus a dead-constant removal found along the way. Behavior-preserving; no public API change.

- **Cache-conflict table (`plan.py`):** collapse the four "X cannot be used with a cache handle" checks into a uniform `(conflicting, message, hint)` table, matching the pattern `capabilities.py::validate_capabilities` already uses. Messages, hints, and failure order are byte-preserved.
- **Coverage for the conflict rows:** adds a parametrized test for the `system_instruction` / `tools` / `tool_choice` rows, which had **no** coverage before (only the `sources` row was tested).
- **Dead-constant removal (`execute.py`):** delete the unused `_OPENAI_FILE_PREFIX` (zero references; tests that use the `"openai://file/"` literal build their own fake ids).
- **Document the deferred-support gates:** the third "low-priority" item turned out **not** to be a redundancy to collapse. The three encodings are distinct and each is load-bearing; added comments so they aren't mistakenly merged.

## Related issue

None - follow-up cleanup ahead of the v2 work.

## Test plan

`just check` passes (lint + mypy strict + 332 passed, 18 deselected - 3 new parametrized cases).

- `plan.py` is a behavior-preserving restructure; the new `test_cached_context_rejects_conflicting_options` parametrized test locks the three previously-uncovered conflict rows, and the existing `test_cached_context_rejects_sources` still covers the fourth.
- `execute.py` / deferred docs are **non-behavioral** (dead-code removal, comments).

## Notes

On the deferred-support gates: investigation showed it's a deliberate 3-layer design, not redundancy.

- `_ProviderSpec.supports_deferred` (registry) - a **pre-instantiation** gate in `_resolve_deferred_provider`, keyed only by the persisted provider name. A `DeferredHandle` carries no `base_url`, so `local` cannot even be constructed to read its capabilities - the registry flag is the only safe way to reject it here.
- `capabilities.deferred_delivery` - the **user-facing** instance gate (`ConfigurationError`).
- `DeferredProvider` protocol - verifies the declaration matches the implementation (`InternalError` if a provider sets the flag without the lifecycle methods).

Collapsing these would reintroduce exactly the failure mode (#169) designed this layering to avoid, so I documented the rationale instead of changing the structure.
