### PR TITLE
feat(providers): pre-flight reject extended thinking on Claude 3 models

### DIFF
--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -57,6 +57,17 @@ _MANUAL_THINKING_BUDGETS = {
 }
 
 
+def _model_lacks_extended_thinking(model: str) -> bool:
+    """True for Claude 3.0/3.5 models, which have no extended thinking.
+
+    Extended thinking launched with Claude 3.7; the 3.0 and 3.5 families are
+    frozen and will never gain it, so this is a stable fact rather than a
+    moving capability matrix. Claude 3.7 (``claude-3-7-*``) and the 4.x
+    families do support thinking and are deliberately excluded.
+    """
+    return "claude-3-" in model and "claude-3-7" not in model
+
+
 class AnthropicProvider:
     """Anthropic Messages API provider."""
 
@@ -506,6 +517,28 @@ class AnthropicProvider:
                 allow_network_errors=True,
                 message="Anthropic batch cancel failed",
             ) from e
+
+    async def validate_request(self, request: ProviderRequest) -> None:
+        """Pre-flight model-specific rejections before any network call.
+
+        Implements the :class:`ValidatingProvider` hook. The provider-level
+        ``reasoning`` capability is coarse; this adds the model-specific layer
+        beneath it. A reasoning request against a Claude 3.0/3.5 model would
+        400 upstream after a wasted round-trip, so fail fast with an actionable
+        error instead.
+        """
+        wants_reasoning = (
+            request.reasoning_effort is not None
+            or request.reasoning_budget_tokens is not None
+        )
+        if wants_reasoning and _model_lacks_extended_thinking(request.model):
+            raise ConfigurationError(
+                f"Model {request.model!r} does not support extended thinking",
+                hint=(
+                    "Remove reasoning_effort/reasoning_budget_tokens, or use a "
+                    "model with extended thinking (Claude 3.7 or 4.x)."
+                ),
+            )
 
     async def generate(
         self,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3295,6 +3295,28 @@ def test_history_still_rejects_items_without_role() -> None:
 
 
 @pytest.mark.asyncio
+async def test_anthropic_preflight_rejects_reasoning_before_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real AnthropicProvider rejects reasoning on Claude 3 via validate_request.
+
+    Proves the pipeline runs the ValidatingProvider pre-flight before any
+    network call: the provider has no usable client, so a non-failing path
+    would error differently than this ConfigurationError.
+    """
+    provider = AnthropicProvider("test-key")
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+    cfg = Config(
+        provider="anthropic", model="claude-3-5-sonnet-20241022", use_mock=True
+    )
+
+    with pytest.raises(ConfigurationError, match="extended thinking"):
+        await pollux.run(
+            "Think hard.", config=cfg, options=Options(reasoning_effort="high")
+        )
+
+
+@pytest.mark.asyncio
 async def test_tool_call_response_populates_conversation_state_without_history(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -4363,6 +4363,52 @@ async def test_anthropic_generate_continuation_no_prompt() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model", ["claude-3-5-sonnet-20241022", "claude-3-haiku-20240307"]
+)
+async def test_anthropic_validate_request_rejects_reasoning_on_claude_3(
+    model: str,
+) -> None:
+    """Claude 3.0/3.5 lack extended thinking; a reasoning request must fail fast."""
+    provider = AnthropicProvider("test-key")
+
+    with pytest.raises(ConfigurationError, match="extended thinking"):
+        await provider.validate_request(
+            ProviderRequest(model=model, parts=["Think hard."], reasoning_effort="high")
+        )
+    with pytest.raises(ConfigurationError, match="extended thinking"):
+        await provider.validate_request(
+            ProviderRequest(
+                model=model, parts=["Think hard."], reasoning_budget_tokens=2048
+            )
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", ["claude-3-7-sonnet-20250219", ANTHROPIC_MODEL])
+async def test_anthropic_validate_request_allows_reasoning_on_thinking_models(
+    model: str,
+) -> None:
+    """Claude 3.7 and 4.x support thinking; the 3.7 prefix must not be rejected."""
+    provider = AnthropicProvider("test-key")
+
+    # Returns None (no raise) when the model supports extended thinking.
+    await provider.validate_request(
+        ProviderRequest(model=model, parts=["Think hard."], reasoning_effort="high")
+    )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_validate_request_allows_non_reasoning_on_claude_3() -> None:
+    """A plain request on a Claude 3 model must pass validation unchanged."""
+    provider = AnthropicProvider("test-key")
+
+    await provider.validate_request(
+        ProviderRequest(model="claude-3-5-sonnet-20241022", parts=["Hello."])
+    )
+
+
+@pytest.mark.asyncio
 async def test_anthropic_upload_raises() -> None:
     """upload_file should raise APIError on network or IO failure."""
     from pathlib import Path


### PR DESCRIPTION
## Summary

`AnthropicProvider` now implements the `ValidatingProvider` hook (already invoked by `execute.py` before any network call). A `reasoning_effort` / `reasoning_budget_tokens` request against a Claude 3.0/3.5 model would 400 upstream after a wasted round-trip; it now fails fast with an actionable `ConfigurationError`. Aligned with the v2 direction of providers owning provider-specific validation.

## Related issue

None

## Test plan

`just check` green (358 passed). Added unit tests (`tests/test_providers.py`): rejects reasoning on `claude-3-5-*` and `claude-3-haiku-*` (both reasoning controls); allows it on `claude-3-7-*` and 4.x; allows non-reasoning requests on Claude 3. Added a pipeline test (`tests/test_pipeline.py`) proving the pre-flight fires before any network call via a real provider. Follows the existing OpenRouter `validate_request` prior art.

## Notes

The rule is deliberately narrow and **stable**: extended thinking launched with Claude 3.7, so the frozen 3.0/3.5 families will never gain it; 3.7 and 4.x are excluded (`"claude-3-" in model and "claude-3-7" not in model`). Gemini `validate_request` was intentionally **not** added; its thinking-model matrix is not stable enough to encode without risking false rejections (a wrong rule is worse than the upstream error). The coarse provider-level `reasoning` capability is unchanged; this adds the model-specific layer beneath it. Conflict-free with the other two v1.8 PRs.