### PR TITLE
feat(providers): add v1 audit escape hatch

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -88,7 +88,8 @@ provider level:
 - **Explicit caching (Gemini):** You upload content once with
   `create_cache()`, get a handle back, and pass that handle to later calls.
 - **Implicit caching (Anthropic):** Pollux maps
-  `Options(implicit_caching=...)` to Anthropic's prompt caching behavior.
+  `Options(implicit_caching=...)` to Anthropic's automatic prompt caching
+  behavior.
 - **Automatic prompt caching (OpenAI, Gemini, OpenRouter):** These providers
   can discount repeated long prefixes on their own. Pollux does not control
   or configure this, but you can benefit from it without doing anything.
@@ -98,10 +99,12 @@ verify automatic prompt caching, check provider-native usage or billing.
 
 ## Implicit Caching (Anthropic)
 
-Anthropic caches shared prefixes from the top of the request downward:
-system instruction, tools, conversation history, and repeated prompt context.
-You do not create a cache object yourself. Pollux toggles this with
-`Options(implicit_caching=...)`.
+Anthropic currently describes this provider feature as automatic prompt
+caching. Pollux calls the toggle `implicit_caching` to distinguish it from
+Gemini's explicit `create_cache()` handles. Anthropic caches shared prefixes
+from the top of the request downward: system instruction, tools, conversation
+history, and repeated prompt context. You do not create a cache object
+yourself. Pollux toggles this with `Options(implicit_caching=...)`.
 
 ### Cost Mechanics
 
@@ -146,8 +149,8 @@ Setting `implicit_caching=True` on a provider that does not support it raises
 ### Current Pollux Scope
 
 Pollux currently exposes Anthropic's default ephemeral caching behavior. It
-does not expose Anthropic's 1-hour TTL or manual block-level cache
-breakpoints in the public API.
+does not expose Anthropic's 1-hour TTL or manual block-level cache breakpoints
+in the public API.
 
 ## Explicit Caching (Gemini)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,9 @@ options = Options(
     # reasoning_budget_tokens=0,      # Explicit reasoning token budget where supported
     max_tokens=4096,                  # Provider-specific output cap
     implicit_caching=True,            # Auto-cache prefix (Anthropic only)
+    provider_options={                # Raw provider escape hatch
+        "openai": {"tools": [{"type": "web_search_preview"}]},
+    },
 )
 ```
 
@@ -178,7 +181,7 @@ options = Options(
 | `system_instruction` | `str \| None` | `None` | Global system prompt |
 | `temperature` | `float \| None` | `None` | Sampling temperature |
 | `top_p` | `float \| None` | `None` | Nucleus sampling probability |
-| `tools` | `list[dict] \| None` | `None` | JSON schemas for native tools. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
+| `tools` | `list[dict] \| None` | `None` | JSON schemas for Pollux-normalized function tools. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 | `tool_choice` | `str \| dict \| None` | `None` | Tool execution strategy. See [Building an Agent Loop](agent-loop.md) |
 | `response_schema` | `type[BaseModel] \| dict` | `None` | Expected JSON response format. See [Extracting Structured Data](structured-data.md) |
 | `reasoning_effort` | `str \| None` | `None` | Controls model thinking depth. See [Writing Portable Code Across Providers](portable-code.md#choosing-a-reasoning-control) |
@@ -188,6 +191,28 @@ options = Options(
 | `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
 | `cache` | `CacheHandle \| None` | `None` | Persistent explicit cache (Gemini). See [Reducing Costs with Context Caching](caching.md) |
 | `implicit_caching` | `bool \| None` | `None` | Enable or disable Anthropic implicit caching. Defaults to `True` for a single provider call and `False` for multi-call fan-out. `implicit_caching=True` raises on providers that do not support it. See [Reducing Costs with Context Caching](caching.md) |
+| `provider_options` | `dict[str, dict] \| None` | `None` | Raw provider-scoped request options. Keys must be provider names. |
+
+### Provider Options Escape Hatch
+
+`provider_options` is Pollux's one raw provider escape hatch. It is for
+provider-specific request fields that Pollux does not normalize, such as
+hosted/server tools, service tiers, or newly released provider knobs.
+
+```python
+options = Options(
+    provider_options={
+        "openai": {"tools": [{"type": "web_search_preview"}]},
+        "gemini": {"seed": 123},
+    },
+)
+```
+
+Only the active provider's dictionary is forwarded. If a raw key overlaps with
+a field Pollux already generated from first-class options, Pollux raises
+`ConfigurationError` instead of silently overriding either value. For example,
+do not pass both `Options(tools=[...])` and
+`provider_options={"openai": {"tools": [...]}}` in the same call.
 
 !!! note
     OpenAI GPT-5 family models (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`) reject

--- a/docs/conversations-and-agents.md
+++ b/docs/conversations-and-agents.md
@@ -134,8 +134,11 @@ result = await run(
 
 ## Setting Up Tool Calling
 
-Pollux passes tool definitions to providers and surfaces tool call responses
-in the result envelope.
+Pollux passes function tool definitions to providers and surfaces tool call
+responses in the result envelope. `Options.tools` is for Pollux-normalized
+client/application tools that your code executes. Provider-hosted server tools
+such as web search or code execution are provider-specific and belong in
+`Options(provider_options=...)`.
 
 **Defining tools:** pass a list of tool schemas in `Options.tools`:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -46,7 +46,8 @@ The primary execution functions are exported from `pollux`:
 ## Core Types
 
 `Source` includes both the generic source constructors and narrow
-provider-specific helpers such as `Source.with_gemini_video_settings(...)`.
+provider-specific helpers such as `Source.with_gemini_video_settings(...)` and
+`Source.with_gemini_url_context()`.
 
 ::: pollux.Source
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -25,6 +25,7 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | Local file inputs | ✅ | ✅ | ✅ | ✅ (images and PDFs) | ❌ | OpenRouter keeps the local file subset narrow; local provider is text-only |
 | PDF URL inputs | ✅ (via URI part) | ✅ (native `input_file.file_url`) | ✅ (native `document` URL block) | ⚠️ best-effort | ❌ | Prefer local PDFs when reliability matters |
 | Image URL inputs | ✅ (via URI part) | ✅ (native `input_image.image_url`) | ✅ (native `image` URL block) | ⚠️ best-effort on supported models | ❌ | Remote fetch behavior can vary by route |
+| Text/document URL inputs | ✅ (Gemini URL Context opt-in) | ✅ (native `input_file.file_url`) | ❌ | ⚠️ best-effort | ❌ | Provider-specific MIME support varies |
 | YouTube URL inputs | ✅ | ⚠️ limited | ⚠️ limited | ❌ | ❌ | OpenAI/Anthropic parity layers (download/re-upload) are out of scope |
 | Explicit caching (`create_cache`) | ✅ | ❌ | ❌ | ❌ | ❌ | Persistent cache handles are Gemini-only |
 | Implicit caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | ❌ | Anthropic-only; see [caching docs](../caching.md#implicit-caching-anthropic) |
@@ -34,7 +35,8 @@ Pollux is **capability-transparent**, not capability-equalizing: providers are a
 | `reasoning_effort` | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.); exact model support remains provider-defined |
 | `reasoning_budget_tokens` | ✅ | ❌ | ✅ | ❌ | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
 | Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | ❌ | Use the deferred API directly. |
-| Tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Requires an OpenRouter model that supports `tools`; forced tool use may also require `tool_choice` |
+| Function tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | `Options.tools` is for Pollux-normalized client/application tools |
+| Provider-hosted tools | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ server-dependent | Raw provider escape hatch; not normalized by Pollux |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Works on OpenRouter models that support tool calling |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
@@ -50,6 +52,10 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   points.
 - Video sources can carry Gemini-specific clipping and FPS controls via
   `Source.with_gemini_video_settings(...)`.
+- HTTP(S) URI sources can opt into Gemini URL Context via
+  `Source.from_uri(...).with_gemini_url_context()`. This performs request-time
+  retrieval, surfaces URL retrieval metadata in diagnostics, and cannot be used
+  with explicit cache handles.
 - Those controls are intentionally not normalized across providers. Pollux
   keeps them explicit so portability decisions stay in caller code.
 - Gemini also caches repeated long prefixes automatically. Pollux does not
@@ -69,9 +75,11 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   Pollux also performs best-effort cleanup of uploaded files after execution.
 - Deferred delivery uses the OpenAI Batch API through Pollux's deferred entry
   points.
-- OpenAI caches repeated long prefixes automatically. Pollux does not expose
-  OpenAI-specific cache controls.
-- Remote URL support is intentionally narrow: PDFs and images only.
+- OpenAI caches repeated long prefixes automatically. OpenAI-specific cache
+  routing controls can be passed through `provider_options`.
+- Remote URL support includes images plus PDFs, text-like files, and common
+  document/spreadsheet/presentation formats accepted by OpenAI `input_file`
+  URLs. Audio, video, and unknown binary URLs remain unsupported.
 - Conversation can use either explicit `history` or `previous_response_id`
   (via `continue_from`). When `previous_response_id` is set, only tool
   result messages are forwarded from history; the rest is handled
@@ -92,7 +100,8 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 ### Anthropic
 
 - Local file uploads use the Anthropic Files API (beta). Supported types:
-  images, PDFs, and text files.
+  images, PDFs, and plaintext files. Convert CSV, Markdown, Office files, and
+  other text-like formats to `text/plain` before sending.
 - Deferred delivery uses the Anthropic Message Batches API through Pollux's
   deferred entry points.
 - Remote URL support is intentionally narrow: images and PDFs only.
@@ -104,7 +113,8 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - Reasoning: thinking text appears in `ResultEnvelope.reasoning`.
   `reasoning_effort` and `reasoning_budget_tokens` are both forwarded for
   Anthropic models that support them. Exact model support and budget floors
-  are enforced by Anthropic.
+  are enforced by Anthropic. Pollux routes current Opus adaptive-thinking
+  models through Anthropic's adaptive thinking mode.
 - Thinking block replay: when Anthropic returns `thinking` or
   `redacted_thinking` blocks, Pollux preserves them in conversation state and
   replays them verbatim on continuation turns so tool loops remain valid.

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -22,7 +22,7 @@ a `Source`, which entry point to call, and how to read the result.
 | Constructor | Input | Notes |
 |---|---|---|
 | `Source.from_text(text)` | Plain string | Identifier defaults to first 50 chars |
-| `Source.from_file(path)` | Local file path | Supports PDF, images, video, audio, text |
+| `Source.from_file(path)` | Local file path | Wraps local files; provider MIME support varies |
 | `Source.from_youtube(url)` | YouTube URL | URL reference (no download); Gemini-native, limited on OpenAI and Anthropic |
 | `Source.from_arxiv(ref)` | arXiv ID or URL | Normalizes to canonical PDF URL (no download at construction time) |
 | `Source.from_uri(uri, mime_type=...)` | Remote URI | Generic remote reference; provider support varies by MIME type |
@@ -56,11 +56,31 @@ profile = Source.from_json(UserProfile(name="Alice", preferences=["concise", "fo
 responses, database records, or configuration objects) as context alongside
 a prompt, without manually serializing to a string.
 
-Pollux accepts PDFs, images, video, audio, and text files through the same
-interface. The source type is detected from the file extension or MIME type;
-you do not need to specify format-specific options. For media sources (images,
-video, audio), keep prompts concrete: ask for objects, attributes, timestamps,
-or quoted text rather than open-ended descriptions.
+Pollux wraps PDFs, images, video, audio, text, and other files through the same
+interface. Provider support is narrower than the `Source` abstraction: Gemini
+has the broadest native multimodal coverage, OpenAI accepts images plus many
+document-like file inputs, and Anthropic document inputs are limited to PDFs
+and plaintext files. Unsupported combinations fail with provider-specific
+errors or Pollux validation hints. For media sources (images, video, audio),
+keep prompts concrete: ask for objects, attributes, timestamps, or quoted text
+rather than open-ended descriptions.
+
+### Gemini URL Context
+
+Gemini can retrieve public HTTP(S) URLs at request time with URL Context. Pollux
+exposes this as a Gemini-specific source modifier:
+
+```python
+source = Source.from_uri(
+    "https://example.com/report.html",
+    mime_type="text/html",
+).with_gemini_url_context()
+```
+
+Use this only when you have chosen Gemini. URL Context retrieval metadata is
+available in `result["diagnostics"]["raw_responses"][i]["artifacts"]`. Because
+retrieval happens at request time, URL Context sources cannot be baked into
+`create_cache()`.
 
 ### Gemini Video Controls
 

--- a/src/pollux/cache.py
+++ b/src/pollux/cache.py
@@ -263,6 +263,19 @@ async def create_cache_impl(
                 f"Expected Source, got {type(s).__name__}",
                 hint="Use Source.from_file(), Source.from_text(), etc.",
             )
+        if (
+            s.provider_hints_for(config.provider) is not None
+            and (s.provider_hints_for(config.provider) or {}).get("url_context")
+            is not None
+        ):
+            raise ConfigurationError(
+                "Gemini URL Context sources cannot be used with create_cache()",
+                hint=(
+                    "URL Context performs request-time retrieval. Remove "
+                    "with_gemini_url_context() or send the URL without an "
+                    "explicit cache handle."
+                ),
+            )
 
     if tools is not None:
         for i, t in enumerate(tools):

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -223,6 +223,9 @@ def _build_provider_requests(plan: Plan) -> list[ProviderRequest]:
                 reasoning_effort=options.reasoning_effort,
                 reasoning_budget_tokens=options.reasoning_budget_tokens,
                 max_tokens=options.max_tokens,
+                provider_options=options.provider_options_for(
+                    plan.request.config.provider
+                ),
             )
         )
     return requests

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -199,6 +199,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
                         provider_state=request_provider_state,
                         max_tokens=options.max_tokens,
                         implicit_caching=implicit_caching,
+                        provider_options=options.provider_options_for(config.provider),
                     )
                     await _validate_provider_request(provider, req)
                     parts = await _substitute_upload_parts(

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal, get_args
 import warnings
 
 from pydantic import BaseModel
 
+from pollux.config import ProviderName
 from pollux.errors import ConfigurationError
 
 if TYPE_CHECKING:
@@ -101,6 +102,9 @@ class Options:
     #: Controls implicit model-level caching (e.g., Anthropic prefix caching).
     #: Defaults to True for a single provider call, False for multi-call fan-out.
     implicit_caching: bool | None = None
+    #: Raw provider-scoped request options. Keys are provider names; values are
+    #: passed through without normalization at the active provider boundary.
+    provider_options: dict[str, dict[str, Any]] | None = None
 
     def __post_init__(self) -> None:
         """Validate option shapes early for clear errors."""
@@ -214,6 +218,28 @@ class Options:
                     "cache must be a CacheHandle from create_cache()",
                     hint="Call create_cache() first, then pass Options(cache=handle).",
                 )
+        if self.provider_options is not None:
+            if not isinstance(self.provider_options, dict):
+                raise ConfigurationError(
+                    "provider_options must be a dictionary keyed by provider name",
+                    hint="Pass provider_options={'openai': {'tools': [...]}}.",
+                )
+            supported_providers = set(get_args(ProviderName))
+            for provider, provider_payload in self.provider_options.items():
+                if provider not in supported_providers:
+                    allowed = ", ".join(sorted(supported_providers))
+                    raise ConfigurationError(
+                        f"Unknown provider_options provider: {provider!r}",
+                        hint=f"Use one of: {allowed}.",
+                    )
+                if not isinstance(provider_payload, dict):
+                    raise ConfigurationError(
+                        f"provider_options[{provider!r}] must be a dictionary",
+                        hint=(
+                            "Pass raw provider parameters as a dictionary, e.g. "
+                            f"provider_options={{{provider!r}: {{'key': 'value'}}}}."
+                        ),
+                    )
 
     def response_schema_json(self) -> dict[str, Any] | None:
         """Return JSON Schema for provider APIs."""
@@ -226,3 +252,10 @@ class Options:
     def response_schema_hash(self) -> str | None:
         """Return a stable hash of the JSON Schema."""
         return response_schema_hash(self.response_schema)
+
+    def provider_options_for(self, provider: str) -> dict[str, Any] | None:
+        """Return raw options for the active provider."""
+        if self.provider_options is None:
+            return None
+        payload = self.provider_options.get(provider)
+        return dict(payload) if payload is not None else None

--- a/src/pollux/providers/_utils.py
+++ b/src/pollux/providers/_utils.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from copy import deepcopy
 from typing import Any
 
-from pollux.errors import APIError
+from pollux.errors import APIError, ConfigurationError
 
 
 def to_strict_schema(schema: dict[str, Any]) -> dict[str, Any]:
@@ -40,3 +41,58 @@ def to_strict_schema(schema: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(result, dict):
         raise APIError("Invalid response_schema: expected object schema")
     return result
+
+
+def merge_provider_options(
+    target: dict[str, Any],
+    provider_options: dict[str, Any] | None,
+    *,
+    provider: str,
+) -> None:
+    """Merge raw provider options while preventing silent core-field overrides."""
+    if provider_options is None:
+        return
+    overlaps = sorted(set(target).intersection(provider_options))
+    if overlaps:
+        joined = ", ".join(repr(key) for key in overlaps)
+        raise ConfigurationError(
+            f"provider_options for {provider!r} overlap with Pollux-managed keys: {joined}",
+            hint=(
+                "Set this parameter through Pollux's first-class options, or "
+                "remove the overlapping key from provider_options."
+            ),
+        )
+    target.update(provider_options)
+
+
+def jsonable_provider_artifact(value: Any) -> Any:
+    """Return a JSON-like representation for best-effort diagnostics."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [jsonable_provider_artifact(item) for item in value]
+    if isinstance(value, tuple):
+        return [jsonable_provider_artifact(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): jsonable_provider_artifact(item)
+            for key, item in value.items()
+            if not callable(item)
+        }
+    if hasattr(value, "model_dump"):
+        with suppress(Exception):
+            return jsonable_provider_artifact(value.model_dump(exclude_none=True))
+    if hasattr(value, "to_dict"):
+        with suppress(Exception):
+            return jsonable_provider_artifact(value.to_dict())
+    attrs: dict[str, Any] = {}
+    for key in dir(value):
+        if key.startswith("_"):
+            continue
+        with suppress(Exception):
+            item = getattr(value, key)
+            if callable(item):
+                continue
+            if isinstance(item, (str, int, float, bool, list, tuple, dict, type(None))):
+                attrs[key] = jsonable_provider_artifact(item)
+    return attrs or repr(value)

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING, Any
 
 from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import wrap_provider_error
-from pollux.providers._utils import to_strict_schema
+from pollux.providers._utils import (
+    jsonable_provider_artifact,
+    merge_provider_options,
+    to_strict_schema,
+)
 from pollux.providers.base import (
     DeferredItemStatus,
     ProviderCapabilities,
@@ -39,7 +43,12 @@ _ANTHROPIC_THINKING_BLOCKS_KEY = "anthropic_thinking_blocks"
 _ALLOWED_REASONING_EFFORTS = {"low", "medium", "high", "max"}
 # Note: Sonnet 4.6 supports both manual and adaptive thinking.
 # We route through adaptive as it is the recommended path and simpler UX.
-_ADAPTIVE_THINKING_MODEL_PREFIXES = ("claude-opus-4-6", "claude-sonnet-4-6")
+_ADAPTIVE_THINKING_MODEL_PREFIXES = (
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+)
 _MANUAL_THINKING_BUDGETS = {
     "low": 2048,
     "medium": 5120,
@@ -312,6 +321,11 @@ class AnthropicProvider:
                 beta_headers.append(existing_beta)
         create_kwargs["extra_headers"] = {"anthropic-beta": ",".join(beta_headers)}
 
+        merge_provider_options(
+            create_kwargs,
+            request.provider_options,
+            provider="anthropic",
+        )
         return create_kwargs
 
     async def submit_deferred(
@@ -557,10 +571,20 @@ class AnthropicProvider:
             provider_state=request.provider_state,
             max_tokens=request.max_tokens,
             implicit_caching=request.implicit_caching,
+            provider_options=request.provider_options,
         )
 
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
         """Upload a local file using the Anthropic Files API."""
+        if not _is_supported_anthropic_file_mime_type(mime_type):
+            raise ConfigurationError(
+                f"Unsupported mime type for Anthropic file input: {mime_type}",
+                hint=(
+                    "Anthropic document inputs support PDFs and plaintext files. "
+                    "Convert CSV, Markdown, Office files, and other text-like "
+                    "formats to text/plain before sending."
+                ),
+            )
         client = self._get_client()
 
         try:
@@ -644,6 +668,7 @@ def _parse_response(
     reasoning_parts: list[str] = []
     tool_calls: list[ToolCall] = []
     thinking_blocks: list[dict[str, str]] = []
+    artifacts: list[Any] = []
 
     for block in getattr(response, "content", []):
         block_type = getattr(block, "type", None)
@@ -674,6 +699,8 @@ def _parse_response(
                     arguments=json.dumps(getattr(block, "input", {})),
                 )
             )
+        elif block_type is not None:
+            artifacts.append(jsonable_provider_artifact(block))
 
     text = "\n\n".join(text_parts) if text_parts else ""
 
@@ -721,6 +748,7 @@ def _parse_response(
             if thinking_blocks
             else None
         ),
+        artifacts={"content_blocks": artifacts} if artifacts else None,
     )
 
 
@@ -990,10 +1018,13 @@ def _normalize_reasoning_effort(reasoning_effort: str, model_name: str) -> str:
             hint=f"Use one of: {allowed}.",
         )
 
-    if effort == "max" and not model_name.lower().startswith("claude-opus-4-6"):
+    model = model_name.lower()
+    if effort == "max" and not model.startswith(
+        ("claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8")
+    ):
         raise ConfigurationError(
-            "reasoning_effort='max' is only supported on Claude Opus 4.6.",
-            hint="Try 'high' for this model.",
+            "reasoning_effort='max' is only supported on Claude Opus 4.6+ models.",
+            hint="Use 'high' for Sonnet, Haiku, or older Opus models.",
         )
 
     return effort
@@ -1004,6 +1035,15 @@ def _supports_adaptive_thinking(model: str) -> bool:
     model_name = model.lower()
     return any(
         model_name.startswith(prefix) for prefix in _ADAPTIVE_THINKING_MODEL_PREFIXES
+    )
+
+
+def _is_supported_anthropic_file_mime_type(mime_type: str) -> bool:
+    """Return True for Anthropic document/image file MIME types Pollux supports."""
+    return (
+        mime_type == "application/pdf"
+        or mime_type == "text/plain"
+        or mime_type.startswith("image/")
     )
 
 
@@ -1106,7 +1146,7 @@ def _normalize_input_part(part: Any) -> dict[str, Any] | None:
                     "file_id": uri,
                 },
             }
-        if mime_type == "application/pdf" or mime_type.startswith("text/"):
+        if mime_type in {"application/pdf", "text/plain"}:
             return {
                 "type": "document",
                 "source": {
@@ -1116,7 +1156,7 @@ def _normalize_input_part(part: Any) -> dict[str, Any] | None:
             }
         raise APIError(
             f"Unsupported mime type for Anthropic Files API: {mime_type}",
-            hint="Anthropic supports text, images and PDFs via file IDs.",
+            hint="Anthropic supports images, PDFs, and plaintext via file IDs.",
         )
 
     if not isinstance(part, dict):

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -15,6 +15,7 @@ import uuid
 
 from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import wrap_provider_error
+from pollux.providers._utils import jsonable_provider_artifact, merge_provider_options
 from pollux.providers.base import (
     DeferredItemStatus,
     ProviderCapabilities,
@@ -52,6 +53,12 @@ def _provider_hint_payload(
     if not isinstance(payload, dict) or not payload:
         raise APIError(f"Provider hint {name!r} must be a non-empty dictionary")
     return payload
+
+
+def _has_provider_hint(part: dict[str, Any], *, name: str) -> bool:
+    """Return True when a transport part carries a named provider hint."""
+    provider_hints = part.get("provider_hints")
+    return isinstance(provider_hints, dict) and name in provider_hints
 
 
 def _build_video_metadata(part: dict[str, Any], *, mime_type: str | None) -> Any:
@@ -148,6 +155,9 @@ class GeminiProvider:
             elif isinstance(p, dict):
                 # Handle URI-based parts (including uploaded assets with video settings)
                 if "uri" in p and "mime_type" in p:
+                    if _has_provider_hint(p, name="url_context"):
+                        converted.append(p["uri"])
+                        continue
                     converted.append(
                         types.Part(
                             file_data=types.FileData(
@@ -255,15 +265,24 @@ class GeminiProvider:
         if request.top_p is not None:
             config_kwargs["top_p"] = request.top_p
 
-        if request.tools is not None:
-            tool_objs = self._normalize_tools(request.tools)
-            if tool_objs:
-                config_kwargs["tools"] = tool_objs
+        tool_objs = (
+            self._normalize_tools(request.tools) if request.tools is not None else []
+        )
+        if _request_uses_url_context(request):
+            tool_objs.append(types.Tool(url_context=types.UrlContext()))
+        if tool_objs:
+            config_kwargs["tools"] = tool_objs
 
+        if request.tools is not None:
             tool_config = self._map_tool_choice(request.tool_choice)
             if tool_config is not None:
                 config_kwargs["tool_config"] = tool_config
 
+        merge_provider_options(
+            config_kwargs,
+            request.provider_options,
+            provider="gemini",
+        )
         return config_kwargs
 
     def _build_contents(
@@ -686,6 +705,7 @@ class GeminiProvider:
             provider_state=request.provider_state,
             max_tokens=request.max_tokens,
             implicit_caching=request.implicit_caching,
+            provider_options=request.provider_options,
         )
 
     async def _upload_deferred_batch_input_file(self, path: Path) -> str:
@@ -1104,6 +1124,7 @@ class GeminiProvider:
 
         finish_reason: str | None = None
         reasoning_parts: list[str] = []
+        artifacts: dict[str, Any] = {}
         try:
             candidates = _field(response, "candidates", []) or []
             if isinstance(candidates, list) and candidates:
@@ -1111,6 +1132,11 @@ class GeminiProvider:
                 finish_reason = _normalize_finish_reason(
                     _field(candidate, "finish_reason")
                 )
+                url_context_metadata = _field(candidate, "url_context_metadata")
+                if url_context_metadata is not None:
+                    artifacts["url_context_metadata"] = jsonable_provider_artifact(
+                        url_context_metadata
+                    )
                 content = _field(candidate, "content")
                 parts = _field(content, "parts", []) if content is not None else []
                 if isinstance(parts, list):
@@ -1131,6 +1157,7 @@ class GeminiProvider:
             tool_calls=tool_calls if tool_calls else None,
             response_id=None,
             finish_reason=finish_reason,
+            artifacts=artifacts or None,
         )
 
 
@@ -1165,6 +1192,14 @@ def _extract_response_text(response: Any) -> str:
             ):
                 parts.append(part_text)
     return "".join(parts)
+
+
+def _request_uses_url_context(request: ProviderRequest) -> bool:
+    """Return True when a request contains a Gemini URL Context source."""
+    for part in request.parts:
+        if isinstance(part, dict) and _has_provider_hint(part, name="url_context"):
+            return True
+    return False
 
 
 def _is_content_list(value: Any) -> bool:

--- a/src/pollux/providers/local.py
+++ b/src/pollux/providers/local.py
@@ -27,7 +27,7 @@ from pollux.providers._openai_compat import (
     first_choice_message,
     parse_usage,
 )
-from pollux.providers._utils import to_strict_schema
+from pollux.providers._utils import merge_provider_options, to_strict_schema
 from pollux.providers.base import ProviderCapabilities
 from pollux.providers.models import (
     Message,
@@ -173,6 +173,11 @@ class LocalProvider:
                     "strict": True,
                 },
             }
+        merge_provider_options(
+            payload,
+            request.provider_options,
+            provider="local",
+        )
 
         client = self._get_client()
         try:

--- a/src/pollux/providers/models.py
+++ b/src/pollux/providers/models.py
@@ -69,6 +69,7 @@ class ProviderRequest:
     provider_state: dict[str, Any] | None = None
     max_tokens: int | None = None
     implicit_caching: bool = False
+    provider_options: dict[str, Any] | None = None
 
 
 def is_file_part(part: Any) -> bool:
@@ -97,6 +98,7 @@ class ProviderResponse:
     response_id: str | None = None
     finish_reason: str | None = None
     provider_state: dict[str, Any] | None = None
+    artifacts: dict[str, Any] | None = None
 
 
 def provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
@@ -119,4 +121,6 @@ def provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:
         payload["finish_reason"] = response.finish_reason
     if response.provider_state is not None:
         payload["provider_state"] = response.provider_state
+    if response.artifacts is not None:
+        payload["artifacts"] = response.artifacts
     return payload

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -13,7 +13,11 @@ from urllib.parse import urlparse
 
 from pollux.errors import APIError, ConfigurationError
 from pollux.providers._errors import wrap_provider_error
-from pollux.providers._utils import to_strict_schema
+from pollux.providers._utils import (
+    jsonable_provider_artifact,
+    merge_provider_options,
+    to_strict_schema,
+)
 from pollux.providers.base import (
     DeferredItemStatus,
     ProviderCapabilities,
@@ -241,6 +245,7 @@ class OpenAIProvider:
 
         tool_calls: list[ToolCall] = []
         reasoning_parts: list[str] = []
+        annotations: list[Any] = []
         for item in _field(response, "output", []) or []:
             item_type = _field(item, "type")
             if item_type == "function_call":
@@ -256,6 +261,11 @@ class OpenAIProvider:
                     summary_text = _field(summary_item, "text")
                     if isinstance(summary_text, str) and summary_text:
                         reasoning_parts.append(summary_text)
+            elif item_type == "message":
+                for content in _field(item, "content", []) or []:
+                    content_annotations = _field(content, "annotations", []) or []
+                    if isinstance(content_annotations, list):
+                        annotations.extend(content_annotations)
 
         return ProviderResponse(
             text=text,
@@ -267,6 +277,11 @@ class OpenAIProvider:
             tool_calls=tool_calls if tool_calls else None,
             response_id=response_id if isinstance(response_id, str) else None,
             finish_reason=finish_reason,
+            artifacts=(
+                {"annotations": jsonable_provider_artifact(annotations)}
+                if annotations
+                else None
+            ),
         )
 
     async def submit_deferred(
@@ -608,6 +623,11 @@ class OpenAIProvider:
                 }
             }
 
+        merge_provider_options(
+            create_kwargs,
+            request.provider_options,
+            provider="openai",
+        )
         return create_kwargs
 
     async def _build_batch_request_body(
@@ -649,6 +669,7 @@ class OpenAIProvider:
             provider_state=request.provider_state,
             max_tokens=request.max_tokens,
             implicit_caching=request.implicit_caching,
+            provider_options=request.provider_options,
         )
         return self._build_responses_create_kwargs(resolved_request)
 
@@ -1071,14 +1092,17 @@ def _normalize_input_part(part: Any) -> dict[str, str] | None:
     if parsed.scheme not in {"http", "https"}:
         raise APIError(f"Unsupported URI for OpenAI provider: {uri}")
 
-    if mime_type == "application/pdf":
+    if _is_openai_remote_file_mime_type(mime_type):
         return {"type": "input_file", "file_url": uri}
     if mime_type.startswith("image/"):
         return {"type": "input_image", "image_url": uri}
 
     raise APIError(
         f"Unsupported remote mime type for OpenAI provider: {mime_type}",
-        hint="Supported remote types for v1.0 are PDFs and images.",
+        hint=(
+            "Supported remote types are images plus text, PDF, and common "
+            "document/spreadsheet/presentation file URLs."
+        ),
     )
 
 
@@ -1103,3 +1127,20 @@ def _is_text_like_mime_type(mime_type: str) -> bool:
         return True
 
     return mime_type.endswith(("+json", "+xml"))
+
+
+def _is_openai_remote_file_mime_type(mime_type: str) -> bool:
+    """Return True when OpenAI can receive a remote URL as input_file."""
+    if _is_text_like_mime_type(mime_type):
+        return True
+    common_document_types = {
+        "application/pdf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/rtf",
+    }
+    return mime_type in common_document_types

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -24,7 +24,7 @@ from pollux.providers._openai_compat import (
     first_choice_message,
     parse_usage,
 )
-from pollux.providers._utils import to_strict_schema
+from pollux.providers._utils import merge_provider_options, to_strict_schema
 from pollux.providers.base import ProviderCapabilities
 from pollux.providers.models import (
     Message,
@@ -133,6 +133,11 @@ class OpenRouterProvider:
                     "schema": strict_schema,
                 },
             }
+        merge_provider_options(
+            payload,
+            request.provider_options,
+            provider="openrouter",
+        )
 
         client = self._get_client()
         try:

--- a/src/pollux/source.py
+++ b/src/pollux/source.py
@@ -317,6 +317,24 @@ class Source:
             ),
         )
 
+    def with_gemini_url_context(self) -> Source:
+        """Return a copy that asks Gemini to retrieve this HTTP(S) URI at request time."""
+        if self.source_type != "uri":
+            raise SourceError("Gemini URL Context requires Source.from_uri(...)")
+
+        parsed = urlparse(self.identifier)
+        if parsed.scheme not in {"http", "https"}:
+            raise SourceError("Gemini URL Context requires an HTTP(S) URI")
+
+        return replace(
+            self,
+            provider_hints=self._with_provider_hint(
+                provider="gemini",
+                name="url_context",
+                payload={},
+            ),
+        )
+
     def _is_video_source(self) -> bool:
         """Return True when Gemini video controls can apply to this source."""
         return self.source_type == "youtube" or self.mime_type.startswith("video/")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ class FakeProvider:
             "previous_response_id": request.previous_response_id,
             "provider_state": request.provider_state,
             "implicit_caching": request.implicit_caching,
+            "provider_options": request.provider_options,
         }
         prompt = (
             request.parts[-1]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -369,6 +369,33 @@ async def test_gemini_reasoning_roundtrip_on_gemini3(gemini_api_key: str) -> Non
 
 
 @pytest.mark.asyncio
+async def test_gemini_url_context_roundtrip(
+    gemini_api_key: str,
+    gemini_test_model: str,
+) -> None:
+    """E2E: Gemini URL Context retrieves a public URL and exposes metadata."""
+    config = Config(
+        provider="gemini",
+        model=gemini_test_model,
+        api_key=gemini_api_key,
+    )
+
+    result = await pollux.run(
+        "Use URL Context. Reply exactly GEMINI_URL_CONTEXT_OK if the URL is accessible.",
+        source=Source.from_uri(
+            "https://raw.githubusercontent.com/openai/openai-python/main/README.md",
+            mime_type="text/markdown",
+        ).with_gemini_url_context(),
+        config=config,
+    )
+
+    assert result["status"] == "ok"
+    assert "gemini_url_context_ok" in result["answers"][0].lower()
+    raw = result["diagnostics"]["raw_responses"][0]
+    assert "url_context_metadata" in raw.get("artifacts", {})
+
+
+@pytest.mark.asyncio
 async def test_gemini_live_deferred_inline_submit_and_inspect(
     gemini_api_key: str,
     gemini_test_model: str,
@@ -534,6 +561,18 @@ async def test_openai_binary_upload_cleanup_roundtrip(
     assert "pdf_ok" in result["answers"][0].lower()
     assert deleted_file_ids
     assert all(isinstance(file_id, str) and file_id for file_id in deleted_file_ids)
+
+    remote = await pollux.run(
+        "Read the remote file and reply exactly REMOTE_MARKDOWN_OK.",
+        source=Source.from_uri(
+            "https://raw.githubusercontent.com/openai/openai-python/main/README.md",
+            mime_type="text/markdown",
+        ),
+        config=config,
+        options=Options(max_tokens=512),
+    )
+    assert remote["status"] == "ok"
+    assert "remote_markdown_ok" in remote["answers"][0].lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -269,6 +269,49 @@ def test_request_rejects_non_source_objects() -> None:
     assert exc.value.hint is not None
 
 
+def test_options_reject_unknown_provider_options_provider() -> None:
+    """provider_options should be keyed by supported provider names."""
+    with pytest.raises(ConfigurationError, match="Unknown provider_options provider"):
+        Options(provider_options={"not-a-provider": {"x": 1}})
+
+
+@pytest.mark.asyncio
+async def test_provider_options_are_forwarded_for_active_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Execution should pass only the active provider's raw options."""
+    fake = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config, _p=fake: _p)
+
+    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+    await pollux.run(
+        "Hello",
+        config=cfg,
+        options=Options(
+            provider_options={
+                "openai": {"seed": 123},
+                "gemini": {"seed": 456},
+            }
+        ),
+    )
+
+    assert fake.last_generate_kwargs is not None
+    assert fake.last_generate_kwargs["provider_options"] == {"seed": 123}
+
+
+@pytest.mark.asyncio
+async def test_create_cache_rejects_gemini_url_context_sources() -> None:
+    """URL Context is request-time retrieval and should not enter explicit caches."""
+    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+    source = Source.from_uri(
+        "https://example.com/page",
+        mime_type="text/html",
+    ).with_gemini_url_context()
+
+    with pytest.raises(ConfigurationError, match="URL Context"):
+        await pollux.create_cache((source,), config=cfg)
+
+
 @pytest.mark.asyncio
 async def test_generate_error_attributes_provider_and_call_index(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -325,6 +325,44 @@ def test_gemini_parse_response_extracts_reasoning_from_thought_parts() -> None:
     assert result.text == "The answer is 42."
 
 
+def test_gemini_parse_response_extracts_url_context_artifacts() -> None:
+    """URL Context metadata should be preserved as provider artifacts."""
+    provider = GeminiProvider("test-key")
+
+    class UrlContextMetadata:
+        def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "url_metadata": [
+                    {
+                        "retrieved_url": "https://example.com",
+                        "url_retrieval_status": "URL_RETRIEVAL_STATUS_SUCCESS",
+                    }
+                ]
+            }
+
+    metadata = UrlContextMetadata()
+    fake_candidate = MagicMock()
+    fake_candidate.url_context_metadata = metadata
+    fake_response = MagicMock()
+    fake_response.text = "ok"
+    fake_response.parsed = None
+    fake_response.usage_metadata = None
+    fake_response.candidates = [fake_candidate]
+
+    result = provider._parse_response(fake_response)
+
+    assert result.artifacts == {
+        "url_context_metadata": {
+            "url_metadata": [
+                {
+                    "retrieved_url": "https://example.com",
+                    "url_retrieval_status": "URL_RETRIEVAL_STATUS_SUCCESS",
+                }
+            ]
+        }
+    }
+
+
 def test_gemini_parse_response_joins_multiple_thought_parts() -> None:
     """Multiple thought parts should be joined with double newlines."""
     provider = GeminiProvider("test-key")
@@ -676,6 +714,87 @@ async def test_gemini_generate_attaches_video_metadata_from_source_settings() ->
 
 
 @pytest.mark.asyncio
+async def test_gemini_generate_uses_url_context_tool_for_url_context_sources() -> None:
+    """Gemini URL Context sources should become URL text plus url_context tool."""
+    captured: dict[str, Any] = {}
+
+    async def fake_generate_content(**kwargs: Any) -> Any:
+        captured["contents"] = kwargs.get("contents")
+        captured["config"] = kwargs.get("config")
+        return MagicMock(text="ok", parsed=None, usage_metadata=None)
+
+    provider = GeminiProvider("test-key")
+    fake_models = MagicMock()
+    fake_models.generate_content = fake_generate_content
+    fake_aio = MagicMock()
+    fake_aio.models = fake_models
+    provider._client = MagicMock()
+    provider._client.aio = fake_aio
+
+    await provider.generate(
+        ProviderRequest(
+            model=GEMINI_MODEL,
+            parts=[
+                {
+                    "uri": "https://example.com/page",
+                    "mime_type": "text/html",
+                    "provider_hints": {"url_context": {}},
+                },
+                "Summarize this URL.",
+            ],
+            tools=[{"name": "save_summary", "parameters": {"type": "object"}}],
+        )
+    )
+
+    assert captured["contents"] == [
+        "https://example.com/page",
+        "Summarize this URL.",
+    ]
+    config = captured["config"]
+    assert len(config.tools) == 2
+    assert config.tools[0].function_declarations[0].name == "save_summary"
+    assert config.tools[1].url_context is not None
+
+
+@pytest.mark.asyncio
+async def test_gemini_provider_options_merge_and_overlap() -> None:
+    """Raw Gemini options should merge unless they overlap managed config keys."""
+    captured: dict[str, Any] = {}
+
+    async def fake_generate_content(**kwargs: Any) -> Any:
+        captured["config"] = kwargs.get("config")
+        return MagicMock(text="ok", parsed=None, usage_metadata=None)
+
+    provider = GeminiProvider("test-key")
+    fake_models = MagicMock()
+    fake_models.generate_content = fake_generate_content
+    fake_aio = MagicMock()
+    fake_aio.models = fake_models
+    provider._client = MagicMock()
+    provider._client.aio = fake_aio
+
+    await provider.generate(
+        ProviderRequest(
+            model=GEMINI_MODEL,
+            parts=["Hello"],
+            provider_options={"seed": 123},
+        )
+    )
+
+    assert captured["config"].seed == 123
+
+    with pytest.raises(ConfigurationError, match="overlap"):
+        await provider.generate(
+            ProviderRequest(
+                model=GEMINI_MODEL,
+                parts=["Hello"],
+                temperature=0.2,
+                provider_options={"temperature": 0.7},
+            )
+        )
+
+
+@pytest.mark.asyncio
 async def test_gemini_strips_additional_properties_from_tool_schemas() -> None:
     """Gemini rejects additionalProperties; Pollux should strip it."""
     captured: dict[str, Any] = {}
@@ -1023,6 +1142,37 @@ async def test_openai_skips_normalization_when_strict_is_false() -> None:
     assert "required" not in params
 
 
+@pytest.mark.asyncio
+async def test_openai_provider_options_merge_and_overlap() -> None:
+    """Raw OpenAI options should merge unless they overlap managed fields."""
+    responses = _FakeResponses()
+    fake_client = type("Client", (), {"responses": responses})()
+
+    provider = OpenAIProvider("test-key")
+    provider._client = fake_client
+
+    await provider.generate(
+        ProviderRequest(
+            model=OPENAI_MODEL,
+            parts=["Search if needed."],
+            provider_options={"tools": [{"type": "web_search_preview"}]},
+        )
+    )
+
+    assert responses.last_kwargs is not None
+    assert responses.last_kwargs["tools"] == [{"type": "web_search_preview"}]
+
+    with pytest.raises(ConfigurationError, match="overlap"):
+        await provider.generate(
+            ProviderRequest(
+                model=OPENAI_MODEL,
+                parts=["Search if needed."],
+                tools=[{"name": "get_weather", "parameters": {"type": "object"}}],
+                provider_options={"tools": [{"type": "web_search_preview"}]},
+            )
+        )
+
+
 # =============================================================================
 # OpenAI Request Part Building (Characterization)
 # =============================================================================
@@ -1168,6 +1318,36 @@ async def test_openai_rejects_unsupported_remote_mime_type() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openai_accepts_remote_text_like_mime_types() -> None:
+    """Remote text-like URIs should use input_file.file_url."""
+    responses = _FakeResponses()
+    fake_client = type("Client", (), {"responses": responses})()
+
+    provider = OpenAIProvider("test-key")
+    provider._client = fake_client
+
+    await provider.generate(
+        ProviderRequest(
+            model=OPENAI_MODEL,
+            parts=[
+                {"uri": "https://example.com/data.csv", "mime_type": "text/csv"},
+                {
+                    "uri": "https://example.com/notes.md",
+                    "mime_type": "text/markdown",
+                },
+            ],
+        )
+    )
+
+    assert responses.last_kwargs is not None
+    content = responses.last_kwargs["input"][0]["content"]
+    assert content == [
+        {"type": "input_file", "file_url": "https://example.com/data.csv"},
+        {"type": "input_file", "file_url": "https://example.com/notes.md"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_openai_generate_forwards_reasoning_effort_and_summary() -> None:
     """reasoning_effort should map to reasoning dict with effort and summary."""
     responses = _FakeResponses()
@@ -1247,6 +1427,32 @@ async def test_openai_extracts_reasoning_summary_from_response() -> None:
 
     assert result.reasoning == "The model considered..."
     assert result.text == "The answer."
+
+
+def test_openai_parse_extracts_output_annotations_as_artifacts() -> None:
+    """OpenAI output annotations should be preserved in diagnostics artifacts."""
+    annotation = {"type": "file_citation", "file_id": "file_123", "index": 0}
+    content = type(
+        "OutputText",
+        (),
+        {"type": "output_text", "text": "cited answer", "annotations": [annotation]},
+    )()
+    message_item = type("MessageItem", (), {"type": "message", "content": [content]})()
+    fake_response = type(
+        "Response",
+        (),
+        {
+            "output_text": "cited answer",
+            "id": "resp_123",
+            "usage": None,
+            "output": [message_item],
+            "status": "completed",
+        },
+    )()
+
+    result = OpenAIProvider._parse_response(fake_response, response_schema=None)
+
+    assert result.artifacts == {"annotations": [annotation]}
 
 
 @pytest.mark.asyncio
@@ -3354,6 +3560,28 @@ def test_anthropic_parse_extracts_cached_tokens() -> None:
     assert result.usage["input_tokens"] == 50
 
 
+def test_anthropic_parse_preserves_unknown_blocks_as_artifacts() -> None:
+    """Provider-specific server-tool blocks should remain inspectable."""
+    from pollux.providers.anthropic import _parse_response
+
+    server_block = type(
+        "ServerToolBlock",
+        (),
+        {"type": "server_tool_use", "id": "srv_123", "name": "web_search"},
+    )()
+    response = _fake_anthropic_response(
+        content=[_fake_text_block("ok"), server_block],
+    )
+
+    result = _parse_response(response, response_schema=None)
+
+    assert result.artifacts == {
+        "content_blocks": [
+            {"id": "srv_123", "name": "web_search", "type": "server_tool_use"}
+        ]
+    }
+
+
 def test_anthropic_parse_omits_cached_tokens_when_absent() -> None:
     """Missing cache_read_input_tokens should not add cached_tokens."""
     from pollux.providers.anthropic import _parse_response
@@ -3752,6 +3980,50 @@ async def test_anthropic_generate_reasoning_with_tools_omits_header_for_adaptive
 
 
 @pytest.mark.asyncio
+async def test_anthropic_generate_uses_adaptive_for_opus_4_7() -> None:
+    """Opus 4.7 rejects manual thinking and should route through adaptive."""
+    provider, messages = _anthropic_provider_with_fake()
+
+    await provider.generate(
+        ProviderRequest(
+            model="claude-opus-4-7",
+            parts=["Think."],
+            reasoning_effort="max",
+        )
+    )
+
+    assert messages.last_kwargs is not None
+    assert messages.last_kwargs["output_config"]["effort"] == "max"
+    assert messages.last_kwargs["thinking"] == {"type": "adaptive"}
+
+
+@pytest.mark.asyncio
+async def test_anthropic_provider_options_merge_and_overlap() -> None:
+    """Raw Anthropic options should merge unless they overlap managed fields."""
+    provider, messages = _anthropic_provider_with_fake()
+
+    await provider.generate(
+        ProviderRequest(
+            model=ANTHROPIC_MODEL,
+            parts=["Hello"],
+            provider_options={"metadata": {"user_id": "pollux-test"}},
+        )
+    )
+
+    assert messages.last_kwargs is not None
+    assert messages.last_kwargs["metadata"] == {"user_id": "pollux-test"}
+
+    with pytest.raises(ConfigurationError, match="overlap"):
+        await provider.generate(
+            ProviderRequest(
+                model=ANTHROPIC_MODEL,
+                parts=["Hello"],
+                provider_options={"max_tokens": 64},
+            )
+        )
+
+
+@pytest.mark.asyncio
 async def test_anthropic_generate_rejects_unknown_reasoning_effort() -> None:
     """Anthropic effort mapping should fail fast on unsupported values."""
     provider, _messages = _anthropic_provider_with_fake()
@@ -3773,7 +4045,7 @@ async def test_anthropic_generate_rejects_max_effort_on_non_opus_4_6() -> None:
 
     provider, _messages = _anthropic_provider_with_fake()
 
-    with pytest.raises(ConfigurationError, match=r"supported on Claude Opus 4\.6"):
+    with pytest.raises(ConfigurationError, match=r"supported on Claude Opus 4\.6\+"):
         await provider.generate(
             ProviderRequest(
                 model="claude-sonnet-4-6",
@@ -4033,6 +4305,33 @@ async def test_anthropic_upload_success(tmp_path: Any) -> None:
     assert fake_files.last_kwargs["extra_headers"] == {
         "anthropic-beta": "files-api-2025-04-14"
     }
+
+
+@pytest.mark.asyncio
+async def test_anthropic_upload_rejects_text_csv_before_dispatch(tmp_path: Any) -> None:
+    """Anthropic accepts only plaintext document files, not all text/* MIME types."""
+
+    class _FakeBetaFiles:
+        upload_called = False
+
+        async def upload(self, **kwargs: Any) -> Any:  # noqa: ARG002
+            self.upload_called = True
+            return type("Result", (), {"id": "file_123"})()
+
+    fake_files = _FakeBetaFiles()
+    fake_client = type(
+        "Client", (), {"beta": type("Beta", (), {"files": fake_files})()}
+    )()
+
+    provider = AnthropicProvider("test-key")
+    provider._client = fake_client
+
+    file_path = tmp_path / "data.csv"
+    file_path.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="Unsupported mime type"):
+        await provider.upload_file(file_path, "text/csv")
+    assert fake_files.upload_called is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -147,3 +147,27 @@ def test_with_gemini_video_settings_returns_copied_payloads() -> None:
     payload["fps"] = 99.0
 
     assert source.gemini_video_settings_for("gemini") == {"fps": 1.0}
+
+
+def test_with_gemini_url_context_stores_provider_hint() -> None:
+    """Gemini URL Context should be a Gemini-scoped URI source hint."""
+    source = Source.from_uri(
+        "https://example.com/page",
+        mime_type="text/html",
+    ).with_gemini_url_context()
+
+    assert source.provider_hints_for("gemini") == {"url_context": {}}
+    assert source.provider_hints_for("openai") is None
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        Source.from_text("hello"),
+        Source.from_uri("gs://bucket/object", mime_type="text/plain"),
+    ],
+)
+def test_with_gemini_url_context_rejects_invalid_sources(source: Source) -> None:
+    """Gemini URL Context should be limited to HTTP(S) URI sources."""
+    with pytest.raises(SourceError):
+        source.with_gemini_url_context()


### PR DESCRIPTION
## Summary

Audits the provider feature implementations: adds a provider-scoped raw options escape hatch, Gemini URL Context sources, provider drift fixes, and diagnostics-only provider artifacts. Updates docs and focused characterization/API coverage so the new behavior is explicit at the provider boundary.

## Related issue

None

## Test plan

- `uv run pytest tests/test_source.py tests/test_pipeline.py::test_options_reject_unknown_provider_options_provider tests/test_pipeline.py::test_provider_options_are_forwarded_for_active_provider tests/test_pipeline.py::test_create_cache_rejects_gemini_url_context_sources tests/test_providers.py -q`
- `uv run pytest tests/test_pipeline.py -q`
- `just check`
- `ENABLE_API_TESTS=1 uv run pytest tests/test_api.py::test_gemini_url_context_roundtrip tests/test_api.py::test_openai_binary_upload_cleanup_roundtrip -q`
- `set -a; source .env; set +a; ENABLE_API_TESTS=1 uv run pytest tests/test_api.py::test_openai_binary_upload_cleanup_roundtrip -q`

## Notes

- No provider SDK dependency floors were raised; implementation and targeted API probes did not prove they were needed.
- Provider-specific artifacts remain diagnostics-only under `diagnostics.raw_responses[i].artifacts`; no public `result["artifacts"]` surface was added.
- The temporary provider behavior probe script was removed before finalizing the branch.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)