### PR TITLE
feat(core): add v2 provider boundary and execution path

### DIFF
--- a/src/pollux/interaction/compile.py
+++ b/src/pollux/interaction/compile.py
@@ -1,0 +1,143 @@
+"""Compile v2 interaction primitives into a provider request.
+
+This is the v2 boundary's request-compilation step. It maps an immutable
+``EnvironmentSnapshot`` + per-turn ``Input`` + ``OutputRequirements`` into the
+provider transport's ``ProviderRequest``. Keeping ``ProviderRequest`` as the
+internal compile artifact lets the existing, battle-tested adapter translation be
+reused unchanged while core speaks the v2 model.
+
+File placeholders in ``parts`` are resolved to provider assets later, by the v2
+execution path's core-orchestrated upload step (see ``interaction/execute.py``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pollux.plan import build_shared_parts
+from pollux.providers.models import (
+    Message as ProviderMessage,
+)
+from pollux.providers.models import (
+    ProviderRequest,
+)
+from pollux.providers.models import (
+    ToolCall as ProviderToolCall,
+)
+
+if TYPE_CHECKING:
+    from pollux.config import Config
+    from pollux.interaction.continuation import Message
+    from pollux.interaction.environment import EnvironmentSnapshot
+    from pollux.interaction.input import Input
+    from pollux.interaction.requirements import OutputRequirements
+    from pollux.interaction.tools import ToolResult
+
+
+def _provider_message(message: Message) -> ProviderMessage:
+    """Translate a v2 replay ``Message`` into a transport ``Message``."""
+    tool_calls = [
+        ProviderToolCall(id=tc.id, name=tc.name, arguments=tc.arguments_text)
+        for tc in message.tool_calls
+    ] or None
+    return ProviderMessage(
+        role=message.role,
+        content=message.content,
+        tool_call_id=message.tool_call_id,
+        tool_calls=tool_calls,
+    )
+
+
+def _tool_result_message(tool_result: ToolResult) -> ProviderMessage:
+    """Represent an application tool result as a tool-role replay message."""
+    return ProviderMessage(
+        role="tool",
+        content=tool_result.content,
+        tool_call_id=tool_result.call_id,
+    )
+
+
+def _resolve_prior_turns(
+    input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+) -> tuple[list[ProviderMessage], str | None, dict[str, object] | None]:
+    """Resolve replay messages, response id, and provider state from an input.
+
+    Continuation and explicit history are alternative prior-state sources
+    (``Input`` already enforces they are not both set). Per-message provider
+    state is folded under a ``"history"`` key so the transport can replay opaque
+    blocks (e.g. reasoning) the same way the v1 path does.
+    """
+    prior: tuple[Message, ...] = ()
+    previous_response_id: str | None = None
+    provider_state: dict[str, object] | None = None
+
+    if input.continuation is not None:
+        prior = input.continuation.messages
+        previous_response_id = input.continuation.response_id
+        if input.continuation.provider_state is not None:
+            provider_state = dict(input.continuation.provider_state)
+    elif input.history is not None:
+        prior = tuple(input.history)
+
+    messages = [_provider_message(m) for m in prior]
+    item_states: list[dict[str, object] | None] = [
+        dict(m.provider_state) if m.provider_state is not None else None for m in prior
+    ]
+    messages.extend(_tool_result_message(tr) for tr in input.tool_results)
+
+    if any(state is not None for state in item_states):
+        provider_state = provider_state or {}
+        provider_state["history"] = item_states
+
+    return messages, previous_response_id, provider_state
+
+
+def compile_request(
+    snapshot: EnvironmentSnapshot,
+    input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+    requirements: OutputRequirements,
+    config: Config,
+    *,
+    cache_name: str | None = None,
+    implicit_caching: bool = False,
+) -> ProviderRequest:
+    """Compile v2 primitives into a ``ProviderRequest`` (file parts unresolved)."""
+    shared_parts = (
+        []
+        if cache_name is not None
+        else build_shared_parts(snapshot.sources, provider=config.provider)
+    )
+    parts = (
+        [*shared_parts, input.content] if input.content is not None else shared_parts
+    )
+
+    tools = [
+        {
+            "name": decl.name,
+            "description": decl.description,
+            "parameters": decl.parameters,
+        }
+        for decl in snapshot.tools
+    ] or None
+
+    history, previous_response_id, provider_state = _resolve_prior_turns(input)
+
+    return ProviderRequest(
+        model=config.model,
+        parts=parts,
+        system_instruction=snapshot.instructions,
+        cache_name=cache_name,
+        response_schema=requirements.output_schema_json(),
+        temperature=requirements.temperature,
+        top_p=requirements.top_p,
+        tools=tools,
+        tool_choice=requirements.tool_choice,
+        reasoning_effort=requirements.reasoning_effort,
+        reasoning_budget_tokens=requirements.reasoning_budget_tokens,
+        history=history or None,
+        previous_response_id=previous_response_id,
+        provider_state=provider_state,
+        max_tokens=requirements.max_tokens,
+        implicit_caching=implicit_caching,
+        provider_options=requirements.provider_options_for(config.provider),
+    )

--- a/src/pollux/interaction/execute.py
+++ b/src/pollux/interaction/execute.py
@@ -1,0 +1,229 @@
+"""The v2 execution path: run interactions and assemble ``Output``.
+
+This is the v2 sibling of ``execute.execute_plan``. It owns the core-side
+orchestration concerns (capability validation, core-orchestrated file uploads
+with single-flight dedup, concurrency, and retry), calls the unchanged provider
+transport (``provider.generate``), and assembles immutable ``Output`` /
+``OutputCollection`` results. The provider request compilation and response
+extraction live in ``interaction/compile.py`` and ``interaction/extract.py``.
+
+The v1 ``run()``/``run_many()`` pipeline is untouched; this path is exercised by
+the v2 frontdoors (``interact()``/``run()``) in Slice 3.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+import time
+from typing import TYPE_CHECKING
+
+from pollux.continuation import build_conversation_state, history_text_from_parts
+from pollux.errors import APIError, InternalError, PolluxError
+from pollux.execute import (
+    _cleanup_uploads,
+    _substitute_upload_parts,
+    _validate_provider_request,
+)
+from pollux.interaction.adapters import continuation_from_state, state_from_continuation
+from pollux.interaction.collection import OutputCollection
+from pollux.interaction.compile import compile_request
+from pollux.interaction.continuation import Continuation
+from pollux.interaction.environment import EnvironmentSnapshot
+from pollux.interaction.extract import provider_response_to_output
+from pollux.interaction.validate import validate_interaction
+from pollux.providers.models import ProviderResponse
+from pollux.retry import retry_async, should_retry_generate
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any
+
+    from pollux.config import Config
+    from pollux.interaction.environment import Environment
+    from pollux.interaction.input import Input
+    from pollux.interaction.output import Output
+    from pollux.interaction.requirements import OutputRequirements
+    from pollux.providers.base import Provider
+    from pollux.providers.models import ProviderFileAsset
+
+
+def _prior_history_dicts(input: Input) -> list[dict[str, Any]]:  # noqa: A002
+    """Reconstruct the prior-turn history dicts that precede this interaction."""
+    if input.continuation is not None:
+        dicts = list(state_from_continuation(input.continuation).history)
+    elif input.history is not None:
+        dicts = list(
+            state_from_continuation(Continuation(messages=tuple(input.history))).history
+        )
+    else:
+        dicts = []
+    dicts.extend(
+        {"role": "tool", "content": tr.content, "tool_call_id": tr.call_id}
+        for tr in input.tool_results
+    )
+    return dicts
+
+
+def _build_continuation(
+    input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+    response: ProviderResponse,
+    user_content: str | None,
+    provider: str,
+) -> Continuation | None:
+    """Assemble the next-turn continuation for one interaction, or ``None``."""
+    state = build_conversation_state(
+        [response],
+        first_prompt=input.content,
+        first_user_content=user_content,
+        conversation_history=_prior_history_dicts(input),
+        previous_response_id=input.continuation.response_id
+        if input.continuation is not None
+        else None,
+        wants_conversation=input.continuation is not None or input.history is not None,
+        provider=provider,
+    )
+    return continuation_from_state(state) if state is not None else None
+
+
+async def execute_interactions(
+    environment: Environment,
+    inputs: Sequence[Input],
+    requirements: OutputRequirements,
+    config: Config,
+    provider: Provider,
+) -> OutputCollection:
+    """Execute one interaction per input over a shared environment.
+
+    Handles capability validation, core-orchestrated uploads (single-flight
+    dedup), concurrency, and retry, then assembles per-interaction ``Output``s.
+    """
+    start_time = time.perf_counter()
+    inputs = tuple(inputs)
+    snapshot = EnvironmentSnapshot.from_environment(
+        environment, provider=config.provider
+    )
+    caps = provider.capabilities
+    validate_interaction(requirements, inputs, snapshot, caps, cache_requested=False)
+
+    implicit_caching = caps.implicit_caching and len(inputs) == 1
+    cache_mode = "implicit" if implicit_caching else "none"
+
+    upload_cache: dict[tuple[str, str], ProviderFileAsset] = {}
+    upload_inflight: dict[tuple[str, str], asyncio.Future[ProviderFileAsset]] = {}
+    upload_lock = asyncio.Lock()
+    retry_policy = config.retry
+    sem = asyncio.Semaphore(config.request_concurrency)
+    user_contents: list[str | None] = [None] * len(inputs)
+
+    async def _execute_call(call_idx: int) -> ProviderResponse:
+        async with sem:
+            try:
+                req = compile_request(
+                    snapshot,
+                    inputs[call_idx],
+                    requirements,
+                    config,
+                    implicit_caching=implicit_caching,
+                )
+                user_contents[call_idx] = history_text_from_parts(req.parts)
+                await _validate_provider_request(provider, req)
+                parts = await _substitute_upload_parts(
+                    req.parts,
+                    provider=provider,
+                    call_idx=call_idx,
+                    upload_cache=upload_cache,
+                    upload_inflight=upload_inflight,
+                    upload_lock=upload_lock,
+                    retry_policy=retry_policy,
+                )
+                req = replace(req, parts=parts)
+
+                if retry_policy.max_attempts <= 1:
+                    return await provider.generate(req)
+                return await retry_async(
+                    lambda: provider.generate(req),
+                    policy=retry_policy,
+                    should_retry=should_retry_generate,
+                )
+            except asyncio.CancelledError:
+                raise
+            except APIError as exc:
+                if exc.call_idx is None:
+                    exc.call_idx = call_idx
+                raise
+            except PolluxError:
+                raise
+            except Exception as exc:
+                from pollux.providers._errors import wrap_provider_error
+
+                provider_name = type(provider).__name__.lower().replace("provider", "")
+                wrapped = wrap_provider_error(
+                    exc,
+                    provider=provider_name,
+                    phase="generate",
+                    allow_network_errors=True,
+                    message=f"{provider_name.capitalize()} generate failed",
+                )
+                if getattr(wrapped, "call_idx", None) is None:
+                    wrapped.call_idx = call_idx
+                raise wrapped from exc
+
+    responses: list[ProviderResponse] = []
+    try:
+        tasks = [asyncio.create_task(_execute_call(i)) for i in range(len(inputs))]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # Collect all outcomes before raising so a failure never leaves a
+        # background task with an unobserved exception. Raise the lowest-index
+        # failure for deterministic attribution.
+        for item in results:
+            if isinstance(item, BaseException):
+                raise item
+            if not isinstance(item, ProviderResponse):
+                raise InternalError(
+                    f"Provider returned invalid response type: {type(item).__name__}",
+                    hint="Providers must return a ProviderResponse.",
+                )
+            responses.append(item)
+    finally:
+        await _cleanup_uploads(upload_cache, provider)
+
+    duration_s = time.perf_counter() - start_time
+
+    outputs: list[Output] = []
+    for idx, response in enumerate(responses):
+        cached = response.usage.get("cached_tokens", 0)
+        cache_hit = cache_mode == "implicit" and isinstance(cached, int) and cached > 0
+        continuation = _build_continuation(
+            inputs[idx], response, user_contents[idx], config.provider
+        )
+        outputs.append(
+            provider_response_to_output(
+                response,
+                requirements=requirements,
+                duration_s=duration_s,
+                cache_used=False,
+                cache_mode=cache_mode,
+                cache_hit=cache_hit,
+                continuation=continuation,
+            )
+        )
+
+    return OutputCollection(
+        outputs=tuple(outputs),
+        prompt_indexes=tuple(range(len(inputs))),
+    )
+
+
+async def execute_interaction(
+    environment: Environment,
+    input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+    requirements: OutputRequirements,
+    config: Config,
+    provider: Provider,
+) -> Output:
+    """Execute a single interaction and return its ``Output``."""
+    collection = await execute_interactions(
+        environment, [input], requirements, config, provider
+    )
+    return collection.outputs[0]

--- a/src/pollux/interaction/extract.py
+++ b/src/pollux/interaction/extract.py
@@ -1,0 +1,95 @@
+"""Extract a v2 ``Output`` from a provider transport response.
+
+This is the v2 boundary's extraction step: it turns a ``ProviderResponse`` into
+the immutable ``Output`` facets (text, structured, reasoning, tool calls, usage,
+metrics, diagnostics). Continuation is assembled by the execution path and passed
+in, since it depends on the request's prior turns.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from pollux.interaction.output import (
+    Diagnostics,
+    Metrics,
+    Output,
+    Usage,
+    completion_status,
+)
+from pollux.interaction.tools import ToolCall
+from pollux.providers.models import provider_response_to_dict
+
+if TYPE_CHECKING:
+    from pollux.interaction.continuation import Continuation
+    from pollux.interaction.requirements import OutputRequirements
+    from pollux.providers.models import ProviderResponse
+
+
+def _structured_payload(response: ProviderResponse) -> Any:
+    """Return the structured payload from a response, parsing text JSON if needed."""
+    if response.structured is not None:
+        return response.structured
+    if response.text:
+        try:
+            return json.loads(response.text)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    return None
+
+
+def _extract_structured(
+    response: ProviderResponse, requirements: OutputRequirements
+) -> Any:
+    """Extract and (when a model class was requested) validate the structured value."""
+    if requirements.output_schema is None:
+        return None
+    raw = _structured_payload(response)
+    model = requirements.output_schema_model()
+    if raw is None or model is None:
+        return raw
+    try:
+        return model.model_validate(raw)
+    except Exception:
+        return None
+
+
+def provider_response_to_output(
+    response: ProviderResponse,
+    *,
+    requirements: OutputRequirements,
+    duration_s: float,
+    n_calls: int = 1,
+    cache_used: bool = False,
+    cache_mode: str = "none",
+    cache_hit: bool = False,
+    continuation: Continuation | None = None,
+    error_category: str | None = None,
+) -> Output:
+    """Assemble an :class:`Output` from a ``ProviderResponse`` and execution metrics."""
+    tool_calls = tuple(
+        ToolCall.from_text(id=tc.id, name=tc.name, arguments_text=tc.arguments)
+        for tc in (response.tool_calls or [])
+    )
+    metrics = Metrics(
+        duration_s=duration_s,
+        n_calls=n_calls,
+        cache_used=cache_used,
+        cache_mode=cache_mode,
+        cache_hit=cache_hit,
+        finish_reason=response.finish_reason,
+        completion_status=completion_status(
+            response.finish_reason, error_category=error_category
+        ),
+    )
+    return Output(
+        text=response.text,
+        structured=_extract_structured(response, requirements),
+        reasoning=response.reasoning,
+        tool_calls=tool_calls,
+        continuation=continuation,
+        usage=Usage.from_dict(response.usage),
+        metrics=metrics,
+        diagnostics=Diagnostics(raw={"response": provider_response_to_dict(response)}),
+    )

--- a/src/pollux/interaction/validate.py
+++ b/src/pollux/interaction/validate.py
@@ -1,0 +1,99 @@
+"""Validate a planned v2 interaction against provider capabilities.
+
+The v2 sibling of ``capabilities.validate_capabilities``: it reads the v2
+primitives (``OutputRequirements`` / ``Input`` / ``EnvironmentSnapshot``) instead
+of ``Options`` and rejects requested features the provider cannot serve before any
+network I/O. Fine-grained capabilities still use the ``ProviderCapabilities``
+booleans; the structural-protocol decomposition is a later Slice 2 sub-PR.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pollux.errors import ConfigurationError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pollux.interaction.environment import EnvironmentSnapshot
+    from pollux.interaction.input import Input
+    from pollux.interaction.requirements import OutputRequirements
+    from pollux.providers.base import ProviderCapabilities
+
+
+def _wants_conversation(inputs: Sequence[Input]) -> bool:
+    """Whether any input continues a prior turn via continuation or history."""
+    return any(
+        inp.continuation is not None or inp.history is not None for inp in inputs
+    )
+
+
+def validate_interaction(
+    requirements: OutputRequirements,
+    inputs: Sequence[Input],
+    snapshot: EnvironmentSnapshot,
+    caps: ProviderCapabilities,
+    *,
+    cache_requested: bool,
+) -> None:
+    """Reject requested features the provider does not support.
+
+    Raises:
+        ConfigurationError: If a requested feature is unsupported. Order is
+            preserved so callers see a deterministic first failure.
+    """
+    wants_conversation = _wants_conversation(inputs)
+
+    uniform_checks: tuple[tuple[bool, bool, str, str], ...] = (
+        (
+            requirements.output_schema is not None,
+            caps.structured_outputs,
+            "Provider does not support structured outputs",
+            "Remove output_schema or choose a provider with schema support.",
+        ),
+        (
+            requirements.reasoning_effort is not None,
+            caps.reasoning,
+            "Provider does not support reasoning controls",
+            "Remove reasoning_effort or choose a provider with reasoning controls.",
+        ),
+        (
+            requirements.reasoning_budget_tokens is not None,
+            caps.reasoning_budget_tokens,
+            "Provider does not support reasoning_budget_tokens",
+            "Use reasoning_effort, or choose a provider that accepts an explicit "
+            "reasoning token budget.",
+        ),
+        (
+            wants_conversation,
+            caps.conversation,
+            "Provider does not support conversation continuity",
+            "Remove continuation/history or choose a provider with conversation "
+            "support.",
+        ),
+    )
+    for requested, supported, message, hint in uniform_checks:
+        if requested and not supported:
+            raise ConfigurationError(message, hint=hint)
+
+    if wants_conversation and len(inputs) != 1:
+        raise ConfigurationError(
+            "Conversation continuity currently supports exactly one input per call",
+            hint="Continue from a single input when passing continuation/history.",
+        )
+
+    if cache_requested and not caps.persistent_cache:
+        raise ConfigurationError(
+            "Provider does not support persistent caching",
+            hint="Remove the cache policy or choose a provider with "
+            "persistent_cache support.",
+        )
+
+    has_file_sources = any(source.source_type == "file" for source in snapshot.sources)
+    if has_file_sources and not caps.uploads:
+        raise ConfigurationError(
+            "Provider does not support file or multimodal input",
+            hint=caps.file_rejection_hint
+            or "Choose a provider with uploads support, or remove file sources.",
+        )

--- a/tests/interaction/test_compile.py
+++ b/tests/interaction/test_compile.py
@@ -1,0 +1,127 @@
+"""Unit tests for v2 primitive -> ProviderRequest compilation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pollux.config import Config
+from pollux.interaction.compile import compile_request
+from pollux.interaction.continuation import Continuation, Message
+from pollux.interaction.environment import Environment, EnvironmentSnapshot
+from pollux.interaction.input import Input
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.tools import ToolCall, ToolDeclaration, ToolResult
+from pollux.source import Source
+from tests.conftest import ANTHROPIC_MODEL
+
+pytestmark = pytest.mark.unit
+
+
+def _cfg() -> Config:
+    return Config(provider="anthropic", model=ANTHROPIC_MODEL, use_mock=True)
+
+
+def _snapshot(**kwargs: Any) -> EnvironmentSnapshot:
+    return EnvironmentSnapshot.from_environment(
+        Environment(**kwargs), provider="anthropic"
+    )
+
+
+def test_maps_environment_and_requirements():
+    snapshot = _snapshot(
+        instructions="sys",
+        sources=[Source.from_text("DOC")],
+        tools=[
+            ToolDeclaration(name="f", description="d", parameters={"type": "object"})
+        ],
+    )
+    req = compile_request(
+        snapshot,
+        Input(content="hi"),
+        OutputRequirements(temperature=0.0, max_tokens=128),
+        _cfg(),
+    )
+    assert req.model == ANTHROPIC_MODEL
+    assert req.system_instruction == "sys"
+    assert req.parts[-1] == "hi"
+    assert "DOC" in req.parts
+    assert req.tools == [
+        {"name": "f", "description": "d", "parameters": {"type": "object"}}
+    ]
+    assert req.temperature == 0.0
+    assert req.max_tokens == 128
+
+
+def test_cache_name_excludes_source_parts():
+    snapshot = _snapshot(sources=[Source.from_text("DOC")])
+    req = compile_request(
+        snapshot,
+        Input(content="hi"),
+        OutputRequirements(),
+        _cfg(),
+        cache_name="caches/x",
+    )
+    assert req.cache_name == "caches/x"
+    assert req.parts == ["hi"]
+
+
+def test_continuation_maps_to_history_and_response_id():
+    cont = Continuation(
+        messages=(
+            Message(role="user", content="earlier"),
+            Message(role="assistant", content="prior"),
+        ),
+        response_id="r1",
+        provider="anthropic",
+        provider_state={"k": "v"},
+    )
+    req = compile_request(
+        _snapshot(),
+        Input(content="next", continuation=cont),
+        OutputRequirements(),
+        _cfg(),
+    )
+    assert req.previous_response_id == "r1"
+    assert req.provider_state == {"k": "v"}
+    assert req.history is not None
+    assert [m.role for m in req.history] == ["user", "assistant"]
+
+
+def test_tool_results_become_tool_messages():
+    cont = Continuation(
+        messages=(
+            Message(
+                role="assistant",
+                content="",
+                tool_calls=(
+                    ToolCall.from_text(id="c1", name="f", arguments_text="{}"),
+                ),
+            ),
+        ),
+        response_id="r1",
+    )
+    req = compile_request(
+        _snapshot(),
+        Input(continuation=cont, tool_results=[ToolResult(call_id="c1", content="42")]),
+        OutputRequirements(),
+        _cfg(),
+    )
+    assert req.history is not None
+    tool_messages = [m for m in req.history if m.role == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "42"
+    assert tool_messages[0].tool_call_id == "c1"
+
+
+def test_provider_options_scoped_to_active_provider():
+    req = compile_request(
+        _snapshot(),
+        Input(content="hi"),
+        OutputRequirements(
+            provider_options={"anthropic": {"beta": ["x"]}, "openai": {"y": 1}}
+        ),
+        _cfg(),
+    )
+    assert req.provider_options == {"beta": ["x"]}

--- a/tests/interaction/test_execute_interaction.py
+++ b/tests/interaction/test_execute_interaction.py
@@ -1,0 +1,115 @@
+"""Integration tests for the v2 execution path.
+
+These run the v2 `execute_interaction(s)` path through provider doubles and assert
+it produces `Output`/`OutputCollection` natively, with parity to the v1 `run()`
+pipeline for the same scripted provider.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import pollux
+from pollux.config import Config
+from pollux.interaction.adapters import output_from_envelope
+from pollux.interaction.environment import Environment
+from pollux.interaction.execute import execute_interaction, execute_interactions
+from pollux.interaction.input import Input
+from pollux.interaction.requirements import OutputRequirements
+from pollux.providers.models import ProviderResponse, ToolCall
+from tests.conftest import ANTHROPIC_MODEL, FakeProvider
+from tests.helpers import ScriptedProvider
+
+pytestmark = pytest.mark.integration
+
+
+def _cfg() -> Config:
+    return Config(provider="anthropic", model=ANTHROPIC_MODEL, use_mock=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_interaction_produces_output():
+    provider = ScriptedProvider(
+        script=[
+            ProviderResponse(
+                text="The answer.",
+                usage={"input_tokens": 3, "total_tokens": 8},
+                finish_reason="stop",
+            )
+        ]
+    )
+    out = await execute_interaction(
+        Environment(instructions="sys"),
+        Input(content="Q"),
+        OutputRequirements(),
+        _cfg(),
+        provider,
+    )
+    assert out.text == "The answer."
+    assert out.usage.total_tokens == 8
+    assert out.metrics.completion_status == "clean"
+
+
+@pytest.mark.asyncio
+async def test_v2_output_matches_v1_envelope(monkeypatch):
+    script = [
+        ProviderResponse(
+            text="The answer.",
+            usage={"input_tokens": 3, "total_tokens": 8},
+            finish_reason="stop",
+        )
+    ]
+    fake_v1 = ScriptedProvider(script=list(script))
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: fake_v1)
+    envelope = await pollux.run("Q", config=_cfg())
+    expected = output_from_envelope(envelope)
+
+    fake_v2 = ScriptedProvider(script=list(script))
+    out = await execute_interaction(
+        Environment(), Input(content="Q"), OutputRequirements(), _cfg(), fake_v2
+    )
+
+    assert out.text == expected.text
+    assert out.usage.to_jsonable() == expected.usage.to_jsonable()
+    assert out.metrics.finish_reason == expected.metrics.finish_reason
+    assert out.metrics.completion_status == expected.metrics.completion_status
+
+
+@pytest.mark.asyncio
+async def test_tool_calls_and_continuation():
+    provider = ScriptedProvider(
+        script=[
+            ProviderResponse(
+                text="",
+                usage={"total_tokens": 2},
+                tool_calls=[
+                    ToolCall(id="c1", name="get_weather", arguments='{"city": "P"}')
+                ],
+                response_id="r1",
+                finish_reason="tool_calls",
+            )
+        ]
+    )
+    out = await execute_interaction(
+        Environment(), Input(content="Weather?"), OutputRequirements(), _cfg(), provider
+    )
+    assert out.tool_calls[0].name == "get_weather"
+    assert out.tool_calls[0].arguments == {"city": "P"}
+    assert out.metrics.completion_status == "clean"
+    assert out.continuation is not None
+    assert any(message.tool_calls for message in out.continuation.messages)
+
+
+@pytest.mark.asyncio
+async def test_execute_interactions_collection():
+    provider = FakeProvider()
+    collection = await execute_interactions(
+        Environment(),
+        [Input(content="Q1"), Input(content="Q2")],
+        OutputRequirements(),
+        _cfg(),
+        provider,
+    )
+    assert collection.answers == ["ok:Q1", "ok:Q2"]
+    assert collection.status == "ok"
+    assert len(collection.outputs) == 2

--- a/tests/interaction/test_extract.py
+++ b/tests/interaction/test_extract.py
@@ -1,0 +1,71 @@
+"""Unit tests for ProviderResponse -> Output extraction."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+import pytest
+
+from pollux.interaction.extract import provider_response_to_output
+from pollux.interaction.requirements import OutputRequirements
+from pollux.providers.models import ProviderResponse, ToolCall
+
+pytestmark = pytest.mark.unit
+
+
+class _Answer(BaseModel):
+    value: int
+
+
+def test_maps_response_facets():
+    resp = ProviderResponse(
+        text="hi",
+        usage={"input_tokens": 3, "total_tokens": 8},
+        reasoning="because",
+        tool_calls=[ToolCall(id="c1", name="f", arguments='{"a": 1}')],
+        finish_reason="stop",
+    )
+    out = provider_response_to_output(
+        resp, requirements=OutputRequirements(), duration_s=1.0
+    )
+    assert out.text == "hi"
+    assert out.reasoning == "because"
+    assert out.tool_calls[0].name == "f"
+    assert out.tool_calls[0].arguments == {"a": 1}
+    assert out.usage.input_tokens == 3
+    assert out.metrics.finish_reason == "stop"
+    assert out.metrics.completion_status == "clean"
+    assert out.diagnostics.raw is not None
+    assert "response" in out.diagnostics.raw
+
+
+def test_truncated_completion_status_from_finish_reason():
+    resp = ProviderResponse(text="...", usage={}, finish_reason="max_tokens")
+    out = provider_response_to_output(
+        resp, requirements=OutputRequirements(), duration_s=0.0
+    )
+    assert out.metrics.completion_status == "truncated"
+
+
+def test_structured_validates_against_model():
+    resp = ProviderResponse(text="", usage={}, structured={"value": 7})
+    out = provider_response_to_output(
+        resp, requirements=OutputRequirements(output_schema=_Answer), duration_s=0.0
+    )
+    assert isinstance(out.structured, _Answer)
+    assert out.structured.value == 7
+
+
+def test_structured_from_text_json_fallback():
+    resp = ProviderResponse(text='{"value": 9}', usage={})
+    out = provider_response_to_output(
+        resp, requirements=OutputRequirements(output_schema=_Answer), duration_s=0.0
+    )
+    assert out.structured.value == 9
+
+
+def test_no_structured_without_schema():
+    resp = ProviderResponse(text='{"value": 1}', usage={})
+    out = provider_response_to_output(
+        resp, requirements=OutputRequirements(), duration_s=0.0
+    )
+    assert out.structured is None


### PR DESCRIPTION
## Summary

Slice 2b of the v2 effort: add the v2 provider boundary as **additive** core machinery under `src/pollux/interaction/`, so a real interaction flows `EnvironmentSnapshot + Input + OutputRequirements + Config -> Output`. The v1 `run()`/`run_many()` pipeline is untouched and stays green; the v2 frontdoors wire onto this path in Slice 3.

- `compile.py` - `compile_request(...)` maps v2 primitives to the transport `ProviderRequest` (extracted from the construction previously inline in `execute.py`).
- `extract.py` - `provider_response_to_output(...)` maps `ProviderResponse` facets to immutable `Output`.
- `validate.py` - v2 capability validation off the new primitives (v2 sibling of `capabilities.validate_capabilities`).
- `execute.py` - `execute_interaction` / `execute_interactions`: the v2 orchestration loop, reusing the already-standalone `execute._substitute_upload_parts` / `_cleanup_uploads` / `_validate_provider_request`, `retry.retry_async`, and `continuation.build_conversation_state`.

## Related issue

None

## Test plan

`just check` passes (ruff, rumdl, mypy strict, 440 tests; 14 new). New coverage: primitive→`ProviderRequest` mapping (sources/instructions/tools/requirements, cache exclusion, continuation→`previous_response_id`+history, tool results→tool messages, scoped provider options); `ProviderResponse`→`Output` extraction (facets, structured validation, completion status); and integration tests that the v2 `execute_interaction(s)` path produces `Output`/`OutputCollection` natively with **parity to v1 `run()`** for the same scripted provider, including tool calls + continuation and a fan-out collection.

## Notes

None