### PR TITLE
chore(core): finish v1.8 cleanup

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,11 +6,10 @@ trustworthy, more legible, and harder to misuse.
 
 - **Intent**: communicate priorities and scope boundaries, not promises.
 - **Last updated**: 2026-04-22
-- **Current status**: v1.7 ships reasoning budget tokens, normalized
-  `cached_tokens` usage reporting across providers, and a text-only `local`
-  provider for self-hosted OpenAI-compatible servers.
-  `Options.delivery_mode` is soft-deprecated and scheduled for removal in
-  v1.8.0.
+- **Current status**: v1.8 ships reasoning budget tokens, normalized
+  `cached_tokens` usage reporting across providers, a text-only `local`
+  provider for self-hosted OpenAI-compatible servers, and removes the deprecated
+  `Options.delivery_mode` shim.
 - **Status tracking**: Issues and PRs are the source of truth for active work.
 
 ## Product Strategy
@@ -62,8 +61,6 @@ the goal; the goal is a small core that stays trustworthy under real use.
 Concrete items currently on the shortlist. None are commitments, and the list
 is expected to stay short. Discovered follow-ups are tracked in GitHub issues.
 
-- **Remove `Options.delivery_mode`** in v1.8.0. The shim is soft-deprecated in
-  v1.7 and emits `DeprecationWarning` on explicit use today.
 - **Gemini flex inference tier** — evaluate provider-specific support for
   Google's flex inference pricing tier (lower cost, higher latency).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,14 +235,6 @@ do not pass both `Options(tools=[...])` and
     provider default when you omit it. OpenRouter forwards it to the routed
     model. Other providers may ignore it in the current release.
 
-!!! warning "Deprecated: `Options.delivery_mode`"
-    `Options.delivery_mode` is deprecated and scheduled for removal in
-    **v1.8.0**. Passing it explicitly now emits a `DeprecationWarning`.
-    New code should omit it: use `run()` / `run_many()` for realtime work and
-    `defer()` / `defer_many()` for deferred work. Legacy
-    `delivery_mode="deferred"` values still raise `ConfigurationError` with
-    guidance that depends on which entry point you called.
-
 !!! warning "Cache handle restrictions"
     When `cache` is set, `system_instruction`, `tools`, and `tool_choice`
     **must not** be passed in the same `Options`. `system_instruction` and

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -234,7 +234,6 @@ asyncio.run(process_collection("./papers", "Summarize the key findings."))
 | `ConfigurationError` at startup | Missing API key | `export GEMINI_API_KEY="your-key"` (or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY`) or pass `api_key` in `Config(...)` |
 | Outputs look like `echo: ...` | `use_mock=True` is set | Set `use_mock=False` (default) and ensure the API key is present |
 | `ConfigurationError` at request time | Provider/model mismatch | Verify the model belongs to the selected provider |
-| `ConfigurationError` mentioning `delivery_mode` | Legacy `Options(delivery_mode="deferred")` was passed | On `run()` / `run_many()`, switch to `defer()` / `defer_many()`. On deferred entry points, remove `delivery_mode`. |
 | `status: "partial"` | Some prompts returned empty answers | Check individual entries in `answers` to identify which prompts failed |
 | Remote source rejected | Unsupported MIME type on OpenAI | OpenAI remote URL support is limited to PDFs and images |
 | Keys show as `***redacted***` | Intentional redaction | Your key is still being used. `Config` hides it from string representations |

--- a/scripts/deferred_delivery_probe.py
+++ b/scripts/deferred_delivery_probe.py
@@ -82,10 +82,6 @@ CASE_DESCRIPTIONS: dict[str, tuple[CaseKind, str]] = {
         "validation",
         "Verify defer_many([]) fails fast with the documented ConfigurationError.",
     ),
-    "legacy_delivery_mode_rejected": (
-        "validation",
-        "Verify Options(delivery_mode='deferred') is rejected on defer entry points.",
-    ),
     "out_of_scope_options_rejected": (
         "validation",
         "Verify deferred rejects cache, conversation continuity, tools, and implicit caching.",
@@ -336,8 +332,6 @@ async def execute_validation_case(
     try:
         if case_name == "empty_prompts_rejected":
             details = await _validation_empty_prompts_rejected(case_dir)
-        elif case_name == "legacy_delivery_mode_rejected":
-            details = await _validation_legacy_delivery_mode_rejected(case_dir)
         elif case_name == "out_of_scope_options_rejected":
             details = await _validation_out_of_scope_options_rejected(case_dir)
         elif case_name == "unsupported_provider_rejected":
@@ -738,23 +732,6 @@ async def _validation_empty_prompts_rejected(case_dir: Path) -> dict[str, Any]:
         "requires at least one prompt",
     )
     return {"checks": [{"name": "empty_prompts", "message": message}]}
-
-
-async def _validation_legacy_delivery_mode_rejected(case_dir: Path) -> dict[str, Any]:
-    config = Config(
-        provider="openai", model=DEFAULT_MODELS["openai"], api_key="test-key"
-    )
-    message = await _expect_configuration_error(
-        case_dir,
-        "legacy_delivery_mode",
-        pollux.defer(
-            "Q1?",
-            config=config,
-            options=Options(delivery_mode="deferred"),
-        ),
-        "not needed with defer",
-    )
-    return {"checks": [{"name": "legacy_delivery_mode", "message": message}]}
 
 
 async def _validation_out_of_scope_options_rejected(case_dir: Path) -> dict[str, Any]:

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -263,15 +263,11 @@ async def continue_tool(
     if options is None:
         merged_options = Options(continue_from=synthetic_envelope)
     else:
-        # TODO(v1.8.0): once Options.delivery_mode is removed, replace this
-        # __dict__ copy with dataclasses.replace(options, history=None,
-        # continue_from=synthetic_envelope). replace() can't be used today
-        # because __post_init__ re-fires the delivery_mode DeprecationWarning
-        # on the already-normalized "realtime" value.
-        kwargs = dict(options.__dict__)
-        kwargs.pop("history", None)
-        kwargs.pop("continue_from", None)
-        merged_options = Options(continue_from=synthetic_envelope, **kwargs)
+        merged_options = replace(
+            options,
+            history=None,
+            continue_from=synthetic_envelope,
+        )
 
     return await run(prompt=None, config=config, options=merged_options)
 

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -148,12 +148,6 @@ def _validate_deferred_plan(plan: Plan, provider: Provider) -> None:
     options = plan.request.options
     caps = provider.capabilities
 
-    if options.delivery_mode == "deferred":
-        raise ConfigurationError(
-            "delivery_mode='deferred' is not needed with defer() or defer_many()",
-            hint="Call defer() / defer_many() directly without setting delivery_mode.",
-        )
-
     _get_deferred_provider(provider)
     if options.cache is not None:
         raise ConfigurationError(

--- a/src/pollux/errors.py
+++ b/src/pollux/errors.py
@@ -50,6 +50,7 @@ class APIError(PolluxError):
         provider: str | None = None,
         phase: str | None = None,
         call_idx: int | None = None,
+        error_category: str | None = None,
     ) -> None:
         super().__init__(message, hint=hint)
         self.retryable = retryable
@@ -58,6 +59,7 @@ class APIError(PolluxError):
         self.provider = provider
         self.phase = phase
         self.call_idx = call_idx
+        self.error_category = error_category
 
 
 class CacheError(APIError):

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -17,7 +17,7 @@ from pollux.continuation import (
     history_to_messages,
     load_continuation,
 )
-from pollux.errors import APIError, ConfigurationError, InternalError, PolluxError
+from pollux.errors import APIError, InternalError, PolluxError
 from pollux.providers.base import FileDeletingProvider, ValidatingProvider
 from pollux.providers.models import (
     Message,
@@ -70,6 +70,7 @@ def _with_call_idx(err: APIError, call_idx: int | None) -> APIError:
         provider=err.provider,
         phase=err.phase,
         call_idx=call_idx,
+        error_category=err.error_category,
     )
 
 
@@ -79,6 +80,7 @@ class ExecutionTrace:
 
     responses: list[ProviderResponse] = field(default_factory=list)
     cache_name: str | None = None
+    cache_mode: str = "none"
     duration_s: float = 0.0
     usage: dict[str, int] = field(default_factory=dict)
     conversation_state: dict[str, Any] | None = None
@@ -103,13 +105,6 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
         options.history is not None or options.continue_from is not None
     )
 
-    # Belt-and-suspenders: Options.__post_init__ already rejects "deferred",
-    # but guard here in case validation is ever bypassed.
-    if options.delivery_mode == "deferred":
-        raise ConfigurationError(
-            "delivery_mode='deferred' is a legacy compatibility shim and is not supported",
-            hint="Use pollux.defer() or pollux.defer_many() for deferred delivery.",
-        )
     has_file_parts = any(is_file_part(p) for p in plan.shared_parts)
     validate_capabilities(
         options,
@@ -294,9 +289,16 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
 
     duration_s = time.perf_counter() - start_time
 
+    cache_mode = "none"
+    if cache_name is not None:
+        cache_mode = "persistent"
+    elif implicit_caching:
+        cache_mode = "implicit"
+
     return ExecutionTrace(
         responses=responses,
         cache_name=cache_name,
+        cache_mode=cache_mode,
         duration_s=duration_s,
         usage=total_usage,
         conversation_state=conversation_state,

--- a/src/pollux/options.py
+++ b/src/pollux/options.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Final, Literal, get_args
-import warnings
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from pydantic import BaseModel
 
@@ -18,18 +17,7 @@ if TYPE_CHECKING:
     from pollux.result import ResultEnvelope
 
 ReasoningEffort = str
-# Intentionally kept as plain ``str`` instead of ``Literal[...]`` so IDEs do
-# not advertise the legacy ``"deferred"`` value in completions while older
-# callers can still pass it during migration. Runtime validation below keeps
-# the accepted set narrow and provides upgrade guidance.
-DeliveryMode = str
 ResponseSchemaInput = type[BaseModel] | dict[str, Any]
-
-# Sentinel default for ``Options.delivery_mode`` so we can distinguish an
-# explicit (deprecated) user value from the implicit default. The sentinel is
-# normalized back to ``"realtime"`` in ``__post_init__`` so external observers
-# never see it.
-_DELIVERY_MODE_UNSET: Final[str] = "__pollux_delivery_mode_unset__"
 
 
 def response_schema_json(
@@ -87,10 +75,7 @@ class Options:
     reasoning_effort: ReasoningEffort | None = None
     #: Controls provider reasoning token budget where supported.
     reasoning_budget_tokens: int | None = None
-    #: Deprecated compatibility shim. Scheduled for removal in v1.8.0.
-    #: Realtime remains the only supported value; use ``run()`` / ``run_many()``
-    #: for realtime work and ``defer()`` / ``defer_many()`` for deferred work.
-    delivery_mode: DeliveryMode = _DELIVERY_MODE_UNSET
+
     #: Mutually exclusive with *continue_from*.
     history: list[dict[str, Any]] | None = None
     #: Mutually exclusive with *history*.
@@ -155,33 +140,6 @@ class Options:
             raise ConfigurationError(
                 "reasoning_effort and reasoning_budget_tokens are mutually exclusive",
                 hint="Choose either qualitative effort or an explicit token budget.",
-            )
-
-        # delivery_mode is a deprecated shim. Distinguish explicit values from
-        # the sentinel default: explicit-but-valid values emit a
-        # DeprecationWarning; the default is silently normalized to "realtime".
-        # Keep the runtime guard even though ``delivery_mode`` is typed as
-        # ``str`` on purpose; the loose annotation is a UX choice for editor
-        # autocomplete, not a widening of the supported values.
-        if self.delivery_mode is _DELIVERY_MODE_UNSET:
-            object.__setattr__(self, "delivery_mode", "realtime")
-        else:
-            if self.delivery_mode not in {"realtime", "deferred"}:
-                raise ConfigurationError(
-                    "delivery_mode must be 'realtime' or 'deferred'",
-                    hint=(
-                        "Remove delivery_mode and keep the default realtime "
-                        "mode, or use defer() / defer_many() for deferred work. "
-                        "delivery_mode is deprecated and will be removed in "
-                        "v1.8.0."
-                    ),
-                )
-            warnings.warn(
-                "Options.delivery_mode is deprecated and will be removed in "
-                "v1.8.0. Use run() / run_many() for realtime work and "
-                "defer() / defer_many() for deferred work.",
-                DeprecationWarning,
-                stacklevel=3,
             )
 
         if self.history is not None and self.continue_from is not None:

--- a/src/pollux/providers/_errors.py
+++ b/src/pollux/providers/_errors.py
@@ -128,6 +128,70 @@ def _auth_hint(
     return None
 
 
+def _detect_error_category(exc: BaseException, status_code: int | None) -> str | None:
+    """Detect normalized error category based on status code, message, and exception type."""
+    for e in walk_exception_chain(exc):
+        name = type(e).__name__
+        msg = str(e).lower()
+
+        # 1. rate_limit
+        if (
+            name == "RateLimitError"
+            or status_code == 429
+            or "rate limit" in msg
+            or "too many requests" in msg
+        ):
+            return "rate_limit"
+
+        # 2. auth_refreshable
+        if (
+            name in ("AuthenticationError", "PermissionDeniedError")
+            or status_code in (401, 403)
+            or "unauthorized" in msg
+            or "invalid api key" in msg
+            or "api key not valid" in msg
+        ):
+            return "auth_refreshable"
+
+        # 3. capacity
+        if (
+            name == "InternalServerError"
+            or status_code in (502, 503, 504)
+            or any(
+                w in msg
+                for w in ("overloaded", "capacity", "unavailable", "server error")
+            )
+        ):
+            return "capacity"
+
+        # 4. context_overflow
+        if (name == "BadRequestError" or status_code == 400) and any(
+            w in msg
+            for w in (
+                "context length",
+                "max tokens",
+                "max_tokens",
+                "too long",
+                "exceeds maximum",
+                "token limit",
+                "exceeds limit",
+                "prompt length",
+            )
+        ):
+            return "context_overflow"
+
+    # Default fallback for status codes
+    if status_code is not None:
+        if status_code == 429:
+            return "rate_limit"
+        if status_code in (401, 403):
+            return "auth_refreshable"
+        if 500 <= status_code < 600:
+            return "capacity"
+
+    return None
+
+
 def wrap_provider_error(
     exc: BaseException,
     *,
@@ -146,6 +210,9 @@ def wrap_provider_error(
     if isinstance(exc, ConfigurationError):
         raise exc
 
+    status_code = extract_status_code(exc)
+    error_category = _detect_error_category(exc, status_code)
+
     # Already wrapped — fill in missing context only.
     if isinstance(exc, APIError):
         if exc.provider is None:
@@ -154,9 +221,10 @@ def wrap_provider_error(
             exc.phase = phase
         if hint is not None and exc.hint is None:
             exc.hint = hint
+        if exc.error_category is None:
+            exc.error_category = error_category
         return exc
 
-    status_code = extract_status_code(exc)
     retry_after_s = extract_retry_after_s(exc)
 
     retryable = retry_after_s is not None
@@ -181,8 +249,9 @@ def wrap_provider_error(
     msg = message or f"{provider} {phase} failed"
 
     err_cls: type[APIError] = APIError
-    if status_code == 429:
+    if status_code == 429 or error_category == "rate_limit":
         err_cls = RateLimitError
+        error_category = "rate_limit"
     elif phase == "cache":
         err_cls = CacheError
 
@@ -196,4 +265,5 @@ def wrap_provider_error(
         retry_after_s=retry_after_s,
         provider=provider,
         phase=phase,
+        error_category=error_category,
     )

--- a/src/pollux/result.py
+++ b/src/pollux/result.py
@@ -43,7 +43,8 @@ class ResultEnvelope(TypedDict, total=False):
     #: ``input_tokens`` for Gemini and OpenAI, but reported separately from
     #: ``input_tokens`` for Anthropic.
     usage: dict[str, int]
-    #: Keys: ``duration_s``, ``n_calls``, ``cache_used``, ``finish_reasons``.
+    #: Keys: ``duration_s``, ``n_calls``, ``cache_used``, ``cache_mode``,
+    #: ``cache_hit``, and ``finish_reasons``.
     metrics: dict[str, Any]
     diagnostics: dict[str, Any]
     _conversation_state: dict[str, Any]
@@ -58,6 +59,7 @@ def build_result_from_responses(
     usage: dict[str, int],
     n_calls: int,
     cache_used: bool = False,
+    cache_mode: str = "none",
 ) -> ResultEnvelope:
     """Build a ResultEnvelope from provider responses.
 
@@ -109,6 +111,12 @@ def build_result_from_responses(
         response.finish_reason for response in responses
     ]
 
+    cache_hit = False
+    if cache_mode == "persistent":
+        cache_hit = cache_used
+    elif cache_mode == "implicit":
+        cache_hit = usage.get("cached_tokens", 0) > 0
+
     envelope = ResultEnvelope(
         status=status,
         answers=answers,
@@ -120,6 +128,8 @@ def build_result_from_responses(
             "n_calls": n_calls,
             "cache_used": cache_used,
             "finish_reasons": finish_reasons,
+            "cache_mode": cache_mode,
+            "cache_hit": cache_hit,
         },
         diagnostics={
             "raw_responses": [provider_response_to_dict(r) for r in responses],
@@ -145,6 +155,7 @@ def build_result(plan: Plan, trace: ExecutionTrace) -> ResultEnvelope:
         usage=trace.usage,
         n_calls=plan.n_calls,
         cache_used=trace.cache_name is not None,
+        cache_mode=trace.cache_mode,
     )
 
     if trace.conversation_state is not None:

--- a/src/pollux/retry.py
+++ b/src/pollux/retry.py
@@ -91,13 +91,15 @@ def should_retry_generate(exc: BaseException) -> bool:
 
     Contract:
     - Cancellation is never retried.
-    - APIError is retried when the provider marked it retryable.
+    - APIError is retried when the provider marked it retryable and the category allows it.
     - Unwrapped transient network errors are retried as a pragmatic fallback.
     """
     if isinstance(exc, asyncio.CancelledError):
         return False
 
     if isinstance(exc, APIError):
+        if exc.error_category in ("context_overflow", "auth_refreshable"):
+            return False
         return exc.retryable is True
 
     return _is_transient_network_error(exc)
@@ -115,6 +117,8 @@ def should_retry_side_effect(exc: BaseException) -> bool:
         return False
 
     if isinstance(exc, APIError):
+        if exc.error_category in ("context_overflow", "auth_refreshable"):
+            return False
         return exc.retryable is True
 
     return False

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,7 +6,6 @@ import asyncio
 from dataclasses import dataclass, field
 import json
 from typing import TYPE_CHECKING, Any
-import warnings
 
 from pydantic import BaseModel
 import pytest
@@ -655,6 +654,128 @@ async def test_retry_matrix(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> N
 
         assert fake.generate_calls == expect_generate_calls
         assert fake.upload_attempts == expect_upload_attempts
+
+
+@pytest.mark.asyncio
+async def test_retry_skipped_for_permanent_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that permanent errors like context_overflow or auth_refreshable do not trigger retries."""
+    retry = RetryPolicy(
+        max_attempts=3,
+        initial_delay_s=0.0,
+        max_delay_s=0.0,
+        jitter=False,
+    )
+
+    @dataclass
+    class _FailingProvider(FakeProvider):
+        calls: int = 0
+        error_type: str = "context_overflow"
+
+        async def generate(self, _request: ProviderRequest) -> ProviderResponse:
+            self.calls += 1
+            if self.error_type == "context_overflow":
+                raise APIError(
+                    "context length exceeded limit",
+                    retryable=True,  # force True to verify category override
+                    status_code=400,
+                    error_category="context_overflow",
+                )
+            raise APIError(
+                "unauthorized access",
+                retryable=True,
+                status_code=401,
+                error_category="auth_refreshable",
+            )
+
+    cfg = Config(
+        provider="gemini",
+        model=GEMINI_MODEL,
+        use_mock=True,
+        retry=retry,
+    )
+
+    # 1. Test context_overflow
+    fake = _FailingProvider(error_type="context_overflow")
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config, _fake=fake: _fake)
+    with pytest.raises(APIError, match="context length"):
+        await pollux.run("hello", config=cfg)
+    assert fake.calls == 1  # Should only run once, not retried!
+
+    # 2. Test auth_refreshable
+    fake2 = _FailingProvider(error_type="auth_refreshable")
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config, _fake=fake2: _fake)
+    with pytest.raises(APIError, match="unauthorized"):
+        await pollux.run("hello", config=cfg)
+    assert fake2.calls == 1  # Should only run once, not retried!
+
+
+@pytest.mark.asyncio
+async def test_cache_diagnostics_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that cache_mode and cache_hit are correctly populated in ResultEnvelope metrics."""
+    from pollux.providers.base import ProviderCapabilities
+
+    fake = FakeProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=True,
+            uploads=True,
+            structured_outputs=False,
+            reasoning=False,
+            deferred_delivery=False,
+            conversation=False,
+            implicit_caching=True,
+        )
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+
+    # 1. No caching
+    # Need a separate provider for No-Implicit-Caching to avoid validation passing
+    fake_no_caching = FakeProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=True,
+            uploads=True,
+            structured_outputs=False,
+            reasoning=False,
+            deferred_delivery=False,
+            conversation=False,
+            implicit_caching=False,
+        )
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake_no_caching)
+    res_none = await pollux.run("hello", config=cfg)
+    assert res_none["metrics"]["cache_mode"] == "none"
+    assert res_none["metrics"]["cache_hit"] is False
+
+    # 2. Implicit caching
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+    res_implicit = await pollux.run(
+        "hello", config=cfg, options=Options(implicit_caching=True)
+    )
+    assert res_implicit["metrics"]["cache_mode"] == "implicit"
+    # usage lacks cached_tokens here, so cache_hit is False
+    assert res_implicit["metrics"]["cache_hit"] is False
+
+    # 3. Persistent caching (using mock provider / plan cache name)
+    @dataclass
+    class _CacheTrackingProvider(FakeProvider):
+        async def create_cache(self, **_kwargs: Any) -> str:
+            return "cachedContents/mock-handle-123"
+
+    fake_cache = _CacheTrackingProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake_cache)
+    cfg_cache = Config(provider="gemini", model=CACHE_MODEL, use_mock=True)
+    handle = await pollux.create_cache(
+        (Source.from_text("shared context"),), config=cfg_cache
+    )
+
+    # Use the handle
+    res_cached = await pollux.run(
+        "hello", config=cfg_cache, options=Options(cache=handle)
+    )
+    assert res_cached["metrics"]["cache_mode"] == "persistent"
+    assert res_cached["metrics"]["cache_hit"] is True
 
 
 @pytest.mark.asyncio
@@ -1749,69 +1870,6 @@ async def test_implicit_caching_requires_provider_capability_when_enabled(
     assert exc.value.hint is not None
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.asyncio
-async def test_delivery_mode_deferred_is_explicitly_not_implemented(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Legacy deferred mode should fail fast and point callers at the sibling API."""
-    fake = FakeProvider(
-        _capabilities=ProviderCapabilities(
-            persistent_cache=True,
-            uploads=True,
-            structured_outputs=True,
-            reasoning=True,
-            reasoning_budget_tokens=True,
-            deferred_delivery=True,
-            conversation=True,
-        )
-    )
-    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
-    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
-
-    with pytest.raises(ConfigurationError, match="legacy compatibility shim"):
-        await pollux.run_many(
-            ("Q1?",),
-            config=cfg,
-            options=Options(delivery_mode="deferred"),
-        )
-
-
-def test_delivery_mode_default_emits_no_deprecation_warning() -> None:
-    """Constructing Options without delivery_mode should be warning-free."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        options = Options()
-
-    assert options.delivery_mode == "realtime"
-
-
-def test_delivery_mode_realtime_emits_deprecation_warning() -> None:
-    """Explicit realtime remains valid but is soft-deprecated ahead of v1.8.0."""
-    with pytest.warns(DeprecationWarning, match="delivery_mode is deprecated"):
-        options = Options(delivery_mode="realtime")
-
-    assert options.delivery_mode == "realtime"
-
-
-def test_delivery_mode_deferred_emits_deprecation_warning() -> None:
-    """Deferred remains constructible so Pollux can raise migration guidance."""
-    with pytest.warns(DeprecationWarning, match="delivery_mode is deprecated"):
-        options = Options(delivery_mode="deferred")
-
-    assert options.delivery_mode == "deferred"
-
-
-def test_delivery_mode_rejects_invalid_values_without_warning() -> None:
-    """Invalid delivery_mode values should raise without emitting a warning."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", DeprecationWarning)
-        with pytest.raises(
-            ConfigurationError, match="must be 'realtime' or 'deferred'"
-        ):
-            Options(delivery_mode="bogus")
-
-
 def test_deferred_handle_round_trip_serialization() -> None:
     """Deferred handles should serialize cleanly for downstream persistence."""
     handle = DeferredHandle(
@@ -1874,20 +1932,6 @@ async def test_defer_rejects_global_mock_provider() -> None:
             ("Summarize this text", "List two risks"),
             sources=(Source.from_text("shared context"),),
             config=cfg,
-        )
-
-
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.asyncio
-async def test_defer_rejects_redundant_legacy_delivery_mode() -> None:
-    """Deferred entry points should tell legacy callers to drop delivery_mode."""
-    cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
-
-    with pytest.raises(ConfigurationError, match="not needed with defer"):
-        await pollux.defer_many(
-            ("Summarize this text",),
-            config=cfg,
-            options=Options(delivery_mode="deferred"),
         )
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -205,6 +205,109 @@ def test_hint_for_400_with_api_key_message() -> None:
     assert "GEMINI_API_KEY" in err.hint
 
 
+def test_wrap_provider_error_categorizes_rate_limit_error() -> None:
+    class _SdkError(Exception):
+        status_code: int
+
+    # Status code 429
+    err1 = wrap_provider_error(
+        _SdkError("Too many requests"),
+        provider="openai",
+        phase="generate",
+        allow_network_errors=True,
+    )
+    assert err1.error_category == "rate_limit"
+
+    # Status code 429 from attribute
+    exc = _SdkError("custom limit")
+    exc.status_code = 429
+    err2 = wrap_provider_error(
+        exc,
+        provider="openai",
+        phase="generate",
+        allow_network_errors=True,
+    )
+    assert err2.error_category == "rate_limit"
+
+
+def test_wrap_provider_error_categorizes_auth_error() -> None:
+    class AuthenticationError(Exception):
+        pass
+
+    err1 = wrap_provider_error(
+        AuthenticationError("Invalid API key"),
+        provider="openai",
+        phase="generate",
+        allow_network_errors=True,
+    )
+    assert err1.error_category == "auth_refreshable"
+
+    class _SdkError(Exception):
+        status_code: int
+
+    exc = _SdkError("unauthorized access")
+    exc.status_code = 401
+    err2 = wrap_provider_error(
+        exc,
+        provider="anthropic",
+        phase="generate",
+        allow_network_errors=True,
+    )
+    assert err2.error_category == "auth_refreshable"
+
+
+def test_wrap_provider_error_categorizes_capacity_error() -> None:
+    class InternalServerError(Exception):
+        pass
+
+    err1 = wrap_provider_error(
+        InternalServerError("Overloaded"),
+        provider="openai",
+        phase="generate",
+        allow_network_errors=True,
+    )
+    assert err1.error_category == "capacity"
+
+    class _SdkError(Exception):
+        status_code: int
+
+    exc = _SdkError("service unavailable")
+    exc.status_code = 503
+    err2 = wrap_provider_error(
+        exc,
+        provider="openai",
+        phase="generate",
+        allow_network_errors=True,
+    )
+    assert err2.error_category == "capacity"
+
+
+def test_wrap_provider_error_categorizes_context_overflow_error() -> None:
+    class BadRequestError(Exception):
+        pass
+
+    err1 = wrap_provider_error(
+        BadRequestError("This model's maximum context length is 8192 tokens"),
+        provider="openai",
+        phase="generate",
+        allow_network_errors=True,
+    )
+    assert err1.error_category == "context_overflow"
+
+    class _SdkError(Exception):
+        status_code: int
+
+    exc = _SdkError("Prompt exceeds maximum context length")
+    exc.status_code = 400
+    err2 = wrap_provider_error(
+        exc,
+        provider="anthropic",
+        phase="generate",
+        allow_network_errors=True,
+    )
+    assert err2.error_category == "context_overflow"
+
+
 # =============================================================================
 # Gemini Response Parsing (Characterization)
 # =============================================================================


### PR DESCRIPTION
## Summary

Finishes the v1.8 cleanup pass by removing the deprecated `Options.delivery_mode` compatibility surface, normalizing provider error categories for retry decisions, and surfacing clearer cache diagnostics in result metrics. Also refreshes docs, roadmap notes, deferred probe validation cases, and boundary tests for the updated behavior.

## Related issue

None

## Test plan

- `uv run pytest tests/test_pipeline.py tests/test_providers.py -q` passed: 285 tests.
- `uv run mypy src/pollux` passed.
- `uv run ruff check src/pollux tests scripts` passed.
- `uv run rumdl check ROADMAP.md docs/configuration.md docs/error-handling.md` passed.
- `just check` passed: Ruff format/check, rumdl, mypy, and 352 non-API tests.

## Notes

The package version remains `1.7.0` because semantic-release owns the release bump and changelog insertion. Historical changelog references to `Options.delivery_mode` are left intact.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
