### PR TITLE
feat(core): stamp continuation state with schema version and provider

### DIFF
--- a/src/pollux/continuation.py
+++ b/src/pollux/continuation.py
@@ -33,19 +33,29 @@ if TYPE_CHECKING:
 class ConversationState:
     """Serialized state stored under a ResultEnvelope's ``_conversation_state`` key.
 
-    This is the single owner of that dict shape: the magic keys (``history``,
-    ``response_id``, ``provider_state``) and the envelope key itself live here
-    rather than as string literals across the read, write, and continue paths.
-    It is distinct from :class:`ContinuationState`, which is the *resolved*
-    prior-turn working state derived from this serialized form.
+    This is the single owner of that dict shape: the magic keys (``version``,
+    ``provider``, ``history``, ``response_id``, ``provider_state``) and the
+    envelope key itself live here rather than as string literals across the
+    read, write, and continue paths. It is distinct from
+    :class:`ContinuationState`, which is the *resolved* prior-turn working state
+    derived from this serialized form.
+
+    The ``version`` and ``provider`` markers let a future major (which redefines
+    this shape) detect and reject an incompatible serialized state with a clear
+    error instead of misreading it. v1.x stays permissive on read: a missing
+    ``version`` is treated as a pre-1.8 envelope rather than an error.
     """
 
     #: Envelope key under which this state is stored in a ``ResultEnvelope``.
     ENVELOPE_KEY: ClassVar[str] = "_conversation_state"
+    #: Schema version stamped into newly written state. Bump on shape changes.
+    SCHEMA_VERSION: ClassVar[int] = 1
 
     history: list[dict[str, Any]]
     response_id: str | None = None
     provider_state: dict[str, Any] | None = None
+    version: int = SCHEMA_VERSION
+    provider: str | None = None
 
     @classmethod
     def from_envelope(cls, envelope: Mapping[str, Any]) -> ConversationState | None:
@@ -57,7 +67,11 @@ class ConversationState:
 
     @classmethod
     def from_state_dict(cls, state: Mapping[str, Any]) -> ConversationState:
-        """Parse a serialized state dict, type-guarding each facet."""
+        """Parse a serialized state dict, type-guarding each facet.
+
+        A missing or non-integer ``version`` is read as ``1`` (a pre-1.8
+        envelope), keeping older serialized state loadable.
+        """
         raw_history = state.get("history")
         history = list(raw_history) if isinstance(raw_history, list) else []
         raw_response_id = state.get("response_id")
@@ -66,10 +80,16 @@ class ConversationState:
         provider_state = (
             dict(raw_provider_state) if isinstance(raw_provider_state, dict) else None
         )
+        raw_version = state.get("version")
+        version = raw_version if isinstance(raw_version, int) else 1
+        raw_provider = state.get("provider")
+        provider = raw_provider if isinstance(raw_provider, str) else None
         return cls(
             history=history,
             response_id=response_id,
             provider_state=provider_state,
+            version=version,
+            provider=provider,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -78,7 +98,9 @@ class ConversationState:
         Optional facets are omitted when unset so the shape stays compact and
         matches what ``build_conversation_state`` has always produced.
         """
-        state: dict[str, Any] = {"history": self.history}
+        state: dict[str, Any] = {"version": self.version, "history": self.history}
+        if self.provider is not None:
+            state["provider"] = self.provider
         if self.provider_state is not None:
             state["provider_state"] = self.provider_state
         if self.response_id is not None:
@@ -216,6 +238,7 @@ def build_conversation_state(
     conversation_history: list[dict[str, Any]],
     previous_response_id: str | None,
     wants_conversation: bool,
+    provider: str | None = None,
 ) -> dict[str, Any] | None:
     """Assemble updated ``_conversation_state`` after a response.
 
@@ -260,4 +283,5 @@ def build_conversation_state(
         provider_state=(
             provider_msg_state if isinstance(provider_msg_state, dict) else None
         ),
+        provider=provider,
     ).to_dict()

--- a/src/pollux/execute.py
+++ b/src/pollux/execute.py
@@ -282,6 +282,7 @@ async def execute_plan(plan: Plan, provider: Provider) -> ExecutionTrace:
             conversation_history=conversation_history,
             previous_response_id=previous_response_id,
             wants_conversation=wants_conversation,
+            provider=config.provider,
         )
     finally:
         # Clean up uploaded files (best-effort; server-side TTL is the backstop).

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,6 +14,7 @@ import pollux
 import pollux.cache
 from pollux.cache import CacheHandle, CacheRegistry, compute_cache_key
 from pollux.config import Config
+from pollux.continuation import ConversationState
 from pollux.deferred import DeferredHandle
 from pollux.errors import (
     APIError,
@@ -3030,11 +3031,36 @@ async def test_conversation_result_includes_conversation_state(
     state = result.get("_conversation_state")
     assert isinstance(state, dict)
     assert state["response_id"] == "resp_next"
+    # Forward-compat stamp: a future major can detect/reject incompatible state.
+    assert state["version"] == 1
+    assert state["provider"] == "gemini"
     assert state["history"] == [
         {"role": "user", "content": "hello"},
         {"role": "user", "content": "Next question?"},
         {"role": "assistant", "content": "Assistant reply."},
     ]
+
+
+def test_conversation_state_stamp_roundtrip_and_back_compat() -> None:
+    """to_dict stamps version/provider; from_state_dict reads pre-1.8 state."""
+    # Newly built state carries the schema version and provider marker.
+    written = ConversationState(
+        history=[{"role": "user", "content": "hi"}],
+        provider="gemini",
+    ).to_dict()
+    assert written["version"] == ConversationState.SCHEMA_VERSION
+    assert written["provider"] == "gemini"
+    assert ConversationState.from_state_dict(written).provider == "gemini"
+
+    # A pre-1.8 envelope (no version, no provider) still loads, read as v1.
+    legacy = ConversationState.from_state_dict(
+        {"history": [{"role": "user", "content": "hi"}]}
+    )
+    assert legacy.version == 1
+    assert legacy.provider is None
+
+    # provider is omitted from the dict when unset, keeping the shape compact.
+    assert "provider" not in ConversationState(history=[]).to_dict()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Stamp serialized `_conversation_state` with a `version` (`SCHEMA_VERSION`) and the originating `provider`. This lets a future major - which redefines the continuation shape - detect and reject an incompatible 1.x artifact with a clear error instead of misreading it. Forward-detect-to-fail-cleanly, not a behavioral shim. Groundwork for the planned v2.0 clean break.

## Related issue

None

## Test plan

`just check` green (353 passed). Added `test_conversation_state_stamp_roundtrip_and_back_compat` (round-trip stamps version/provider; a pre-1.8 envelope with no `version` still loads as v1; `provider` omitted when unset) and extended the existing emission test to assert the stamp. Existing `continue_from` tests already feed versionless hand-built state, exercising back-compat.

## Notes

`ConversationState` remains the single owner of the dict shape; reads stay permissive (missing `version` → v1) so 1.7-and-earlier envelopes keep loading. The provider name is threaded from `config.provider` at the `build_conversation_state` call site. Conflict-free with the other two v1.8 PRs (test hunks do not overlap).