### PR TITLE
feat(core): add v2 interaction model types

### DIFF
--- a/src/pollux/interaction/__init__.py
+++ b/src/pollux/interaction/__init__.py
@@ -1,0 +1,63 @@
+"""The Pollux v2 canonical interaction model.
+
+These are the application-facing primitives for the v2 mental model::
+
+    Environment + Input + Config -> Output
+
+The types here are frozen dataclasses with no behavior beyond construction,
+validation, and serialization. The live ``run()`` / ``run_many()`` pipeline does
+not use them yet; the provider boundary is migrated onto them in Slice 2. They
+are not re-exported from the top-level ``pollux`` package until the Slice 3
+frontdoor cutover.
+"""
+
+from __future__ import annotations
+
+from pollux.interaction.collection import CollectionStatus, OutputCollection
+from pollux.interaction.continuation import Continuation, Message
+from pollux.interaction.environment import (
+    CachePolicy,
+    CacheSetting,
+    Environment,
+    EnvironmentSnapshot,
+)
+from pollux.interaction.input import Input
+from pollux.interaction.output import (
+    CompletionStatus,
+    Diagnostics,
+    Metrics,
+    Output,
+    Usage,
+    completion_status,
+)
+from pollux.interaction.requirements import OutputRequirements, ToolChoice
+from pollux.interaction.tools import (
+    JSONValue,
+    ToolCall,
+    ToolDeclaration,
+    ToolResult,
+)
+
+__all__ = [
+    "CachePolicy",
+    "CacheSetting",
+    "CollectionStatus",
+    "CompletionStatus",
+    "Continuation",
+    "Diagnostics",
+    "Environment",
+    "EnvironmentSnapshot",
+    "Input",
+    "JSONValue",
+    "Message",
+    "Metrics",
+    "Output",
+    "OutputCollection",
+    "OutputRequirements",
+    "ToolCall",
+    "ToolChoice",
+    "ToolDeclaration",
+    "ToolResult",
+    "Usage",
+    "completion_status",
+]

--- a/src/pollux/interaction/adapters.py
+++ b/src/pollux/interaction/adapters.py
@@ -1,0 +1,257 @@
+"""Transitional adapters between v1.x shapes and the v2 interaction model.
+
+These conversions prove the v2 types losslessly represent today's
+``ResultEnvelope`` / ``ConversationState`` / ``Options`` while the live pipeline
+is untouched. They are scaffolding: Slice 2 makes the provider boundary emit
+``Output`` natively, and this module is deleted then. Nothing here is part of the
+intended public v2 API.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from pollux.continuation import ConversationState
+from pollux.interaction.collection import OutputCollection
+from pollux.interaction.continuation import Continuation, Message
+from pollux.interaction.environment import Environment
+from pollux.interaction.input import Input
+from pollux.interaction.output import (
+    Diagnostics,
+    Metrics,
+    Output,
+    Usage,
+    completion_status,
+)
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.tools import ToolCall, ToolDeclaration
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from pollux.options import Options
+    from pollux.source import Source
+
+
+def _args_text(raw: Any) -> str:
+    """Coerce a v1 tool-call ``arguments`` value to a raw argument string."""
+    if isinstance(raw, str):
+        return raw
+    try:
+        return json.dumps(raw)
+    except TypeError:
+        return str(raw)
+
+
+def _message_from_history_dict(history: Mapping[str, Any]) -> Message:
+    """Convert a v1 history dict into a typed v2 :class:`Message`."""
+    raw_tool_calls = history.get("tool_calls")
+    tool_calls: tuple[ToolCall, ...] = ()
+    if isinstance(raw_tool_calls, list):
+        tool_calls = tuple(
+            ToolCall.from_text(
+                id=str(tc.get("id", "")),
+                name=str(tc.get("name", "")),
+                arguments_text=_args_text(tc.get("arguments", "")),
+            )
+            for tc in raw_tool_calls
+            if isinstance(tc, dict)
+        )
+    content = history.get("content", "")
+    tool_call_id = history.get("tool_call_id")
+    provider_state = history.get("provider_state")
+    return Message(
+        role=str(history.get("role", "user")),
+        content=content if isinstance(content, str) else str(content),
+        tool_calls=tool_calls,
+        tool_call_id=tool_call_id if isinstance(tool_call_id, str) else None,
+        provider_state=provider_state if isinstance(provider_state, dict) else None,
+    )
+
+
+def _history_dict_from_message(message: Message) -> dict[str, Any]:
+    """Convert a typed v2 :class:`Message` back into a v1 history dict."""
+    payload: dict[str, Any] = {"role": message.role, "content": message.content}
+    if message.tool_calls:
+        payload["tool_calls"] = [
+            {"id": tc.id, "name": tc.name, "arguments": tc.arguments_text}
+            for tc in message.tool_calls
+        ]
+    if message.tool_call_id is not None:
+        payload["tool_call_id"] = message.tool_call_id
+    if message.provider_state is not None:
+        payload["provider_state"] = message.provider_state
+    return payload
+
+
+def continuation_from_state(
+    state: ConversationState | Mapping[str, Any],
+) -> Continuation:
+    """Convert a v1 ``ConversationState`` (or its dict) into a v2 ``Continuation``."""
+    resolved = (
+        state
+        if isinstance(state, ConversationState)
+        else ConversationState.from_state_dict(state)
+    )
+    messages = tuple(_message_from_history_dict(h) for h in resolved.history)
+    return Continuation(
+        messages=messages,
+        response_id=resolved.response_id,
+        provider=resolved.provider,
+        provider_state=resolved.provider_state,
+    )
+
+
+def state_from_continuation(continuation: Continuation) -> ConversationState:
+    """Convert a v2 ``Continuation`` back into a v1 ``ConversationState``."""
+    history = [_history_dict_from_message(m) for m in continuation.messages]
+    return ConversationState(
+        history=history,
+        response_id=continuation.response_id,
+        provider_state=continuation.provider_state,
+        provider=continuation.provider,
+    )
+
+
+def _build_output(
+    envelope: Mapping[str, Any],
+    index: int,
+    *,
+    usage: Usage,
+) -> Output:
+    """Assemble one :class:`Output` from a v1 envelope at *index*."""
+    answers = envelope.get("answers") or []
+    text = answers[index] if index < len(answers) else ""
+
+    structured_list = envelope.get("structured")
+    structured = (
+        structured_list[index]
+        if isinstance(structured_list, list) and index < len(structured_list)
+        else None
+    )
+    reasoning_list = envelope.get("reasoning")
+    reasoning = (
+        reasoning_list[index]
+        if isinstance(reasoning_list, list) and index < len(reasoning_list)
+        else None
+    )
+
+    metrics_dict = envelope.get("metrics") or {}
+    finish_reasons = metrics_dict.get("finish_reasons") or []
+    finish_reason = finish_reasons[index] if index < len(finish_reasons) else None
+    metrics = Metrics(
+        duration_s=float(metrics_dict.get("duration_s", 0.0)),
+        n_calls=1,
+        cache_used=bool(metrics_dict.get("cache_used", False)),
+        cache_mode=str(metrics_dict.get("cache_mode", "none")),
+        cache_hit=bool(metrics_dict.get("cache_hit", False)),
+        finish_reason=finish_reason,
+        completion_status=completion_status(finish_reason),
+    )
+
+    tool_calls_envelope = envelope.get("tool_calls")
+    tool_calls: tuple[ToolCall, ...] = ()
+    if isinstance(tool_calls_envelope, list) and index < len(tool_calls_envelope):
+        tool_calls = tuple(
+            ToolCall.from_text(
+                id=str(tc.get("id", "")),
+                name=str(tc.get("name", "")),
+                arguments_text=_args_text(tc.get("arguments", "")),
+            )
+            for tc in tool_calls_envelope[index]
+            if isinstance(tc, dict)
+        )
+
+    continuation: Continuation | None = None
+    state = envelope.get(ConversationState.ENVELOPE_KEY)
+    if isinstance(state, dict):
+        continuation = continuation_from_state(state)
+
+    diagnostics_raw = envelope.get("diagnostics")
+    diagnostics = Diagnostics(
+        raw=dict(diagnostics_raw) if isinstance(diagnostics_raw, dict) else None
+    )
+
+    return Output(
+        text=text if isinstance(text, str) else str(text),
+        structured=structured,
+        reasoning=reasoning,
+        tool_calls=tool_calls,
+        continuation=continuation,
+        usage=usage,
+        metrics=metrics,
+        diagnostics=diagnostics,
+    )
+
+
+def output_from_envelope(envelope: Mapping[str, Any], *, index: int = 0) -> Output:
+    """Convert a single-interaction v1 ``ResultEnvelope`` into an ``Output``."""
+    return _build_output(
+        envelope, index, usage=Usage.from_dict(envelope.get("usage", {}))
+    )
+
+
+def collection_from_envelope(envelope: Mapping[str, Any]) -> OutputCollection:
+    """Convert a multi-interaction v1 ``ResultEnvelope`` into an ``OutputCollection``."""
+    answers = envelope.get("answers") or []
+    diagnostics = envelope.get("diagnostics") or {}
+    raw_responses = diagnostics.get("raw_responses") or []
+    outputs: list[Output] = []
+    for i in range(len(answers)):
+        per_call_usage = (
+            raw_responses[i].get("usage", {})
+            if i < len(raw_responses) and isinstance(raw_responses[i], dict)
+            else {}
+        )
+        outputs.append(
+            _build_output(envelope, i, usage=Usage.from_dict(per_call_usage))
+        )
+    return OutputCollection(
+        outputs=tuple(outputs),
+        prompt_indexes=tuple(range(len(answers))),
+    )
+
+
+def requirements_from_options(options: Options) -> OutputRequirements:
+    """Project the per-generation fields of v1 ``Options`` onto requirements."""
+    return OutputRequirements(
+        output_schema=options.response_schema,
+        temperature=options.temperature,
+        top_p=options.top_p,
+        max_tokens=options.max_tokens,
+        reasoning_effort=options.reasoning_effort,
+        reasoning_budget_tokens=options.reasoning_budget_tokens,
+        tool_choice=options.tool_choice,
+        provider_options=options.provider_options,
+    )
+
+
+def environment_from_options(
+    options: Options, sources: Sequence[Source]
+) -> Environment:
+    """Project the stable-setup fields of v1 ``Options`` onto an environment.
+
+    Concrete v1 ``CacheHandle`` mapping is out of Slice 1 scope (cache-handle
+    identity lands with the provider boundary); only the cache-bearing fields
+    that decompose cleanly are carried here.
+    """
+    tools = tuple(ToolDeclaration.from_dict(tool) for tool in (options.tools or ()))
+    return Environment(
+        instructions=options.system_instruction,
+        sources=tuple(sources),
+        tools=tools,
+    )
+
+
+def input_from_options(options: Options, prompt: str | None) -> Input:
+    """Project a v1 ``Options`` prior-turn state plus *prompt* onto an ``Input``."""
+    history: tuple[Message, ...] | None = None
+    continuation: Continuation | None = None
+    if options.history is not None:
+        history = tuple(_message_from_history_dict(h) for h in options.history)
+    elif options.continue_from is not None:
+        state = ConversationState.from_envelope(options.continue_from)
+        if state is not None:
+            continuation = continuation_from_state(state)
+    return Input(content=prompt, history=history, continuation=continuation)

--- a/src/pollux/interaction/collection.py
+++ b/src/pollux/interaction/collection.py
@@ -1,0 +1,93 @@
+"""``OutputCollection``: the aggregate result for source-pattern runs.
+
+Fan-out, fan-in, and broadcast produce many interaction outputs. A collection
+preserves per-interaction outputs and prompt/source indexes, exposes ergonomic
+list accessors, and carries the partial-completion ``status`` that single
+``Output`` deliberately does not.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from pollux.interaction.output import Usage
+
+if TYPE_CHECKING:
+    from pollux.interaction.output import Output
+
+#: ``"ok"`` when every answer is non-empty, ``"error"`` when all are empty,
+#: ``"partial"`` otherwise.
+CollectionStatus = Literal["ok", "partial", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class OutputCollection:
+    """Aggregate result for a multi-call source pattern."""
+
+    outputs: tuple[Output, ...] = ()
+    prompt_indexes: tuple[int, ...] | None = None
+    source_indexes: tuple[int, ...] | None = None
+
+    def __post_init__(self) -> None:
+        """Coerce the outputs sequence to an immutable tuple."""
+        object.__setattr__(self, "outputs", tuple(self.outputs))
+
+    @property
+    def answers(self) -> list[str]:
+        """Per-interaction primary text, in input order."""
+        return [output.text for output in self.outputs]
+
+    @property
+    def structured(self) -> list[Any]:
+        """Per-interaction structured payloads, in input order."""
+        return [output.structured for output in self.outputs]
+
+    @property
+    def usage(self) -> Usage:
+        """Token usage summed across interactions."""
+        input_tokens = sum(o.usage.input_tokens for o in self.outputs)
+        output_tokens = sum(o.usage.output_tokens for o in self.outputs)
+        total_tokens = sum(o.usage.total_tokens for o in self.outputs)
+        reasoning = [
+            o.usage.reasoning_tokens
+            for o in self.outputs
+            if o.usage.reasoning_tokens is not None
+        ]
+        cached = [
+            o.usage.cached_tokens
+            for o in self.outputs
+            if o.usage.cached_tokens is not None
+        ]
+        return Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+            reasoning_tokens=sum(reasoning) if reasoning else None,
+            cached_tokens=sum(cached) if cached else None,
+        )
+
+    @property
+    def status(self) -> CollectionStatus:
+        """Partial-completion status based on answer presence."""
+        if not self.outputs:
+            return "ok"
+        empty = sum(1 for output in self.outputs if not output.text.strip())
+        if empty == len(self.outputs):
+            return "error"
+        if empty > 0:
+            return "partial"
+        return "ok"
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict with per-output detail and aggregates."""
+        payload: dict[str, Any] = {
+            "status": self.status,
+            "outputs": [output.to_jsonable() for output in self.outputs],
+            "usage": self.usage.to_jsonable(),
+        }
+        if self.prompt_indexes is not None:
+            payload["prompt_indexes"] = list(self.prompt_indexes)
+        if self.source_indexes is not None:
+            payload["source_indexes"] = list(self.source_indexes)
+        return payload

--- a/src/pollux/interaction/continuation.py
+++ b/src/pollux/interaction/continuation.py
@@ -1,0 +1,145 @@
+"""The v2 ``Continuation`` primitive and its typed replay messages.
+
+``Continuation`` is the public, serializable state Pollux needs to continue a
+provider-correct interaction. It replaces v1.x's private ``_conversation_state``
+dict. It is not memory: Pollux does not summarize, rank, or compact it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from pollux.errors import PolluxError
+from pollux.interaction.tools import ToolCall
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+#: Bump when the serialized shape changes incompatibly.
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class Message:
+    """A typed conversational turn preserved for provider-correct replay."""
+
+    role: str
+    content: str = ""
+    tool_calls: tuple[ToolCall, ...] = ()
+    tool_call_id: str | None = None
+    provider_state: dict[str, Any] | None = None
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize to a compact JSON-compatible dict (optional facets omitted)."""
+        payload: dict[str, Any] = {"role": self.role, "content": self.content}
+        if self.tool_calls:
+            payload["tool_calls"] = [tc.to_jsonable() for tc in self.tool_calls]
+        if self.tool_call_id is not None:
+            payload["tool_call_id"] = self.tool_call_id
+        if self.provider_state is not None:
+            payload["provider_state"] = self.provider_state
+        return payload
+
+    @classmethod
+    def from_jsonable(cls, data: Mapping[str, Any]) -> Message:
+        """Parse a serialized message, type-guarding each facet."""
+        raw_tool_calls = data.get("tool_calls")
+        tool_calls: tuple[ToolCall, ...] = ()
+        if isinstance(raw_tool_calls, list):
+            tool_calls = tuple(
+                ToolCall.from_text(
+                    id=str(tc.get("id", "")),
+                    name=str(tc.get("name", "")),
+                    arguments_text=str(tc.get("arguments_text", "")),
+                    index=tc.get("index") if isinstance(tc.get("index"), int) else None,
+                    provider_state=tc.get("provider_state")
+                    if isinstance(tc.get("provider_state"), dict)
+                    else None,
+                )
+                for tc in raw_tool_calls
+                if isinstance(tc, dict)
+            )
+        content = data.get("content", "")
+        tool_call_id = data.get("tool_call_id")
+        provider_state = data.get("provider_state")
+        return cls(
+            role=str(data.get("role", "user")),
+            content=content if isinstance(content, str) else str(content),
+            tool_calls=tool_calls,
+            tool_call_id=tool_call_id if isinstance(tool_call_id, str) else None,
+            provider_state=provider_state if isinstance(provider_state, dict) else None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Continuation:
+    """Serializable state for continuing a provider-correct interaction."""
+
+    SCHEMA_VERSION: ClassVar[int] = SCHEMA_VERSION
+
+    messages: tuple[Message, ...] = ()
+    response_id: str | None = None
+    provider: str | None = None
+    provider_state: dict[str, Any] | None = None
+    version: int = SCHEMA_VERSION
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict with version/provider markers."""
+        payload: dict[str, Any] = {
+            "version": self.version,
+            "messages": [m.to_jsonable() for m in self.messages],
+        }
+        if self.provider is not None:
+            payload["provider"] = self.provider
+        if self.response_id is not None:
+            payload["response_id"] = self.response_id
+        if self.provider_state is not None:
+            payload["provider_state"] = self.provider_state
+        return payload
+
+    @classmethod
+    def from_jsonable(
+        cls,
+        data: Mapping[str, Any],
+        *,
+        expected_provider: str | None = None,
+    ) -> Continuation:
+        """Parse a serialized continuation, rejecting incompatible artifacts.
+
+        A continuation written by an incompatible schema version is refused with
+        a clear error rather than misread. When *expected_provider* is given, a
+        continuation produced by a different provider is also refused.
+        """
+        raw_version = data.get("version")
+        version = raw_version if isinstance(raw_version, int) else None
+        if version != SCHEMA_VERSION:
+            raise PolluxError(
+                f"Incompatible continuation: expected schema version "
+                f"{SCHEMA_VERSION}, got {version!r}",
+                hint="This continuation was produced by a different Pollux "
+                "version. Start a new interaction instead of reusing it.",
+            )
+        provider = data.get("provider")
+        provider = provider if isinstance(provider, str) else None
+        if expected_provider is not None and provider != expected_provider:
+            raise PolluxError(
+                f"Continuation provider {provider!r} does not match the active "
+                f"provider {expected_provider!r}",
+                hint="Reuse a continuation only with the provider that produced it.",
+            )
+        raw_messages = data.get("messages")
+        messages: tuple[Message, ...] = ()
+        if isinstance(raw_messages, list):
+            messages = tuple(
+                Message.from_jsonable(m) for m in raw_messages if isinstance(m, dict)
+            )
+        response_id = data.get("response_id")
+        provider_state = data.get("provider_state")
+        return cls(
+            messages=messages,
+            response_id=response_id if isinstance(response_id, str) else None,
+            provider=provider,
+            provider_state=provider_state if isinstance(provider_state, dict) else None,
+            version=version,
+        )

--- a/src/pollux/interaction/environment.py
+++ b/src/pollux/interaction/environment.py
@@ -1,0 +1,112 @@
+"""``Environment`` and ``EnvironmentSnapshot``: the reusable model-facing setup.
+
+An :class:`Environment` is the stable context around one or more interactions:
+instructions, sources, tool declarations, and a cache preference. It does not
+contain conversation history or application memory. An
+:class:`EnvironmentSnapshot` is the planned, immutable provider-facing form whose
+``fingerprint`` backs continuation and cache compatibility checks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pollux.interaction.tools import ToolDeclaration
+    from pollux.source import Source
+
+
+@dataclass(frozen=True, slots=True)
+class CachePolicy:
+    """An explicit persistent-cache preference for an environment."""
+
+    ttl_seconds: int | None = None
+
+
+#: ``"auto"`` opts into provider-managed caching; ``"none"`` disables it.
+CacheSetting = CachePolicy | Literal["auto", "none"] | None
+
+
+@dataclass(frozen=True, slots=True)
+class Environment:
+    """The reusable, stable model-facing setup around interactions.
+
+    ``sources`` and ``tools`` accept any ordered sequence and are frozen to
+    tuples. Tool declarations must be :class:`ToolDeclaration` objects; the
+    friendly facades (Slice 3) coerce raw dict schemas through
+    :meth:`ToolDeclaration.from_dict`.
+    """
+
+    instructions: str | None = None
+    sources: Sequence[Source] = ()
+    tools: Sequence[ToolDeclaration] = ()
+    cache: CacheSetting = None
+    metadata: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        """Freeze the source and tool sequences to immutable tuples."""
+        object.__setattr__(self, "sources", tuple(self.sources))
+        object.__setattr__(self, "tools", tuple(self.tools))
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentSnapshot:
+    """The planned, immutable provider-facing environment for one interaction."""
+
+    instructions: str | None = None
+    sources: tuple[Source, ...] = ()
+    tools: tuple[ToolDeclaration, ...] = ()
+    cache: CacheSetting = None
+    provider: str | None = None
+
+    def fingerprint(self) -> str:
+        """Return a stable hash of the provider-facing environment identity.
+
+        Used to reject reuse of a continuation or cache handle against an
+        environment whose instructions, sources, or tools have changed.
+        """
+        payload = {
+            "instructions": self.instructions,
+            "sources": [
+                source.cache_identity_hash(provider=self.provider)
+                for source in self.sources
+            ],
+            "tools": [
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                }
+                for tool in self.tools
+            ],
+            "cache": _cache_fingerprint(self.cache),
+        }
+        encoded = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @classmethod
+    def from_environment(
+        cls, environment: Environment, *, provider: str | None = None
+    ) -> EnvironmentSnapshot:
+        """Freeze an :class:`Environment` into a provider-facing snapshot."""
+        return cls(
+            instructions=environment.instructions,
+            sources=tuple(environment.sources),
+            tools=tuple(environment.tools),
+            cache=environment.cache,
+            provider=provider,
+        )
+
+
+def _cache_fingerprint(cache: CacheSetting) -> Any:
+    """Reduce a cache setting to a JSON-stable fingerprint component."""
+    if isinstance(cache, CachePolicy):
+        return {"ttl_seconds": cache.ttl_seconds}
+    return cache

--- a/src/pollux/interaction/input.py
+++ b/src/pollux/interaction/input.py
@@ -1,0 +1,53 @@
+"""``Input``: the per-interaction payload asking the model for one response.
+
+An :class:`Input` represents exactly one model turn. Agent loops are repeated
+inputs over a stable or evolving environment. Prior turn state arrives either as
+explicit ``history`` or as a ``continuation`` from a previous output — not both.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pollux.errors import ConfigurationError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pollux.interaction.continuation import Continuation, Message
+    from pollux.interaction.tools import ToolResult
+
+
+@dataclass(frozen=True, slots=True)
+class Input:
+    """One model turn: user content plus optional prior state and tool results.
+
+    ``history`` and ``tool_results`` accept any ordered sequence and are frozen
+    to tuples.
+    """
+
+    content: str | None = None
+    history: Sequence[Message] | None = None
+    continuation: Continuation | None = None
+    tool_results: Sequence[ToolResult] = ()
+
+    def __post_init__(self) -> None:
+        """Coerce sequences to tuples and validate the turn is well formed."""
+        if self.history is not None:
+            object.__setattr__(self, "history", tuple(self.history))
+        object.__setattr__(self, "tool_results", tuple(self.tool_results))
+
+        if self.history is not None and self.continuation is not None:
+            raise ConfigurationError(
+                "history and continuation are mutually exclusive",
+                hint="Use exactly one prior-turn state source per interaction.",
+            )
+
+        has_content = bool(self.content and self.content.strip())
+        if not has_content and not self.tool_results:
+            raise ConfigurationError(
+                "Input has no user content and no tool results",
+                hint="Provide content for a new turn, or tool_results to "
+                "continue from prior tool calls.",
+            )

--- a/src/pollux/interaction/output.py
+++ b/src/pollux/interaction/output.py
@@ -1,0 +1,167 @@
+"""``Output``: the completed result of one model interaction.
+
+``Output`` is an immutable object with named facets. It is not a dict-shaped
+envelope: code reads ``output.text`` / ``output.tool_calls`` and serializes with
+``to_jsonable()``. There is no ``confidence``, ``extraction_method``, or
+single-result ``status`` heuristic — completion legibility lives in
+``metrics.completion_status``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from pollux.interaction.continuation import Continuation
+    from pollux.interaction.tools import ToolCall
+
+#: Whether a turn stopped cleanly, was truncated by a token limit, was cut off by
+#: another provider-side condition, or failed.
+CompletionStatus = Literal["clean", "truncated", "cutoff", "error"]
+
+_CLEAN_FINISH = {"stop", "tool_calls", "end_turn", "stop_sequence", "complete"}
+_TRUNCATED_FINISH = {"max_tokens", "length"}
+_CUTOFF_FINISH = {
+    "content_filter",
+    "safety",
+    "recitation",
+    "prohibited_content",
+    "blocklist",
+    "spii",
+}
+
+
+def completion_status(
+    finish_reason: str | None,
+    *,
+    error_category: str | None = None,
+) -> CompletionStatus:
+    """Map a normalized finish reason and error category to a completion status.
+
+    ``error_category`` values come from
+    :func:`pollux.providers._errors._detect_error_category`. A context-overflow
+    error is reported as ``"truncated"``; any other categorized error is
+    ``"error"``. Otherwise the (already normalized) finish reason decides.
+    """
+    if error_category == "context_overflow":
+        return "truncated"
+    if error_category is not None:
+        return "error"
+    if finish_reason is None:
+        return "clean"
+    reason = finish_reason.lower()
+    if reason in _CLEAN_FINISH:
+        return "clean"
+    if reason in _TRUNCATED_FINISH:
+        return "truncated"
+    if reason in _CUTOFF_FINISH:
+        return "cutoff"
+    return "cutoff"
+
+
+@dataclass(frozen=True, slots=True)
+class Usage:
+    """Normalized token and cache usage where providers report it."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    reasoning_tokens: int | None = None
+    cached_tokens: int | None = None
+
+    @classmethod
+    def from_dict(cls, usage: Mapping[str, int]) -> Usage:
+        """Build from the v1 flat usage dict, ignoring unknown keys."""
+        reasoning = usage.get("reasoning_tokens")
+        cached = usage.get("cached_tokens")
+        return cls(
+            input_tokens=int(usage.get("input_tokens", 0)),
+            output_tokens=int(usage.get("output_tokens", 0)),
+            total_tokens=int(usage.get("total_tokens", 0)),
+            reasoning_tokens=int(reasoning) if reasoning is not None else None,
+            cached_tokens=int(cached) if cached is not None else None,
+        )
+
+    def to_jsonable(self) -> dict[str, int]:
+        """Serialize to a compact dict (optional facets omitted when unset)."""
+        payload = {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+        }
+        if self.reasoning_tokens is not None:
+            payload["reasoning_tokens"] = self.reasoning_tokens
+        if self.cached_tokens is not None:
+            payload["cached_tokens"] = self.cached_tokens
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class Metrics:
+    """Pollux execution metrics for one interaction."""
+
+    duration_s: float = 0.0
+    n_calls: int = 1
+    cache_used: bool = False
+    cache_mode: str = "none"
+    cache_hit: bool = False
+    finish_reason: str | None = None
+    completion_status: CompletionStatus = "clean"
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "duration_s": self.duration_s,
+            "n_calls": self.n_calls,
+            "cache_used": self.cache_used,
+            "cache_mode": self.cache_mode,
+            "cache_hit": self.cache_hit,
+            "finish_reason": self.finish_reason,
+            "completion_status": self.completion_status,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Diagnostics:
+    """Provider and Pollux details for debugging; not normal control flow."""
+
+    raw: dict[str, Any] | None = None
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict (empty when no detail is set)."""
+        return dict(self.raw) if self.raw else {}
+
+
+@dataclass(frozen=True, slots=True)
+class Output:
+    """The completed result of one model interaction, as named facets."""
+
+    text: str = ""
+    structured: Any = None
+    reasoning: str | None = None
+    tool_calls: tuple[ToolCall, ...] = ()
+    continuation: Continuation | None = None
+    usage: Usage = field(default_factory=Usage)
+    metrics: Metrics = field(default_factory=Metrics)
+    diagnostics: Diagnostics = field(default_factory=Diagnostics)
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict (optional facets omitted)."""
+        payload: dict[str, Any] = {"text": self.text}
+        if self.structured is not None:
+            payload["structured"] = self.structured
+        if self.reasoning is not None:
+            payload["reasoning"] = self.reasoning
+        if self.tool_calls:
+            payload["tool_calls"] = [tc.to_jsonable() for tc in self.tool_calls]
+        if self.continuation is not None:
+            payload["continuation"] = self.continuation.to_jsonable()
+        payload["usage"] = self.usage.to_jsonable()
+        payload["metrics"] = self.metrics.to_jsonable()
+        diagnostics = self.diagnostics.to_jsonable()
+        if diagnostics:
+            payload["diagnostics"] = diagnostics
+        return payload

--- a/src/pollux/interaction/requirements.py
+++ b/src/pollux/interaction/requirements.py
@@ -1,0 +1,143 @@
+"""``OutputRequirements``: what kind of response Pollux should ask for.
+
+This is the per-generation requirement bundle split out of v1.x ``Options``:
+structured-output schema, generation controls, reasoning controls, tool choice,
+and a scoped provider-options escape hatch. It is not environment — it carries
+no stable sources, tool declarations, cache handles, history, or auth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, get_args
+
+from pollux.config import ProviderName
+from pollux.errors import ConfigurationError
+from pollux.options import (
+    ResponseSchemaInput,
+    response_schema_hash,
+    response_schema_json,
+    response_schema_model,
+)
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+#: ``"auto"`` / ``"required"`` / ``"none"``, or a provider-specific dict.
+ToolChoice = Literal["auto", "required", "none"] | dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class OutputRequirements:
+    """Per-interaction controls for the response Pollux asks the model to produce."""
+
+    output_schema: ResponseSchemaInput | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    seed: int | None = None
+    reasoning_effort: str | None = None
+    reasoning_budget_tokens: int | None = None
+    tool_choice: ToolChoice | None = None
+    #: Raw provider-scoped generation options keyed by provider name. Passed
+    #: through without normalization at the active provider boundary.
+    provider_options: dict[str, dict[str, Any]] | None = None
+
+    def __post_init__(self) -> None:
+        """Validate requirement shapes early for clear errors."""
+        if self.output_schema is not None and not (
+            isinstance(self.output_schema, dict)
+            or (
+                isinstance(self.output_schema, type)
+                and _is_base_model(self.output_schema)
+            )
+        ):
+            raise ConfigurationError(
+                "output_schema must be a Pydantic model class or JSON schema dict",
+                hint="Pass a BaseModel subclass or a dict following JSON Schema.",
+            )
+        if self.max_tokens is not None and (
+            isinstance(self.max_tokens, bool)
+            or not isinstance(self.max_tokens, int)
+            or self.max_tokens <= 0
+        ):
+            raise ConfigurationError(
+                "max_tokens must be a positive integer",
+                hint="Pass max_tokens=16384 or greater for thinking models.",
+            )
+        if self.reasoning_budget_tokens is not None and (
+            isinstance(self.reasoning_budget_tokens, bool)
+            or not isinstance(self.reasoning_budget_tokens, int)
+            or self.reasoning_budget_tokens < 0
+        ):
+            raise ConfigurationError(
+                "reasoning_budget_tokens must be a non-negative integer",
+                hint="Pass reasoning_budget_tokens=0 or a larger integer.",
+            )
+        if (
+            self.reasoning_effort is not None
+            and self.reasoning_budget_tokens is not None
+        ):
+            raise ConfigurationError(
+                "reasoning_effort and reasoning_budget_tokens are mutually exclusive",
+                hint="Choose either qualitative effort or an explicit token budget.",
+            )
+        if self.seed is not None and (
+            isinstance(self.seed, bool) or not isinstance(self.seed, int)
+        ):
+            raise ConfigurationError(
+                "seed must be an integer",
+                hint="Pass seed=42 for reproducible sampling where supported.",
+            )
+        if self.provider_options is not None:
+            _validate_provider_options(self.provider_options)
+
+    def output_schema_json(self) -> dict[str, Any] | None:
+        """Return JSON Schema for provider APIs."""
+        return response_schema_json(self.output_schema)
+
+    def output_schema_model(self) -> type[BaseModel] | None:
+        """Return the Pydantic model class when one was provided."""
+        return response_schema_model(self.output_schema)
+
+    def output_schema_hash(self) -> str | None:
+        """Return a stable hash of the JSON Schema."""
+        return response_schema_hash(self.output_schema)
+
+    def provider_options_for(self, provider: str) -> dict[str, Any] | None:
+        """Return raw generation options for the active provider."""
+        if self.provider_options is None:
+            return None
+        payload = self.provider_options.get(provider)
+        return dict(payload) if payload is not None else None
+
+
+def _is_base_model(candidate: type[Any]) -> bool:
+    """Return True when *candidate* is a Pydantic ``BaseModel`` subclass."""
+    from pydantic import BaseModel
+
+    return issubclass(candidate, BaseModel)
+
+
+def _validate_provider_options(
+    provider_options: dict[str, dict[str, Any]],
+) -> None:
+    """Validate the scoped provider-options escape hatch shape."""
+    if not isinstance(provider_options, dict):
+        raise ConfigurationError(
+            "provider_options must be a dictionary keyed by provider name",
+            hint="Pass provider_options={'openai': {'frequency_penalty': 0.5}}.",
+        )
+    supported = set(get_args(ProviderName))
+    for provider, payload in provider_options.items():
+        if provider not in supported:
+            allowed = ", ".join(sorted(supported))
+            raise ConfigurationError(
+                f"Unknown provider_options provider: {provider!r}",
+                hint=f"Use one of: {allowed}.",
+            )
+        if not isinstance(payload, dict):
+            raise ConfigurationError(
+                f"provider_options[{provider!r}] must be a dictionary",
+                hint="Pass raw provider parameters as a dictionary.",
+            )

--- a/src/pollux/interaction/tools.py
+++ b/src/pollux/interaction/tools.py
@@ -1,0 +1,139 @@
+"""Tool declaration, call, and result primitives for the v2 interaction model.
+
+These are provider-neutral. A :class:`ToolDeclaration` describes a function the
+model may request; a :class:`ToolCall` is a normalized request the model emitted;
+a :class:`ToolResult` is application-produced output for a prior call. None of
+them execute anything — applications own tool execution and policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import TYPE_CHECKING, Any
+
+from pollux.errors import ConfigurationError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+#: A parsed JSON value, as produced by :func:`json.loads`.
+JSONValue = dict[str, Any] | list[Any] | str | int | float | bool | None
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDeclaration:
+    """A provider-neutral description of a tool the model may request."""
+
+    name: str
+    description: str = ""
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ToolDeclaration:
+        """Build a declaration from a flat or OpenAI-style ``function`` dict."""
+        payload: Mapping[str, Any] = data
+        nested = data.get("function")
+        if isinstance(nested, dict):
+            payload = nested
+        name = payload.get("name")
+        if not isinstance(name, str) or not name:
+            raise ConfigurationError(
+                "tool declaration requires a non-empty 'name'",
+                hint="Pass {'name': 'get_weather', 'description': ..., "
+                "'parameters': {...}}.",
+            )
+        description = payload.get("description", "")
+        parameters = payload.get("parameters", {})
+        return cls(
+            name=name,
+            description=str(description) if description is not None else "",
+            parameters=dict(parameters) if isinstance(parameters, dict) else {},
+        )
+
+
+def _parse_arguments(arguments_text: str) -> tuple[JSONValue, str | None]:
+    """Parse a raw provider argument string once.
+
+    Returns the parsed value and ``None`` on success, or ``(None, message)``
+    when the text is not valid JSON. An empty string parses to ``None`` without
+    being treated as an error.
+    """
+    if arguments_text == "":
+        return None, None
+    try:
+        return json.loads(arguments_text), None
+    except (json.JSONDecodeError, ValueError) as exc:
+        return None, str(exc)
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCall:
+    """A normalized tool request emitted by the model.
+
+    ``arguments_text`` is the exact raw provider argument string (after any
+    stream fragments are assembled). ``arguments`` is the parsed JSON; when the
+    text is not valid JSON it is ``None`` and ``arguments_error`` explains why.
+    This preserves both convenience and recoverability.
+    """
+
+    id: str
+    name: str
+    arguments_text: str = ""
+    arguments: JSONValue = None
+    arguments_error: str | None = None
+    index: int | None = None
+    provider_state: dict[str, Any] | None = None
+
+    @classmethod
+    def from_text(
+        cls,
+        *,
+        id: str,  # noqa: A002 - mirrors the public ToolCall.id field name
+        name: str,
+        arguments_text: str = "",
+        index: int | None = None,
+        provider_state: dict[str, Any] | None = None,
+    ) -> ToolCall:
+        """Build a call from raw provider fields, parsing arguments once."""
+        arguments, arguments_error = _parse_arguments(arguments_text)
+        return cls(
+            id=id,
+            name=name,
+            arguments_text=arguments_text,
+            arguments=arguments,
+            arguments_error=arguments_error,
+            index=index,
+            provider_state=provider_state,
+        )
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize to a compact JSON-compatible dict (optional facets omitted)."""
+        payload: dict[str, Any] = {
+            "id": self.id,
+            "name": self.name,
+            "arguments_text": self.arguments_text,
+        }
+        if self.arguments_error is not None:
+            payload["arguments_error"] = self.arguments_error
+        if self.index is not None:
+            payload["index"] = self.index
+        if self.provider_state is not None:
+            payload["provider_state"] = self.provider_state
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ToolResult:
+    """Application-produced output returned to the model for a prior tool call."""
+
+    call_id: str
+    content: str
+    is_error: bool = False
+
+    def to_jsonable(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict."""
+        payload: dict[str, Any] = {"call_id": self.call_id, "content": self.content}
+        if self.is_error:
+            payload["is_error"] = True
+        return payload

--- a/tests/interaction/test_adapters_equivalence.py
+++ b/tests/interaction/test_adapters_equivalence.py
@@ -1,0 +1,110 @@
+"""Equivalence tests: v2 types losslessly represent today's pipeline output.
+
+These run the real mock-provider pipeline, then convert the resulting
+``ResultEnvelope`` through the transitional adapters and assert the v2 facets
+match. This is the proof backing the Slice 1 types before the provider boundary
+is migrated in Slice 2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import pollux
+from pollux.config import Config
+from pollux.interaction.adapters import (
+    collection_from_envelope,
+    output_from_envelope,
+)
+from pollux.providers.models import ProviderResponse, ToolCall
+from tests.conftest import GEMINI_MODEL
+from tests.helpers import ScriptedProvider
+
+pytestmark = pytest.mark.integration
+
+
+def _mock_cfg() -> Config:
+    return Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+
+
+@pytest.mark.asyncio
+async def test_single_output_matches_envelope(monkeypatch):
+    fake = ScriptedProvider(
+        script=[
+            ProviderResponse(
+                text="The answer.",
+                usage={"input_tokens": 3, "total_tokens": 8},
+                finish_reason="stop",
+            )
+        ]
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+
+    envelope = await pollux.run("What?", config=_mock_cfg())
+    output = output_from_envelope(envelope)
+
+    assert output.text == envelope["answers"][0]
+    assert output.usage.input_tokens == 3
+    assert output.usage.total_tokens == 8
+    assert output.metrics.finish_reason == "stop"
+    assert output.metrics.completion_status == "clean"
+
+    payload = output.to_jsonable()
+    assert "confidence" not in payload
+    assert "status" not in payload
+    assert "extraction_method" not in payload
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_and_continuation_survive_conversion(monkeypatch):
+    fake = ScriptedProvider(
+        script=[
+            ProviderResponse(
+                text="",
+                usage={"total_tokens": 2},
+                tool_calls=[
+                    ToolCall(id="call_1", name="get_weather", arguments='{"city": "P"}')
+                ],
+                response_id="resp_1",
+                finish_reason="tool_calls",
+            )
+        ]
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+
+    envelope = await pollux.run("Weather?", config=_mock_cfg())
+    output = output_from_envelope(envelope)
+
+    assert len(output.tool_calls) == 1
+    call = output.tool_calls[0]
+    assert call.id == "call_1"
+    assert call.name == "get_weather"
+    assert call.arguments == {"city": "P"}
+    assert call.arguments_error is None
+    assert output.metrics.completion_status == "clean"
+
+    assert output.continuation is not None
+    assert any(message.tool_calls for message in output.continuation.messages)
+
+
+@pytest.mark.asyncio
+async def test_collection_matches_envelope(monkeypatch):
+    fake = ScriptedProvider(
+        script=[
+            ProviderResponse(
+                text="A1", usage={"total_tokens": 1}, finish_reason="stop"
+            ),
+            ProviderResponse(
+                text="A2", usage={"total_tokens": 2}, finish_reason="stop"
+            ),
+        ]
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake)
+
+    envelope = await pollux.run_many(("Q1", "Q2"), config=_mock_cfg())
+    collection = collection_from_envelope(envelope)
+
+    assert collection.answers == envelope["answers"]
+    assert collection.status == envelope["status"]
+    assert len(collection.outputs) == 2
+    assert collection.usage.total_tokens == envelope["usage"]["total_tokens"]

--- a/tests/interaction/test_adapters_options.py
+++ b/tests/interaction/test_adapters_options.py
@@ -1,0 +1,91 @@
+"""Unit tests: v1 ``Options`` decomposes cleanly into the v2 split.
+
+The adapters here are transitional, but the decomposition they demonstrate is
+the load-bearing v2 reshaping of the ``Options`` kitchen-sink into ``Environment``
+/ ``Input`` / ``OutputRequirements``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pollux.continuation import ConversationState
+from pollux.interaction.adapters import (
+    continuation_from_state,
+    environment_from_options,
+    input_from_options,
+    requirements_from_options,
+    state_from_continuation,
+)
+from pollux.options import Options
+from pollux.source import Source
+
+if TYPE_CHECKING:
+    from pollux.result import ResultEnvelope
+
+pytestmark = pytest.mark.unit
+
+
+def test_requirements_projection():
+    opts = Options(temperature=0.0, max_tokens=512, tool_choice="auto", top_p=0.9)
+    req = requirements_from_options(opts)
+    assert req.temperature == 0.0
+    assert req.max_tokens == 512
+    assert req.top_p == 0.9
+    assert req.tool_choice == "auto"
+
+
+def test_environment_projection():
+    opts = Options(
+        system_instruction="sys",
+        tools=[{"name": "f", "description": "d", "parameters": {"type": "object"}}],
+    )
+    env = environment_from_options(opts, [Source.from_text("doc")])
+    assert env.instructions == "sys"
+    assert len(env.sources) == 1
+    assert env.tools[0].name == "f"
+
+
+def test_input_projection_with_plain_prompt():
+    inp = input_from_options(Options(), "the prompt")
+    assert inp.content == "the prompt"
+    assert inp.continuation is None
+    assert inp.history is None
+
+
+def test_input_projection_recovers_continuation():
+    state = ConversationState(
+        history=[{"role": "user", "content": "earlier"}],
+        response_id="r1",
+        provider="anthropic",
+    )
+    envelope: ResultEnvelope = {"_conversation_state": state.to_dict()}
+    inp = input_from_options(Options(continue_from=envelope), "next")
+    assert inp.continuation is not None
+    assert inp.continuation.response_id == "r1"
+
+
+def test_continuation_state_roundtrip_preserves_messages():
+    state = ConversationState(
+        history=[
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "1", "name": "f", "arguments": '{"a": 1}'}],
+            },
+        ],
+        response_id="r1",
+        provider="gemini",
+    )
+    cont = continuation_from_state(state)
+    assert cont.response_id == "r1"
+    assert cont.provider == "gemini"
+    assert cont.messages[1].tool_calls[0].name == "f"
+    assert cont.messages[1].tool_calls[0].arguments == {"a": 1}
+
+    back = state_from_continuation(cont)
+    assert back.history[0]["content"] == "hi"
+    assert back.history[1]["tool_calls"][0]["arguments"] == '{"a": 1}'

--- a/tests/interaction/test_collection.py
+++ b/tests/interaction/test_collection.py
@@ -1,0 +1,52 @@
+"""Unit tests for ``OutputCollection`` aggregation and status."""
+
+from __future__ import annotations
+
+import pytest
+
+from pollux.interaction.collection import OutputCollection
+from pollux.interaction.output import Output, Usage
+
+pytestmark = pytest.mark.unit
+
+
+def _output(text: str, total: int = 0) -> Output:
+    return Output(text=text, usage=Usage(total_tokens=total))
+
+
+def test_answers_and_structured_preserve_order():
+    coll = OutputCollection(
+        outputs=(
+            Output(text="a", structured={"v": 1}),
+            Output(text="b", structured={"v": 2}),
+        )
+    )
+    assert coll.answers == ["a", "b"]
+    assert coll.structured == [{"v": 1}, {"v": 2}]
+
+
+def test_usage_is_summed_across_outputs():
+    coll = OutputCollection(outputs=(_output("a", 3), _output("b", 5)))
+    assert coll.usage.total_tokens == 8
+
+
+@pytest.mark.parametrize(
+    ("texts", "expected"),
+    [
+        (["a", "b"], "ok"),
+        (["a", ""], "partial"),
+        (["", ""], "error"),
+        ([], "ok"),
+    ],
+)
+def test_status_reflects_answer_presence(texts, expected):
+    coll = OutputCollection(outputs=tuple(_output(t) for t in texts))
+    assert coll.status == expected
+
+
+def test_to_jsonable_includes_outputs_and_aggregates():
+    coll = OutputCollection(outputs=(_output("a", 1), _output("b", 2)))
+    payload = coll.to_jsonable()
+    assert payload["status"] == "ok"
+    assert [o["text"] for o in payload["outputs"]] == ["a", "b"]
+    assert payload["usage"]["total_tokens"] == 3

--- a/tests/interaction/test_continuation.py
+++ b/tests/interaction/test_continuation.py
@@ -1,0 +1,62 @@
+"""Unit tests for the v2 ``Continuation`` primitive."""
+
+from __future__ import annotations
+
+import pytest
+
+from pollux.errors import PolluxError
+from pollux.interaction.continuation import SCHEMA_VERSION, Continuation, Message
+from pollux.interaction.tools import ToolCall
+
+pytestmark = pytest.mark.unit
+
+
+def test_continuation_roundtrips_through_jsonable():
+    cont = Continuation(
+        messages=(
+            Message(role="user", content="hi"),
+            Message(
+                role="assistant",
+                content="",
+                tool_calls=(
+                    ToolCall.from_text(id="c1", name="f", arguments_text='{"a": 1}'),
+                ),
+            ),
+        ),
+        response_id="r1",
+        provider="anthropic",
+    )
+    restored = Continuation.from_jsonable(cont.to_jsonable())
+    assert restored.response_id == "r1"
+    assert restored.provider == "anthropic"
+    assert restored.messages[0].content == "hi"
+    assert restored.messages[1].tool_calls[0].name == "f"
+    assert restored.messages[1].tool_calls[0].arguments == {"a": 1}
+
+
+def test_continuation_stamps_current_schema_version():
+    assert Continuation().to_jsonable()["version"] == SCHEMA_VERSION
+
+
+def test_continuation_rejects_incompatible_version():
+    blob = Continuation(provider="mock").to_jsonable()
+    blob["version"] = SCHEMA_VERSION + 1
+    with pytest.raises(PolluxError, match="Incompatible continuation"):
+        Continuation.from_jsonable(blob)
+
+
+def test_continuation_rejects_missing_version():
+    with pytest.raises(PolluxError, match="Incompatible continuation"):
+        Continuation.from_jsonable({"messages": []})
+
+
+def test_continuation_rejects_provider_mismatch():
+    blob = Continuation(provider="anthropic").to_jsonable()
+    with pytest.raises(PolluxError, match="does not match"):
+        Continuation.from_jsonable(blob, expected_provider="openai")
+
+
+def test_continuation_accepts_matching_provider():
+    blob = Continuation(provider="openai").to_jsonable()
+    restored = Continuation.from_jsonable(blob, expected_provider="openai")
+    assert restored.provider == "openai"

--- a/tests/interaction/test_environment.py
+++ b/tests/interaction/test_environment.py
@@ -1,0 +1,62 @@
+"""Unit tests for ``Environment`` and ``EnvironmentSnapshot``."""
+
+from __future__ import annotations
+
+import pytest
+
+from pollux.interaction.environment import (
+    CachePolicy,
+    Environment,
+    EnvironmentSnapshot,
+)
+from pollux.interaction.tools import ToolDeclaration
+from pollux.source import Source
+
+pytestmark = pytest.mark.unit
+
+
+def test_environment_freezes_sequences_to_tuples():
+    env = Environment(
+        sources=[Source.from_text("a")],
+        tools=[ToolDeclaration(name="f", description="d")],
+    )
+    assert isinstance(env.sources, tuple)
+    assert isinstance(env.tools, tuple)
+    assert env.tools[0].name == "f"
+
+
+def test_environment_accepts_declaration_objects():
+    decl = ToolDeclaration(name="f", description="d")
+    env = Environment(tools=[decl])
+    assert env.tools[0] is decl
+
+
+def test_snapshot_fingerprint_is_stable():
+    env = Environment(instructions="sys", sources=(Source.from_text("doc"),))
+    snap_a = EnvironmentSnapshot.from_environment(env)
+    snap_b = EnvironmentSnapshot.from_environment(env)
+    assert snap_a.fingerprint() == snap_b.fingerprint()
+
+
+def test_snapshot_fingerprint_changes_with_instructions():
+    base = EnvironmentSnapshot.from_environment(Environment(instructions="a"))
+    other = EnvironmentSnapshot.from_environment(Environment(instructions="b"))
+    assert base.fingerprint() != other.fingerprint()
+
+
+def test_snapshot_fingerprint_changes_with_sources():
+    one = EnvironmentSnapshot.from_environment(
+        Environment(sources=(Source.from_text("x"),))
+    )
+    two = EnvironmentSnapshot.from_environment(
+        Environment(sources=(Source.from_text("y"),))
+    )
+    assert one.fingerprint() != two.fingerprint()
+
+
+def test_snapshot_fingerprint_changes_with_cache_policy():
+    none_cache = EnvironmentSnapshot.from_environment(Environment())
+    ttl_cache = EnvironmentSnapshot.from_environment(
+        Environment(cache=CachePolicy(ttl_seconds=3600))
+    )
+    assert none_cache.fingerprint() != ttl_cache.fingerprint()

--- a/tests/interaction/test_input.py
+++ b/tests/interaction/test_input.py
@@ -1,0 +1,51 @@
+"""Unit tests for the per-turn ``Input`` primitive."""
+
+from __future__ import annotations
+
+import pytest
+
+from pollux.errors import ConfigurationError
+from pollux.interaction.continuation import Continuation, Message
+from pollux.interaction.input import Input
+from pollux.interaction.tools import ToolResult
+
+pytestmark = pytest.mark.unit
+
+
+def test_plain_content_input():
+    inp = Input(content="hello")
+    assert inp.content == "hello"
+    assert inp.tool_results == ()
+
+
+def test_coerces_tool_results_to_tuple():
+    inp = Input(content="x", tool_results=[ToolResult(call_id="c1", content="ok")])
+    assert isinstance(inp.tool_results, tuple)
+
+
+def test_empty_content_valid_with_tool_results():
+    inp = Input(tool_results=[ToolResult(call_id="c1", content="ok")])
+    assert inp.content is None
+    assert len(inp.tool_results) == 1
+
+
+def test_rejects_empty_input():
+    with pytest.raises(ConfigurationError, match="no user content"):
+        Input()
+
+
+def test_rejects_history_and_continuation_together():
+    with pytest.raises(ConfigurationError, match="mutually exclusive"):
+        Input(
+            content="x",
+            history=(Message(role="user", content="prior"),),
+            continuation=Continuation(provider="mock"),
+        )
+
+
+def test_continuation_only_with_tool_results_is_valid():
+    inp = Input(
+        continuation=Continuation(provider="mock"),
+        tool_results=[ToolResult(call_id="c1", content="ok")],
+    )
+    assert inp.continuation is not None

--- a/tests/interaction/test_output.py
+++ b/tests/interaction/test_output.py
@@ -1,0 +1,77 @@
+"""Unit tests for ``Output`` and its facets."""
+
+from __future__ import annotations
+
+import pytest
+
+from pollux.interaction.output import (
+    Metrics,
+    Output,
+    Usage,
+    completion_status,
+)
+from pollux.interaction.tools import ToolCall
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("finish_reason", "error_category", "expected"),
+    [
+        ("stop", None, "clean"),
+        ("tool_calls", None, "clean"),
+        ("end_turn", None, "clean"),
+        (None, None, "clean"),
+        ("max_tokens", None, "truncated"),
+        ("length", None, "truncated"),
+        ("content_filter", None, "cutoff"),
+        ("safety", None, "cutoff"),
+        ("stop", "context_overflow", "truncated"),
+        ("stop", "rate_limit", "error"),
+        ("weird_unknown", None, "cutoff"),
+    ],
+)
+def test_completion_status_mapping(finish_reason, error_category, expected):
+    assert completion_status(finish_reason, error_category=error_category) == expected
+
+
+def test_usage_from_dict_ignores_unknown_keys():
+    usage = Usage.from_dict(
+        {"input_tokens": 3, "output_tokens": 5, "total_tokens": 8, "extra": 1}
+    )
+    assert usage.input_tokens == 3
+    assert usage.output_tokens == 5
+    assert usage.total_tokens == 8
+    assert usage.reasoning_tokens is None
+
+
+def test_usage_to_jsonable_omits_unset_optional_facets():
+    assert Usage(input_tokens=1, output_tokens=2, total_tokens=3).to_jsonable() == {
+        "input_tokens": 1,
+        "output_tokens": 2,
+        "total_tokens": 3,
+    }
+
+
+def test_output_to_jsonable_has_named_facets_without_v1_vestiges():
+    output = Output(
+        text="hi",
+        tool_calls=(ToolCall.from_text(id="c1", name="f", arguments_text="{}"),),
+        metrics=Metrics(finish_reason="stop", completion_status="clean"),
+    )
+    payload = output.to_jsonable()
+    assert payload["text"] == "hi"
+    assert payload["tool_calls"][0]["name"] == "f"
+    assert payload["metrics"]["completion_status"] == "clean"
+    assert "confidence" not in payload
+    assert "status" not in payload
+    assert "extraction_method" not in payload
+
+
+def test_output_omits_empty_optional_facets():
+    payload = Output(text="hi").to_jsonable()
+    assert "structured" not in payload
+    assert "reasoning" not in payload
+    assert "tool_calls" not in payload
+    assert "continuation" not in payload
+    assert "diagnostics" not in payload

--- a/tests/interaction/test_requirements.py
+++ b/tests/interaction/test_requirements.py
@@ -1,0 +1,64 @@
+"""Unit tests for ``OutputRequirements`` validation and schema helpers."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+import pytest
+
+from pollux.errors import ConfigurationError
+from pollux.interaction.requirements import OutputRequirements
+
+pytestmark = pytest.mark.unit
+
+
+class _Answer(BaseModel):
+    value: int
+
+
+def test_accepts_first_class_generation_controls():
+    req = OutputRequirements(temperature=0.0, top_p=0.9, max_tokens=512, seed=42)
+    assert req.temperature == 0.0
+    assert req.max_tokens == 512
+    assert req.seed == 42
+
+
+def test_rejects_non_positive_max_tokens():
+    with pytest.raises(ConfigurationError, match="max_tokens"):
+        OutputRequirements(max_tokens=0)
+
+
+def test_rejects_negative_reasoning_budget():
+    with pytest.raises(ConfigurationError, match="reasoning_budget_tokens"):
+        OutputRequirements(reasoning_budget_tokens=-1)
+
+
+def test_rejects_reasoning_effort_and_budget_together():
+    with pytest.raises(ConfigurationError, match="mutually exclusive"):
+        OutputRequirements(reasoning_effort="high", reasoning_budget_tokens=1024)
+
+
+def test_rejects_unknown_provider_options_provider():
+    with pytest.raises(ConfigurationError, match="Unknown provider_options"):
+        OutputRequirements(provider_options={"not_a_provider": {"k": "v"}})
+
+
+def test_provider_options_for_returns_scoped_copy():
+    req = OutputRequirements(provider_options={"openai": {"frequency_penalty": 0.5}})
+    assert req.provider_options_for("openai") == {"frequency_penalty": 0.5}
+    assert req.provider_options_for("anthropic") is None
+
+
+def test_schema_helpers_for_pydantic_model():
+    req = OutputRequirements(output_schema=_Answer)
+    assert req.output_schema_model() is _Answer
+    schema_json = req.output_schema_json()
+    assert schema_json is not None
+    assert schema_json["title"] == "_Answer"
+    assert req.output_schema_hash() is not None
+
+
+def test_schema_helpers_none_without_schema():
+    req = OutputRequirements()
+    assert req.output_schema_model() is None
+    assert req.output_schema_json() is None
+    assert req.output_schema_hash() is None

--- a/tests/interaction/test_tools.py
+++ b/tests/interaction/test_tools.py
@@ -1,0 +1,78 @@
+"""Unit tests for the v2 tool primitives."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from pollux.errors import ConfigurationError
+from pollux.interaction.tools import ToolCall, ToolDeclaration, ToolResult
+
+pytestmark = pytest.mark.unit
+
+
+def test_tool_call_parses_valid_json_once():
+    call = ToolCall.from_text(id="c1", name="f", arguments_text='{"city": "Paris"}')
+    assert call.arguments == {"city": "Paris"}
+    assert call.arguments_error is None
+    assert call.arguments_text == '{"city": "Paris"}'
+
+
+def test_tool_call_preserves_raw_text_on_invalid_json():
+    call = ToolCall.from_text(id="c1", name="f", arguments_text="{not json")
+    assert call.arguments is None
+    assert call.arguments_error is not None
+    assert call.arguments_text == "{not json"
+
+
+def test_tool_call_empty_arguments_is_not_an_error():
+    call = ToolCall.from_text(id="c1", name="f", arguments_text="")
+    assert call.arguments is None
+    assert call.arguments_error is None
+
+
+def test_tool_call_to_jsonable_omits_unset_facets():
+    call = ToolCall.from_text(id="c1", name="f", arguments_text='{"a": 1}')
+    payload = call.to_jsonable()
+    assert payload == {"id": "c1", "name": "f", "arguments_text": '{"a": 1}'}
+
+
+def test_tool_call_is_frozen():
+    call = ToolCall.from_text(id="c1", name="f")
+    with pytest.raises(FrozenInstanceError):
+        call.name = "g"  # type: ignore[misc]
+
+
+def test_tool_declaration_from_flat_dict():
+    decl = ToolDeclaration.from_dict(
+        {"name": "get_weather", "description": "d", "parameters": {"type": "object"}}
+    )
+    assert decl.name == "get_weather"
+    assert decl.description == "d"
+    assert decl.parameters == {"type": "object"}
+
+
+def test_tool_declaration_from_openai_function_dict():
+    decl = ToolDeclaration.from_dict(
+        {"type": "function", "function": {"name": "f", "description": "d"}}
+    )
+    assert decl.name == "f"
+    assert decl.description == "d"
+
+
+def test_tool_declaration_requires_name():
+    with pytest.raises(ConfigurationError):
+        ToolDeclaration.from_dict({"description": "no name"})
+
+
+def test_tool_result_to_jsonable():
+    assert ToolResult(call_id="c1", content="ok").to_jsonable() == {
+        "call_id": "c1",
+        "content": "ok",
+    }
+    assert ToolResult(call_id="c1", content="boom", is_error=True).to_jsonable() == {
+        "call_id": "c1",
+        "content": "boom",
+        "is_error": True,
+    }


### PR DESCRIPTION
## Summary

Land the canonical v2 interaction model as a standalone `src/pollux/interaction/` package - `Environment`/`Input`/`OutputRequirements` inputs and `Output`/`OutputCollection`/`Continuation` results, plus `ToolDeclaration`/`ToolCall`/`ToolResult`, all frozen dataclasses. This is Slice 1 of the v2 effort: it establishes the types without touching the live `run()`/`run_many()` pipeline, so `main` stays green.

Transitional `adapters.py` proves the new types losslessly represent today's `ResultEnvelope`/`ConversationState`/`Options`. The provider boundary is migrated onto these types - and the adapters deleted - in Slice 2.

Adopted simplifications vs. v1: dropped vestigial `confidence`/`extraction_method` and the single-result empty-answer `status` (replaced by `metrics.completion_status`); one rich lazy-parsing `ToolCall`; typed `Continuation`/`Message` replacing the stringly-typed history path.

## Related issue

None

## Test plan

`just check` passes (ruff format + lint, rumdl, mypy strict, 426 tests; 65 new under `tests/interaction/`, 19 api deselected). Coverage includes `ToolCall` valid/invalid/empty JSON parsing, `Continuation` round-trip + version/provider rejection, `completion_status` mapping across finish reasons and error categories, `OutputRequirements` validation, and `Environment` fingerprinting. The load-bearing equivalence tests run the real mock pipeline and assert `ResultEnvelope -> Output`/`OutputCollection` facet parity, including tool calls and continuation.

## Notes

Deliberate deviations from the v2 sketch, all defensible:
- `Event` is deferred to Slice 4 (streaming) - the adapters don't exercise it, so defining it now would park unused surface.
- Core `Environment.tools` requires `ToolDeclaration` objects; raw-dict coercion (`ToolDeclaration.from_dict`) belongs at the Slice 3 facade.
- User-constructed collection fields are typed `Sequence[...]` (frozen to tuples) so list literals typecheck under strict mypy; Pollux-produced types stay `tuple`.
- `ToolCall.arguments_error` is `str | None` (serializable) rather than `Exception | str | None`.

`adapters.py` is scaffolding and is removed in Slice 2.