### PR TITLE
feat(api): add interact() v2 frontdoor

### DIFF
--- a/docs/migrating-to-v2.md
+++ b/docs/migrating-to-v2.md
@@ -123,6 +123,21 @@ migration easier:
   `defer_many()` only when provider-side deferred delivery is the workflow you
   want.
 
+## What Is Available Now
+
+The 2.0 interaction model is landing incrementally on `main`. The first frontdoor
+is live:
+
+- `interact(environment, input, *, config, **generation_kwargs) -> Output` runs
+  one explicit interaction over an `Environment` and `Input`, returning an
+  `Output` with named facets (`text`, `structured`, `reasoning`, `tool_calls`,
+  `continuation`, `usage`, `metrics`, `diagnostics`). Continue a conversation or
+  tool loop by passing the prior `Output`'s `continuation` and any `tool_results`
+  in the next `Input` — this is the replacement for `continue_tool()`.
+
+`run()` / `run_many()` / `defer()` keep their 1.x behavior for now and move onto
+the same model in later changes.
+
 ## As The Design Settles
 
 This page will change as the 2.0 API moves from plan to release candidate. Use

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,6 +16,7 @@ For provider-level feature differences, see [Provider Capabilities](provider-cap
 |---|---|---|
 | Ask one prompt about one source (or no source) | `run()` | [Sending Content to Models](../sending-content.md) |
 | Ask many prompts against shared sources | `run_many()` | [Analyzing Collections with Source Patterns](../source-patterns.md) |
+| Run one explicit interaction (environment + input), incl. tools/continuation | `interact()` (2.0) | [Building an Agent Loop](../agent-loop.md) |
 | Submit non-urgent work and collect it later | `defer()` / `defer_many()` | [Building With Deferred Delivery](../building-with-deferred-delivery.md) |
 | Check deferred job status or collect terminal results | `inspect_deferred()` / `collect_deferred()` / `cancel_deferred()` | [Submitting Work for Later Collection](../submitting-work-for-later-collection.md) |
 | Feed tool results back into a conversation turn | `continue_tool()` | [Building an Agent Loop](../agent-loop.md) |
@@ -28,6 +29,8 @@ The primary execution functions are exported from `pollux`:
 ::: pollux.run
 
 ::: pollux.run_many
+
+::: pollux.interact
 
 ::: pollux.defer
 
@@ -64,6 +67,30 @@ provider-specific helpers such as `Source.with_gemini_video_settings(...)` and
 ::: pollux.RetryPolicy
 
 ::: pollux.ResultEnvelope
+
+## Interaction Types (2.0)
+
+The canonical v2 interaction model. `interact()` takes an `Environment` and an
+`Input` and returns an `Output`; `OutputCollection` is the source-pattern
+aggregate. These coexist with the 1.x types during the 2.0 cutover.
+
+::: pollux.Environment
+
+::: pollux.Input
+
+::: pollux.Output
+
+::: pollux.OutputCollection
+
+::: pollux.OutputRequirements
+
+::: pollux.Continuation
+
+::: pollux.ToolDeclaration
+
+::: pollux.ToolCall
+
+::: pollux.ToolResult
 
 ## Error Types
 

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -3,6 +3,7 @@
 Public API:
     - run(): Single prompt execution
     - run_many(): Multi-prompt source-pattern execution
+    - interact(): One explicit v2 interaction over an Environment and Input
     - defer(): Single deferred request submission
     - defer_many(): Multi-prompt deferred submission
     - inspect_deferred(): Inspect a deferred job
@@ -49,7 +50,21 @@ from pollux.errors import (
     SourceError,
 )
 from pollux.execute import execute_plan
-from pollux.options import Options
+from pollux.interaction import (
+    Continuation,
+    Environment,
+    Input,
+    Message,
+    Output,
+    OutputCollection,
+    OutputRequirements,
+    ToolCall,
+    ToolChoice,
+    ToolDeclaration,
+    ToolResult,
+)
+from pollux.interaction.execute import execute_interaction
+from pollux.options import Options, ResponseSchemaInput
 from pollux.plan import build_plan
 from pollux.providers.base import CloseableProvider
 from pollux.request import normalize_request
@@ -101,6 +116,78 @@ async def run(
     """
     sources = (source,) if source else ()
     return await run_many(prompt, sources=sources, config=config, options=options)
+
+
+async def interact(
+    environment: Environment,
+    input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+    *,
+    config: Config,
+    output: ResponseSchemaInput | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    seed: int | None = None,
+    reasoning_effort: str | None = None,
+    reasoning_budget_tokens: int | None = None,
+    tool_choice: ToolChoice | None = None,
+    provider_options: dict[str, dict[str, Any]] | None = None,
+) -> Output:
+    """Run one explicit v2 interaction over an environment and input.
+
+    The v2 interaction facade: build an :class:`Environment` once (instructions,
+    sources, tools, cache preference), then send :class:`Input` turns. Returns an
+    :class:`Output` with named facets (``text``, ``structured``, ``reasoning``,
+    ``tool_calls``, ``continuation``, ``usage``, ``metrics``, ``diagnostics``).
+    Continue by passing the prior output's ``continuation`` and any
+    ``tool_results`` in the next ``Input``.
+
+    Args:
+        environment: Reusable model-facing setup for the interaction.
+        input: The per-turn payload (user content, continuation, tool results).
+        config: Configuration specifying provider and model.
+        output: Optional Pydantic model or JSON Schema for structured output.
+        temperature: Optional sampling temperature.
+        top_p: Optional nucleus-sampling probability.
+        max_tokens: Optional hard cap on output tokens.
+        seed: Optional sampling seed where supported.
+        reasoning_effort: Optional qualitative reasoning effort.
+        reasoning_budget_tokens: Optional explicit reasoning token budget.
+        tool_choice: Optional tool-choice control.
+        provider_options: Optional raw provider-scoped generation options.
+
+    Returns:
+        The completed :class:`Output` for the interaction.
+
+    Example:
+        environment = Environment(instructions=system_prompt, tools=tool_decls)
+        result = await interact(environment, Input("Inspect the repo."), config=cfg)
+        while result.tool_calls:
+            results = [ToolResult(call_id=c.id, content=run_tool(c)) for c in result.tool_calls]
+            result = await interact(
+                environment,
+                Input(continuation=result.continuation, tool_results=results),
+                config=cfg,
+            )
+    """
+    requirements = OutputRequirements(
+        output_schema=output,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+        seed=seed,
+        reasoning_effort=reasoning_effort,
+        reasoning_budget_tokens=reasoning_budget_tokens,
+        tool_choice=tool_choice,
+        provider_options=provider_options,
+    )
+    provider = _get_provider(config)
+    try:
+        return await execute_interaction(
+            environment, input, requirements, config, provider
+        )
+    finally:
+        await _close_provider(provider)
 
 
 async def defer(
@@ -478,11 +565,18 @@ __all__ = [
     "CacheHandle",
     "Config",
     "ConfigurationError",
+    "Continuation",
     "DeferredHandle",
     "DeferredNotReadyError",
     "DeferredSnapshot",
+    "Environment",
+    "Input",
     "InternalError",
+    "Message",
     "Options",
+    "Output",
+    "OutputCollection",
+    "OutputRequirements",
     "PlanningError",
     "PolluxError",
     "RateLimitError",
@@ -490,6 +584,10 @@ __all__ = [
     "RetryPolicy",
     "Source",
     "SourceError",
+    "ToolCall",
+    "ToolChoice",
+    "ToolDeclaration",
+    "ToolResult",
     "cancel_deferred",
     "collect_deferred",
     "continue_tool",
@@ -497,6 +595,7 @@ __all__ = [
     "defer",
     "defer_many",
     "inspect_deferred",
+    "interact",
     "run",
     "run_many",
 ]

--- a/tests/interaction/test_interact_frontdoor.py
+++ b/tests/interaction/test_interact_frontdoor.py
@@ -1,0 +1,122 @@
+"""Integration tests for the interact() v2 frontdoor."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+import pytest
+
+import pollux
+from pollux import Environment, Input, Output, ToolDeclaration, ToolResult, interact
+from pollux.config import Config
+from pollux.providers.base import ProviderCapabilities
+from pollux.providers.models import ProviderResponse
+from pollux.providers.models import ToolCall as ProviderToolCall
+from tests.conftest import ANTHROPIC_MODEL, FakeProvider
+from tests.helpers import ScriptedProvider
+
+pytestmark = pytest.mark.integration
+
+
+def _cfg() -> Config:
+    return Config(provider="anthropic", model=ANTHROPIC_MODEL, use_mock=True)
+
+
+class _Weather(BaseModel):
+    value: int
+
+
+@pytest.mark.asyncio
+async def test_interact_returns_output(monkeypatch):
+    provider = ScriptedProvider(
+        script=[
+            ProviderResponse(text="hi", usage={"total_tokens": 3}, finish_reason="stop")
+        ]
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    out = await interact(
+        Environment(instructions="sys"), Input("Hello?"), config=_cfg()
+    )
+
+    assert isinstance(out, Output)
+    assert out.text == "hi"
+    assert out.metrics.completion_status == "clean"
+
+
+@pytest.mark.asyncio
+async def test_first_class_kwargs_reach_the_provider(monkeypatch):
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    await interact(
+        Environment(instructions="sys"), Input("Q"), config=_cfg(), temperature=0.25
+    )
+
+    assert provider.last_generate_kwargs is not None
+    assert provider.last_generate_kwargs["temperature"] == 0.25
+    assert provider.last_generate_kwargs["system_instruction"] == "sys"
+
+
+@pytest.mark.asyncio
+async def test_structured_output(monkeypatch):
+    provider = ScriptedProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=False, uploads=False, structured_outputs=True
+        ),
+        script=[
+            ProviderResponse(
+                text="", usage={}, structured={"value": 7}, finish_reason="stop"
+            )
+        ],
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    out = await interact(Environment(), Input("Q"), config=_cfg(), output=_Weather)
+
+    assert isinstance(out.structured, _Weather)
+    assert out.structured.value == 7
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_continues_from_tool_results(monkeypatch):
+    provider = ScriptedProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=True, uploads=True, conversation=True
+        ),
+        script=[
+            ProviderResponse(
+                text="",
+                usage={"total_tokens": 1},
+                tool_calls=[
+                    ProviderToolCall(
+                        id="c1", name="get_weather", arguments='{"city": "P"}'
+                    )
+                ],
+                response_id="r1",
+                finish_reason="tool_calls",
+            ),
+            ProviderResponse(
+                text="It is sunny.", usage={"total_tokens": 2}, finish_reason="stop"
+            ),
+        ],
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+    env = Environment(
+        instructions="sys",
+        tools=[ToolDeclaration(name="get_weather", description="Get weather")],
+    )
+
+    first = await interact(env, Input("Weather in Paris?"), config=_cfg())
+    assert first.tool_calls[0].name == "get_weather"
+    assert first.continuation is not None
+
+    results = [
+        ToolResult(call_id=call.id, content="sunny") for call in first.tool_calls
+    ]
+    final = await interact(
+        env,
+        Input(continuation=first.continuation, tool_results=results),
+        config=_cfg(),
+    )
+    assert final.text == "It is sunny."
+    assert not final.tool_calls


### PR DESCRIPTION
## Summary

Adds `interact()`, the v2 interaction facade - the first frontdoor of the Slice 3 cutover. Build an `Environment` once (instructions, sources, tools, cache preference), send `Input` turns, and get back an `Output` with named facets (`text`, `structured`, `reasoning`, `tool_calls`, `continuation`, `usage`, `metrics`, `diagnostics`). Continue a conversation or tool loop by passing the prior `Output`'s `continuation` and any `tool_results` in the next `Input` - the replacement for `continue_tool()`.

```python
async def interact(environment, input, *, config, output=None, temperature=None, ...) -> Output
```

It builds `OutputRequirements` from first-class kwargs and reuses the existing provider lifecycle (`_get_provider` / `_close_provider`) around `execute_interaction`. The v2 interaction types are now surfaced at the top level (`pollux.Environment`, `Input`, `Output`, `OutputCollection`, `OutputRequirements`, `Continuation`, `ToolDeclaration`, `ToolCall`, `ToolResult`, `Message`).

**Purely additive** - `run()` / `run_many()` / `defer()` are unchanged and `main` stays green.

## Related issue

None

## Test plan

`just check` passes (ruff, rumdl, mypy strict, 457 tests; 4 new) and `mkdocs build --strict` is clean. New tests cover: `interact()` returns `Output`; first-class kwargs reach the provider request (temperature, instructions); structured output; and the **agent loop** from the scout sketch: `interact` → `tool_calls` → `ToolResult`s → `interact(Input(continuation=..., tool_results=...))` completes a two-turn cycle.

## Notes

First of the ~5-PR Slice 3 cutover. Docs: `interact()` added to the API reference and the migration guide.