### PR TITLE
ci(release): add v1 maintenance release line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ name: Continuous Integration
   push:
     # Avoid duplicate CI runs on feature branches that already have a PR.
     # (Push to a PR branch triggers both `push` and `pull_request`.)
-    branches: [main, "release/**"]
-  # Run on pull requests that target the main branch
+    branches: [main, v1, "release/**"]
+  # Run on pull requests that target active release lines.
   pull_request:
-    branches: [main, "release/**"]
+    branches: [main, v1, "release/**"]
   # Run API tests nightly to detect provider-side drift during quiet periods
   schedule:
     - cron: "0 8 * * *" # 8am UTC daily

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,9 @@ name: Release
 
 jobs:
   release:
-    # Safety: allow dry-runs from any branch. Restrict real publishing to main/release branches.
-    if: ${{ inputs.dry_run || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}
+    # Safety: allow dry-runs from any branch. Restrict real publishing to
+    # final release lines (main, v1) and RC branches (release/**).
+    if: ${{ inputs.dry_run || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1' || startsWith(github.ref, 'refs/heads/release/') }}
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,6 +296,12 @@ major_on_zero = true
 match = "main"
 prerelease = false
 
+[tool.semantic_release.branches.v1]
+# Long-lived v1 maintenance line. Publishes final patch/minor releases after
+# main moves to v2 (e.g., 1.8.1 or 1.9.0), not prereleases.
+match = "v1"
+prerelease = false
+
 [tool.semantic_release.branches.release]
 # Release branches publish RCs (e.g., 1.0.0-rc.1) before final main release.
 match = "^release\\/.*$"
@@ -303,9 +309,9 @@ prerelease = true
 prerelease_token = "rc"
 
 [tool.semantic_release.branches.preview]
-# Allow dry-run previews on non-main/non-release branches without changing release rules.
+# Allow dry-run previews on feature branches without changing release rules.
 # This produces prerelease versions like `0.10.0-preview.1` on feature branches.
-match = "^(?!main$)(?!release\\/).+"
+match = "^(?!main$)(?!v1$)(?!release\\/).+"
 prerelease = true
 prerelease_token = "preview"
 


### PR DESCRIPTION
## Summary

Adds `v1` as a long-lived final-release maintenance line for Python Semantic Release so v1 patch/minor releases can continue after `main` moves to v2. CI and the manual release workflow now recognize `v1`, while `release/**` remains reserved for RC prereleases.

## Related issue

None

## Test plan

- `just lint`
- `git diff --check`
- `uv run semantic-release --noop -v version` confirmed config parses and this feature branch still matches the `preview` group instead of `v1`
- `uv run python - <<'PY' ... PY` confirmed the parsed PSR `v1` branch is `prerelease = false` and `preview` excludes `v1`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `just typecheck`
- `just check` (359 passed, 19 deselected non-API tests)

No library behavior tests were added because this is release-infrastructure configuration. The checks above validate workflow syntax, PSR config parsing, and the existing non-API test boundary.

## Notes

Future v1 maintenance PRs should target `v1`; conventional commits on that branch can publish final `1.8.x` patch releases or a future `1.9.0` if needed. Check the PyPI trusted-publishing environment rules and branch protection settings after merging so `v1` is allowed wherever `main` is allowed.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
