### PR TITLE
docs(v1.8): refine migration cleanup notes

### DIFF
--- a/docs/migrating-to-v2.md
+++ b/docs/migrating-to-v2.md
@@ -26,6 +26,9 @@ You should read this page if your 1.x code uses any of these:
 
 - `Options(...)` for output shape, tools, reasoning, caching, or provider
   controls.
+- The removed `Options.delivery_mode` setting. In v1.8+, use `run()` /
+  `run_many()` for realtime calls and `defer()` / `defer_many()` for
+  provider-side deferred work.
 - `continue_from`, `history`, `continue_tool()`, or persisted continuation
   blobs.
 - `create_cache(...)` and explicit cache handles.

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -164,9 +164,9 @@ async def defer_many(
 ) -> DeferredHandle:
     """Submit deferred work and return a handle for later inspection/collection.
 
-    Removed in Pollux 2.0: the 2.0 deferred entry point submits a single
-    interaction or a source-pattern collection through one unambiguous call.
-    See the *Migrating to 2.0* guide.
+    Planned for Pollux 2.0: deferred submission moves to one entry point that
+    can submit a single interaction or a source-pattern collection. See the
+    *Migrating to 2.0* guide.
     """
     request = normalize_request(prompts, sources, config, options=options)
     if not request.prompts:
@@ -237,8 +237,8 @@ async def continue_tool(
 ) -> ResultEnvelope:
     """Continue a conversation with the results of tool calls.
 
-    Removed in Pollux 2.0: continuation and tool-result replay become core
-    interaction semantics, expressed as
+    Planned for Pollux 2.0: continuation and tool-result replay become core
+    interaction semantics, expressed as something like
     ``interact(environment, Input(continuation=..., tool_results=...))`` rather
     than a dedicated helper. See the *Migrating to 2.0* guide.
 
@@ -292,7 +292,7 @@ async def create_cache(
 ) -> CacheHandle:
     """Create a persistent context cache for use with ``run()`` / ``run_many()``.
 
-    Removed in Pollux 2.0: context caching moves into environment preparation,
+    Planned for Pollux 2.0: context caching moves into environment preparation,
     where cache identity is part of a prepared environment rather than a
     standalone handle. See the *Migrating to 2.0* guide.
 

--- a/src/pollux/retry.py
+++ b/src/pollux/retry.py
@@ -124,10 +124,6 @@ def should_retry_side_effect(exc: BaseException) -> bool:
     return False
 
 
-# Backwards-compatible internal alias.
-should_retry = should_retry_generate
-
-
 def _compute_backoff_delay(policy: RetryPolicy, *, retry_index: int) -> float:
     """Compute backoff delay with full jitter when enabled."""
     # retry_index starts at 1 for the first retry sleep.


### PR DESCRIPTION
## Summary

Refines the final v1.8 cleanup notes after removing `Options.delivery_mode`: the migration guide now points users to explicit realtime vs deferred entry points, public docstrings avoid implying Pollux 2.0 has already shipped, and an unused internal retry alias is removed.

## Related issue

None

## Test plan

- `uv run python - <<'PY' ... PY` import smoke for `pollux` and `should_retry_generate`
- `uv run pytest tests/test_pipeline.py -k "options or deferred" -q` (35 passed, 79 deselected)
- `just format`
- `just lint`
- `just typecheck`
- `just check` (359 passed, 19 deselected non-API tests)

No new tests were added: this is a non-behavioral documentation/API-surface cleanup, with existing boundary coverage confirming options and deferred behavior.

## Notes

Changelog and version increments are intentionally untouched because PSR handles them automatically.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
