### PR TITLE
ci(docs): avoid duplicate next alias

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -136,7 +136,6 @@ jobs:
           else
             version="next"
             title="Next"
-            aliases="next"
           fi
           if [[ -z "${title}" ]]; then
             title="${version}"


### PR DESCRIPTION
## Summary

Fixes the Docs workflow failure from the post-merge #187 run. Main docs are deployed as the `next` version with the selector title `Next`; `next` is no longer passed as both the version and alias, which `mike` rejects.

## Related issue

None

## Test plan

- `actionlint .github/workflows/docs.yml`
- `uv run mkdocs build --strict --clean`
- `git diff --check`
- `uv run mike deploy --branch tmp-mike-next-smoke-... --title "Next" next` followed by deleting the temporary local branch

No library behavior tests were added because this is a one-line docs deployment workflow fix.

## Notes

None

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [ ] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
