### PR TITLE
docs(docs): mark v2-removed entry points and add 2.0 migration stub

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,18 +5,23 @@ This roadmap is intentionally scope-constrained. Pollux is already past the
 trustworthy, more legible, and harder to misuse.
 
 - **Intent**: communicate priorities and scope boundaries, not promises.
-- **Last updated**: 2026-04-22
-- **Current status**: v1.8 ships reasoning budget tokens, normalized
-  `cached_tokens` usage reporting across providers, a text-only `local`
-  provider for self-hosted OpenAI-compatible servers, and removes the deprecated
+- **Last updated**: 2026-06-12
+- **Current release**: v1.8 adds reasoning budget tokens, normalized
+  `cached_tokens` usage reporting, a text-only `local` provider, serialized
+  continuation state stamps, and Anthropic pre-flight rejection of
+  extended-thinking requests on Claude 3 models. It also removes the deprecated
   `Options.delivery_mode` shim.
+- **Next major**: v2.0 is planned as a major-version cleanup of Pollux's
+  interaction model. See `docs/migrating-to-v2.md` for the migration direction.
 - **Status tracking**: Issues and PRs are the source of truth for active work.
 
 ## Product Strategy
 
 - **Policy**: Pollux is capability-transparent, not capability-equalizing.
+  Pollux surfaces provider differences instead of pretending every model
+  supports the same controls.
 - Pollux owns orchestration primitives, not full application workflows.
-- Prefer stronger guarantees, clearer docs, and sharper errors over a broader
+- Prefer stronger guarantees, better docs, and sharper errors over a broader
   public API.
 - New surface area should earn its place by removing repeated downstream
   boilerplate without hiding meaningful provider differences.
@@ -61,7 +66,7 @@ the goal; the goal is a small core that stays trustworthy under real use.
 Concrete items currently on the shortlist. None are commitments, and the list
 is expected to stay short. Discovered follow-ups are tracked in GitHub issues.
 
-- **Gemini flex inference tier** — evaluate provider-specific support for
+- **Gemini flex inference tier**: evaluate provider-specific support for
   Google's flex inference pricing tier (lower cost, higher latency).
 
 ## High-Bar / Not Planned

--- a/docs/migrating-to-v2.md
+++ b/docs/migrating-to-v2.md
@@ -1,0 +1,133 @@
+<!-- Intent: Preview the planned Pollux 2.0 migration path for 1.x users.
+     Teach what is expected to stay familiar, what is expected to move, and
+     what users can do in 1.x to reduce future churn. Do NOT present the v2 API
+     as final or require users to rewrite code before v2 is released. Assumes
+     the reader has used Pollux 1.x. Register: warm guide with precise caveats. -->
+
+# Migrating to Pollux 2.0
+
+!!! warning "Planned, not released"
+    Pollux 2.0 has not shipped. This page describes the migration direction so
+    you can write 1.x code with less future churn. Names, signatures, and exact
+    replacement snippets may change before release.
+
+Pollux 2.0 is planned as a major-version cleanup of the interaction model. The
+goal is to name the pieces of a model interaction directly: the environment the
+model runs in, the input for this turn, the output requirements, and the
+continuation state that carries work forward.
+
+Most one-shot code should remain recognizable. The bigger changes affect code
+that builds agent loops, persists continuation state, prepares caches, submits
+deferred collections, or reaches into result dictionaries.
+
+## Who Is Affected
+
+You should read this page if your 1.x code uses any of these:
+
+- `Options(...)` for output shape, tools, reasoning, caching, or provider
+  controls.
+- `continue_from`, `history`, `continue_tool()`, or persisted continuation
+  blobs.
+- `create_cache(...)` and explicit cache handles.
+- `defer_many(...)`.
+- Dictionary-style result access such as `result["text"]`.
+
+If your code calls `run()` with a prompt, sources, and config, the migration is
+expected to be small.
+
+## What Stays Familiar
+
+These 1.x entry points are expected to keep their role:
+
+- `run()` for one realtime interaction.
+- `run_many()` for source-pattern collections: fan-out, fan-in, and broadcast.
+- `defer()` for provider-side work that you submit now and collect later.
+- `inspect_deferred()`, `collect_deferred()`, and `cancel_deferred()` for the
+  deferred lifecycle.
+
+In other words, the first Pollux program still starts with `run()`.
+
+## What Changes
+
+The planned changes move behavior out of special-case helpers and into named
+interaction pieces. Treat the right column as migration direction until the v2
+API lands.
+
+| 1.x | Planned 2.0 shape | Why |
+| --- | --- | --- |
+| `Options(...)` | `Environment`, `Input`, and `OutputRequirements` | Provider, turn input, and output contract become separate objects. |
+| `continue_tool(env, results)` | `interact(environment, Input(continuation=..., tool_results=...))` | Tool-result replay becomes part of continuing an interaction. |
+| `create_cache(...)` | Prepared `Environment` | Cache identity belongs with the model environment that will reuse it. |
+| `defer_many(...)` | `defer(...)` | Deferred submission uses one entry point for one interaction or a collection. |
+| `result["text"]` | `result.text` | Results become typed outputs with named facets and explicit serialization. |
+
+## Before And After
+
+Here is the expected direction for result handling:
+
+```python
+# 1.x
+text = result["text"]
+payload = dict(result)
+
+# 2.0 planned shape
+text = result.text
+payload = result.to_jsonable()
+```
+
+Tool loops are expected to move from a helper-shaped API to an
+interaction-shaped API:
+
+```python
+# 1.x
+next_result = await continue_tool(env, tool_results)
+
+# 2.0 planned shape
+next_result = await interact(
+    environment,
+    Input(continuation=continuation, tool_results=tool_results),
+)
+```
+
+The important shift is ownership. Your code still owns tool execution, approval,
+logging, limits, and storage. Pollux owns the provider-facing interaction and
+the continuation format it needs for the next turn.
+
+## Serialized State
+
+Pollux 1.x now stamps serialized continuation state and deferred handles with a
+version and provider marker. Pollux 2.0 is expected to reject incompatible 1.x
+artifacts with an actionable error instead of reading them as 2.0 state.
+
+Plan to re-run work across the major-version boundary rather than reusing old
+serialized continuation blobs. Persist enough application state to rebuild the
+request when that is the right recovery path.
+
+## What To Do In 1.x
+
+You do not need to rewrite working 1.x code before 2.0 exists. To make future
+migration easier:
+
+- Keep provider setup, prompts, sources, and output requirements separated in
+  your own code.
+- Prefer public result fields and documented envelope behavior over ad hoc
+  dictionary probing.
+- Treat continuation blobs and deferred handles as Pollux-owned artifacts.
+  Store them, but do not inspect or mutate their internals.
+- Keep tool execution policy in your application code: dispatch, approval,
+  logging, retries, and stop conditions.
+- Use `run()` and `run_many()` for realtime source patterns, and `defer()` /
+  `defer_many()` only when provider-side deferred delivery is the workflow you
+  want.
+
+## As The Design Settles
+
+This page will change as the 2.0 API moves from plan to release candidate. Use
+it as the public migration guide; exact replacement snippets will become more
+specific as names and signatures settle.
+
+---
+
+For the concepts behind the planned model, read [Core Concepts](concepts.md).
+For the current provider contract, see
+[Provider Capabilities](reference/provider-capabilities.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
   - Writing Portable Code Across Providers: portable-code.md
   - Handling Errors and Recovery: error-handling.md
   - Configuring Pollux: configuration.md
+  - Migrating to 2.0: migrating-to-v2.md
   - Reference:
       - API: reference/api.md
       - Provider Capabilities: reference/provider-capabilities.md

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -162,7 +162,12 @@ async def defer_many(
     config: Config,
     options: Options | None = None,
 ) -> DeferredHandle:
-    """Submit deferred work and return a handle for later inspection/collection."""
+    """Submit deferred work and return a handle for later inspection/collection.
+
+    Removed in Pollux 2.0: the 2.0 deferred entry point submits a single
+    interaction or a source-pattern collection through one unambiguous call.
+    See the *Migrating to 2.0* guide.
+    """
     request = normalize_request(prompts, sources, config, options=options)
     if not request.prompts:
         raise ConfigurationError(
@@ -232,6 +237,11 @@ async def continue_tool(
 ) -> ResultEnvelope:
     """Continue a conversation with the results of tool calls.
 
+    Removed in Pollux 2.0: continuation and tool-result replay become core
+    interaction semantics, expressed as
+    ``interact(environment, Input(continuation=..., tool_results=...))`` rather
+    than a dedicated helper. See the *Migrating to 2.0* guide.
+
     Args:
         continue_from: The previous ResultEnvelope containing tool calls.
         tool_results: List of tool results as dicts (must provide 'role': 'tool',
@@ -281,6 +291,10 @@ async def create_cache(
     ttl_seconds: int = 3600,
 ) -> CacheHandle:
     """Create a persistent context cache for use with ``run()`` / ``run_many()``.
+
+    Removed in Pollux 2.0: context caching moves into environment preparation,
+    where cache identity is part of a prepared environment rather than a
+    standalone handle. See the *Migrating to 2.0* guide.
 
     Args:
         sources: Content to cache (files, text, URLs).


### PR DESCRIPTION
## Summary

Pollux 2.0 is a planned **clean break** (no API-spelling shims). Mark `continue_tool`, `defer_many`, and `create_cache` in their docstrings as removed in 2.0, pointing at their 2.0 replacements (`interact` / single `defer` / environment preparation). Add a clearly-planned "Migrating to 2.0" guide (v1→v2 concept map, clean-break + artifact-rejection posture) wired into the mkdocs nav, and refresh ROADMAP current status for the v1.8 cut.

## Related issue

None

## Test plan

`just check` green; `mkdocs build --strict` builds clean (the sketches-not-in-nav line is pre-existing INFO, intentional). No code-behavior change: docstrings, a new docs page, nav, and ROADMAP only.

## Notes

**No runtime `DeprecationWarning`**: the 2.0 replacements do not exist in 1.x, and v2 is a clean break rather than a shimmed one, so a runtime warning would be premature noise for the small user base. No manual `CHANGELOG.md`/version edits; those are generated by python-semantic-release from conventional commits. The migration page is explicitly labelled planned/not-released; names may still change before 2.0. Conflict-free with the other two v1.8 PRs.