### PR TITLE
ci(docs): deploy versioned documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,25 +2,45 @@ name: Docs
 
 "on":
   push:
-    branches: [ main ]
+    branches: [ main, v1 ]
     tags: [ 'v*' ]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'pyproject.toml'
       - 'README.md'
       - 'src/**'
+      - 'uv.lock'
       - '.github/workflows/docs.yml'
   pull_request:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'pyproject.toml'
       - 'README.md'
       - 'src/**'
+      - 'uv.lock'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
+    inputs:
+      docs_version:
+        description: 'Optional mike version override, e.g. 1.8'
+        required: false
+        type: string
+        default: ""
+      aliases:
+        description: 'Optional space-separated aliases, e.g. v1 latest'
+        required: false
+        type: string
+        default: ""
+      default_version:
+        description: 'Optional mike default version or alias, e.g. latest'
+        required: false
+        type: string
+        default: ""
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -49,11 +69,6 @@ jobs:
       - name: Build site (strict)
         run: uv run mkdocs build --strict --clean
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: site
-
       - name: Upload PR preview artifact
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v6
@@ -64,11 +79,99 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1' || startsWith(github.ref, 'refs/tags/v')) }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Configure docs version
+        id: docs-version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ref_name="${GITHUB_REF_NAME}"
+          version=""
+          default_version=""
+          aliases=""
+
+          if [[ -n "${{ inputs.docs_version }}" ]]; then
+            version="${{ inputs.docs_version }}"
+            aliases="${{ inputs.aliases }}"
+            default_version="${{ inputs.default_version }}"
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            release="${ref_name#v}"
+            version="${release%.*}"
+            major="${version%%.*}"
+            if [[ "${major}" == "1" ]]; then
+              aliases="v1"
+            else
+              aliases="latest"
+              default_version="latest"
+            fi
+          elif [[ "${ref_name}" == "v1" ]]; then
+            version="v1"
+          else
+            version="dev"
+            aliases="latest"
+            default_version="latest"
+          fi
+
+          {
+            echo "version=${version}"
+            echo "aliases=${aliases}"
+            echo "default_version=${default_version}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy versioned docs
+        run: |
+          aliases="${{ steps.docs-version.outputs.aliases }}"
+          if [[ -n "${aliases}" ]]; then
+            uv run mike deploy \
+              --push \
+              --update-aliases \
+              "${{ steps.docs-version.outputs.version }}" \
+              ${aliases}
+          else
+            uv run mike deploy \
+              --push \
+              --update-aliases \
+              "${{ steps.docs-version.outputs.version }}"
+          fi
+
+      - name: Set default docs version
+        if: ${{ steps.docs-version.outputs.default_version != '' }}
+        run: uv run mike set-default --push "${{ steps.docs-version.outputs.default_version }}"
+
+      - name: Checkout Pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,8 @@ extra_css:
 
 extra:
   generator: false
+  version:
+    provider: mike
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/seanbrar/pollux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ lint = [
     "vulture>=2.14",
 ]
 docs = [
+    "mike>=2.1.0",
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.6.0",
     "mkdocstrings[python]>=0.25.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1134,6 +1134,23 @@ wheels = [
 ]
 
 [[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
+]
+
+[[package]]
 name = "mkdocs"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1430,6 +1447,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "hypothesis" },
+    { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-htmlproofer-plugin" },
     { name = "mkdocs-material" },
@@ -1451,6 +1469,7 @@ dev = [
     { name = "vulture" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-htmlproofer-plugin" },
     { name = "mkdocs-material" },
@@ -1489,6 +1508,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "hypothesis", specifier = ">=6.140.0" },
+    { name = "mike", specifier = ">=2.1.0" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-htmlproofer-plugin" },
     { name = "mkdocs-material", specifier = ">=9.6.0" },
@@ -1510,6 +1530,7 @@ dev = [
     { name = "vulture", specifier = ">=2.14" },
 ]
 docs = [
+    { name = "mike", specifier = ">=2.1.0" },
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-htmlproofer-plugin" },
     { name = "mkdocs-material", specifier = ">=9.6.0" },
@@ -1741,6 +1762,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -2410,6 +2440,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds MkDocs Material versioning via `mike` so Pollux can publish divergent docs for the moving v1 maintenance line and v2/main development. The docs workflow now deploys an assembled multi-version Pages artifact from `gh-pages` while keeping PR builds as strict MkDocs preview artifacts.

## Related issue

None

## Test plan

- `actionlint .github/workflows/docs.yml`
- `uv run mkdocs build --strict --clean`
- `git diff --check`
- `just lint`
- `just check` (359 passed, 19 deselected non-API tests)

No library behavior tests were added because this is docs deployment configuration. Existing checks cover the package after the docs dependency lockfile update, and `mkdocs build --strict` validates the site content.

## Notes

Deployment behavior after merge:

- `main` publishes the moving `dev` docs with alias `latest` and default `latest`.
- `v1` publishes the moving `v1` docs.
- tags such as `v1.8.1` publish frozen `1.8` docs and update alias `v1`.
- future tags such as `v2.0.0` publish frozen `2.0` docs and move alias/default `latest`.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
