### PR TITLE
ci(docs): label main docs as next

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,11 @@ name: Docs
         required: false
         type: string
         default: ""
+      title:
+        description: 'Optional version selector title, e.g. 1.8 or Next'
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -105,16 +110,19 @@ jobs:
 
           ref_name="${GITHUB_REF_NAME}"
           version=""
+          title=""
           default_version=""
           aliases=""
 
           if [[ -n "${{ inputs.docs_version }}" ]]; then
             version="${{ inputs.docs_version }}"
+            title="${{ inputs.title }}"
             aliases="${{ inputs.aliases }}"
             default_version="${{ inputs.default_version }}"
           elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             release="${ref_name#v}"
             version="${release%.*}"
+            title="${version}"
             major="${version%%.*}"
             if [[ "${major}" == "1" ]]; then
               aliases="v1"
@@ -124,14 +132,19 @@ jobs:
             fi
           elif [[ "${ref_name}" == "v1" ]]; then
             version="v1"
+            title="v1"
           else
-            version="dev"
-            aliases="latest"
-            default_version="latest"
+            version="next"
+            title="Next"
+            aliases="next"
+          fi
+          if [[ -z "${title}" ]]; then
+            title="${version}"
           fi
 
           {
             echo "version=${version}"
+            echo "title=${title}"
             echo "aliases=${aliases}"
             echo "default_version=${default_version}"
           } >> "$GITHUB_OUTPUT"
@@ -148,12 +161,14 @@ jobs:
             uv run mike deploy \
               --push \
               --update-aliases \
+              --title "${{ steps.docs-version.outputs.title }}" \
               "${{ steps.docs-version.outputs.version }}" \
               ${aliases}
           else
             uv run mike deploy \
               --push \
               --update-aliases \
+              --title "${{ steps.docs-version.outputs.title }}" \
               "${{ steps.docs-version.outputs.version }}"
           fi
 


### PR DESCRIPTION
## Summary

Changes the versioned docs workflow so main-branch documentation is published as `next` with the display title `Next`, rather than `dev`/`latest`. This keeps unreleased v2 documentation clearly separate while allowing stable release tags to own the `latest` alias.

## Related issue

None

## Test plan

- `actionlint .github/workflows/docs.yml`
- `uv run mkdocs build --strict --clean`
- `git diff --check`
- `just lint`
- `just check` (359 passed, 19 deselected non-API tests)

No library behavior tests were added because this is docs deployment configuration only.

## Notes

`/latest/` and `/` will point to the stable v1.8 docs until a future v2 release tag moves `latest` to `2.0`. A normal main-branch docs deployment after this change will publish `/next/` with the selector label `Next`.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
