### PR TITLE
feat(core): add v2 capability resolution and Config declarations

### DIFF
--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import os
-from typing import Literal, get_args
+from typing import TYPE_CHECKING, Literal, get_args
 
 import dotenv
 
 from pollux.errors import ConfigurationError
 from pollux.retry import RetryPolicy
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 ProviderName = Literal["gemini", "openai", "anthropic", "openrouter", "local"]
 
@@ -74,6 +77,11 @@ class Config:
     use_mock: bool = False
     request_concurrency: int = 6
     retry: RetryPolicy = field(default_factory=RetryPolicy)
+    #: Optional capability declarations that override the provider's static
+    #: capabilities for this config (v2 interaction path). A declared capability
+    #: wins over the provider's static value; undeclared capabilities fall back to
+    #: it. Useful for local OpenAI-compatible servers whose support varies.
+    capabilities: Mapping[str, bool] | None = None
 
     def __post_init__(self) -> None:
         """Auto-resolve credentials and validate configuration."""

--- a/src/pollux/interaction/capabilities.py
+++ b/src/pollux/interaction/capabilities.py
@@ -1,0 +1,67 @@
+"""Resolve effective provider capabilities for the v2 interaction path.
+
+A provider exposes static capabilities. A ``Config`` may additionally declare
+capability overrides — to cap support a provider claims, or to assert support a
+provider's static block omits (the local OpenAI-compatible server case). When the
+two disagree, the user's declaration wins; undeclared capabilities fall back to
+the provider's static value. The structural-protocol decomposition of capabilities
+arrives with the Slice 3 boundary restructure; this is the additive seam.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from pollux.errors import ConfigurationError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+    from pollux.providers.base import ProviderCapabilities
+
+#: Boolean capability fields a ``Config`` may declare. These mirror the boolean
+#: fields of ``ProviderCapabilities``.
+DECLARABLE_CAPABILITIES = (
+    "persistent_cache",
+    "uploads",
+    "structured_outputs",
+    "reasoning",
+    "reasoning_budget_tokens",
+    "deferred_delivery",
+    "conversation",
+    "implicit_caching",
+)
+
+
+def resolve_capabilities(
+    static: ProviderCapabilities,
+    declared: Mapping[str, bool] | None,
+) -> ProviderCapabilities:
+    """Return the effective capabilities, applying ``Config`` declarations.
+
+    Raises:
+        ConfigurationError: If a declared capability name is unknown or its value
+            is not a boolean. Raised before any network I/O.
+    """
+    if not declared:
+        return static
+
+    # Typed Any so dataclasses.replace accepts the splat across mixed field types.
+    overrides: dict[str, Any] = {}
+    for name, value in declared.items():
+        if name not in DECLARABLE_CAPABILITIES:
+            allowed = ", ".join(DECLARABLE_CAPABILITIES)
+            raise ConfigurationError(
+                f"Unknown capability declaration: {name!r}",
+                hint=f"Declarable capabilities are: {allowed}.",
+            )
+        if not isinstance(value, bool):
+            raise ConfigurationError(
+                f"Capability declaration {name!r} must be a boolean",
+                hint="Pass capabilities={'structured_outputs': True}.",
+            )
+        overrides[name] = value
+
+    return replace(static, **overrides)

--- a/src/pollux/interaction/execute.py
+++ b/src/pollux/interaction/execute.py
@@ -26,6 +26,7 @@ from pollux.execute import (
     _validate_provider_request,
 )
 from pollux.interaction.adapters import continuation_from_state, state_from_continuation
+from pollux.interaction.capabilities import resolve_capabilities
 from pollux.interaction.collection import OutputCollection
 from pollux.interaction.compile import compile_request
 from pollux.interaction.continuation import Continuation
@@ -103,7 +104,7 @@ async def execute_interactions(
     snapshot = EnvironmentSnapshot.from_environment(
         environment, provider=config.provider
     )
-    caps = provider.capabilities
+    caps = resolve_capabilities(provider.capabilities, config.capabilities)
     validate_interaction(requirements, inputs, snapshot, caps, cache_requested=False)
 
     implicit_caching = caps.implicit_caching and len(inputs) == 1

--- a/tests/interaction/test_capabilities.py
+++ b/tests/interaction/test_capabilities.py
@@ -1,0 +1,57 @@
+"""Unit tests for v2 capability resolution (Config declarations vs static)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pollux.errors import ConfigurationError
+from pollux.interaction.capabilities import resolve_capabilities
+from pollux.providers.base import ProviderCapabilities
+
+pytestmark = pytest.mark.unit
+
+
+def _static(**overrides: Any) -> ProviderCapabilities:
+    base: dict[str, Any] = {"persistent_cache": False, "uploads": False}
+    base.update(overrides)
+    return ProviderCapabilities(**base)
+
+
+def test_none_declaration_returns_static_unchanged():
+    static = _static(uploads=True)
+    assert resolve_capabilities(static, None) is static
+
+
+def test_empty_declaration_returns_static():
+    static = _static()
+    assert resolve_capabilities(static, {}) is static
+
+
+def test_declaration_caps_a_supported_capability():
+    static = _static(structured_outputs=True)
+    resolved = resolve_capabilities(static, {"structured_outputs": False})
+    assert resolved.structured_outputs is False
+
+
+def test_declaration_asserts_an_unsupported_capability():
+    static = _static(structured_outputs=False)
+    resolved = resolve_capabilities(static, {"structured_outputs": True})
+    assert resolved.structured_outputs is True
+
+
+def test_undeclared_capabilities_fall_back_to_static():
+    static = _static(uploads=True, structured_outputs=False)
+    resolved = resolve_capabilities(static, {"structured_outputs": True})
+    assert resolved.uploads is True
+
+
+def test_unknown_capability_name_raises():
+    with pytest.raises(ConfigurationError, match="Unknown capability"):
+        resolve_capabilities(_static(), {"streaming": True})
+
+
+def test_non_bool_capability_value_raises():
+    with pytest.raises(ConfigurationError, match="must be a boolean"):
+        resolve_capabilities(_static(), {"structured_outputs": "yes"})  # type: ignore[dict-item]

--- a/tests/interaction/test_execute_capabilities.py
+++ b/tests/interaction/test_execute_capabilities.py
@@ -1,0 +1,80 @@
+"""Integration tests: Config capability declarations steer v2 validation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+import pytest
+
+from pollux.config import Config
+from pollux.errors import ConfigurationError
+from pollux.interaction.environment import Environment
+from pollux.interaction.execute import execute_interaction
+from pollux.interaction.input import Input
+from pollux.interaction.requirements import OutputRequirements
+from pollux.providers.base import ProviderCapabilities
+from tests.conftest import ANTHROPIC_MODEL, FakeProvider
+
+pytestmark = pytest.mark.integration
+
+
+class _Out(BaseModel):
+    value: int
+
+
+@pytest.mark.asyncio
+async def test_declaration_caps_provider_support():
+    # Provider statically supports structured outputs; Config caps it off.
+    provider = FakeProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=True, uploads=True, structured_outputs=True
+        )
+    )
+    cfg = Config(
+        provider="anthropic",
+        model=ANTHROPIC_MODEL,
+        use_mock=True,
+        capabilities={"structured_outputs": False},
+    )
+    with pytest.raises(ConfigurationError, match="structured outputs"):
+        await execute_interaction(
+            Environment(),
+            Input(content="Q"),
+            OutputRequirements(output_schema=_Out),
+            cfg,
+            provider,
+        )
+
+
+@pytest.mark.asyncio
+async def test_declaration_asserts_support_provider_omits():
+    # Provider static block omits structured outputs; Config asserts it.
+    provider = FakeProvider()  # structured_outputs=False by default
+    cfg = Config(
+        provider="anthropic",
+        model=ANTHROPIC_MODEL,
+        use_mock=True,
+        capabilities={"structured_outputs": True},
+    )
+    out = await execute_interaction(
+        Environment(),
+        Input(content="Q"),
+        OutputRequirements(output_schema=_Out),
+        cfg,
+        provider,
+    )
+    assert out.text == "ok:Q"
+
+
+@pytest.mark.asyncio
+async def test_unknown_capability_declaration_raises_before_call():
+    provider = FakeProvider()
+    cfg = Config(
+        provider="anthropic",
+        model=ANTHROPIC_MODEL,
+        use_mock=True,
+        capabilities={"telepathy": True},
+    )
+    with pytest.raises(ConfigurationError, match="Unknown capability"):
+        await execute_interaction(
+            Environment(), Input(content="Q"), OutputRequirements(), cfg, provider
+        )

--- a/tests/interaction/test_provider_tool_translation.py
+++ b/tests/interaction/test_provider_tool_translation.py
@@ -1,0 +1,71 @@
+"""Coverage: v2 ToolDeclaration dicts translate correctly per provider.
+
+The v2 path compiles tools to a neutral ``{name, description, parameters}`` dict.
+These tests confirm each real adapter's tool normalizer consumes that exact shape,
+so tool calling is provider-complete through the v2 boundary (not just mock).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pollux.config import Config, ProviderName
+from pollux.errors import ConfigurationError
+from pollux.interaction.compile import compile_request
+from pollux.interaction.environment import Environment, EnvironmentSnapshot
+from pollux.interaction.execute import execute_interaction
+from pollux.interaction.input import Input
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.tools import ToolDeclaration
+from pollux.providers.anthropic import AnthropicProvider
+from pollux.providers.local import LocalProvider
+from pollux.providers.openai import OpenAIProvider
+
+pytestmark = pytest.mark.unit
+
+_LOCAL_BASE_URL = "http://localhost:1234/v1"
+_TOOL = ToolDeclaration(
+    name="get_weather",
+    description="Get weather",
+    parameters={"type": "object", "properties": {"city": {"type": "string"}}},
+)
+
+
+def _compiled_tools(provider_name: ProviderName) -> list[dict[str, Any]]:
+    snapshot = EnvironmentSnapshot.from_environment(
+        Environment(tools=[_TOOL]), provider=provider_name
+    )
+    cfg = Config(provider=provider_name, model="m", use_mock=True)
+    req = compile_request(snapshot, Input(content="hi"), OutputRequirements(), cfg)
+    assert req.tools is not None
+    return req.tools
+
+
+def test_translates_to_anthropic_input_schema():
+    tools = AnthropicProvider._normalize_tools(_compiled_tools("anthropic"))
+    assert tools[0]["name"] == "get_weather"
+    assert tools[0]["input_schema"]["type"] == "object"
+    assert tools[0]["description"] == "Get weather"
+
+
+def test_translates_to_openai_function():
+    tools = OpenAIProvider._normalize_tools(_compiled_tools("openai"))
+    assert tools[0]["type"] == "function"
+    assert tools[0]["name"] == "get_weather"
+    assert "parameters" in tools[0]
+
+
+@pytest.mark.asyncio
+async def test_local_rejects_tools_through_v2():
+    provider = LocalProvider(base_url=_LOCAL_BASE_URL)
+    cfg = Config(provider="local", model="m", base_url=_LOCAL_BASE_URL)
+    with pytest.raises(ConfigurationError):
+        await execute_interaction(
+            Environment(tools=[_TOOL]),
+            Input(content="hi"),
+            OutputRequirements(),
+            cfg,
+            provider,
+        )


### PR DESCRIPTION
## Summary

Completes the **additive** Slice 2 scope. Adds `Config.capabilities` declarations and a `resolve_capabilities()` precedence helper so the v2 interaction path honors user capability overrides: a declared capability **wins** over the provider's static value - to cap support a provider claims, or to assert support a provider's static block omits (the local OpenAI-compatible server case) - while undeclared capabilities fall back to it. Resolution is wired into `execute_interactions`.

Also locks in **cross-provider coverage**: because the 2b refinement routes the v2 path through the unchanged `provider.generate(ProviderRequest)`, the adapters already work - every adapter's `_normalize_tools` already expects the neutral `{name, description, parameters}` dict that `compile.py` emits. Tests confirm Anthropic (`input_schema`) and OpenAI (`type: function`) translation and that the local provider rejects tools through the v2 path.

## Related issue

None

## Test plan

`just check` passes (ruff, rumdl, mypy strict, 453 tests; 13 new). Coverage: capability resolution precedence (declared caps-off / asserts-on, undeclared fallback, unknown name + non-bool rejection); `Config` declarations steering v2 validation end-to-end through `execute_interaction`; and cross-provider tool-dict translation.

## Notes

Scope note: the structural capability-protocol decomposition (`UploadingProvider`/`CachingProvider` as `@runtime_checkable` protocols) is **not** additive - `upload_file`/`create_cache` are required `Provider` methods that every adapter defines (local defines them and raises, signaling no-uploads via the `uploads=False` flag), so `isinstance` can't distinguish capability. Making them structural requires the base `Provider` protocol restructure, which lands with the **Slice 3 cutover** alongside deleting `ProviderRequest`, flipping `provider.generate` to take primitives/return `Output`, removing the slice-1 `adapters.py`, and rewiring the frontdoors.