### PR TITLE
chore(lint): enable repeated-comparison rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ select = [
     "ICN", # flake8-import-conventions
     "N",   # pep8-naming
     "PIE", # flake8-pie
+    "PLR1714", # repeated equality comparisons
     "PTH", # flake8-use-pathlib
     "PYI", # flake8-pyi
     "RET", # flake8-return

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -1040,10 +1040,8 @@ def _supports_adaptive_thinking(model: str) -> bool:
 
 def _is_supported_anthropic_file_mime_type(mime_type: str) -> bool:
     """Return True for Anthropic document/image file MIME types Pollux supports."""
-    return (
-        mime_type == "application/pdf"
-        or mime_type == "text/plain"
-        or mime_type.startswith("image/")
+    return mime_type in {"application/pdf", "text/plain"} or mime_type.startswith(
+        "image/"
     )
 
 


### PR DESCRIPTION
## Summary

Enables Ruff `PLR1714` to catch repeated equality comparisons and applies the single cleanup it surfaces in the Anthropic MIME-type helper. This keeps the stronger lint follow-up low-noise while avoiding broad style churn.

## Related issue

None

## Test plan

- `uv run ruff format --check pyproject.toml src/pollux/providers/anthropic.py` passed.
- `uv run ruff check pyproject.toml src/pollux/providers/anthropic.py` passed.
- `uv run ruff check . --select PLR1714` passed.
- `uv run mypy src/pollux/providers/anthropic.py` passed.
- `uv run pytest tests/test_providers.py -q` passed: 169 tests.

## Notes

I checked `/Users/sean/GitHub/steelmark/lodenlab/scout/`; it does not currently configure Ruff and instead uses pytest plus Pyright strict mode. The broader stronger-rule scan in Pollux was dominated by high-churn categories (`TRY003`, `PLR2004`, and `E501`), so this PR only adopts the low-noise rule with one actionable finding.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [ ] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
