### PR TITLE
feat(core): wire persistent caching into the v2 path

### DIFF
--- a/cookbook/__main__.py
+++ b/cookbook/__main__.py
@@ -29,9 +29,8 @@ COOKBOOK_DIRNAME = "cookbook"
 EXCLUDE_DIRS = {"utils", "templates", "data", "__pycache__"}
 
 # Recipes pending migration to the v2 Output model (tracked v2 cookbook
-# follow-up). The heavy "projects/" recipes mutate the v1 result envelope and the
-# cache recipe depends on persistent caching, which returns in a later v2 change.
-SHELVED_V2 = {"projects", "optimization/cache-warming-and-ttl.py"}
+# follow-up). The heavy "projects/" recipes mutate the v1 result envelope.
+SHELVED_V2 = {"projects"}
 
 # Determines the "start here" recipe for bare invocation / --list display.
 START_HERE_DISPLAY = "getting-started/analyze-single-paper.py"

--- a/cookbook/optimization/cache-warming-and-ttl.py
+++ b/cookbook/optimization/cache-warming-and-ttl.py
@@ -7,9 +7,12 @@ Problem:
 
 Pattern:
     - Keep prompts and sources fixed.
-    - Create a persistent cache via ``create_cache()``.
-    - Run once to warm and once to reuse (back-to-back).
-    - Compare tokens and cache signal.
+    - Prepare an environment with a ``CachePolicy`` to create a persistent cache.
+    - Run once to warm and once to reuse (back-to-back) over that environment.
+    - Compare tokens and the cache signal.
+
+Persistent caching is a provider capability (e.g. Gemini). Run with ``--mock``
+for an offline smoke test, or ``--provider gemini`` against a real key.
 """
 
 from __future__ import annotations
@@ -27,10 +30,10 @@ from cookbook.utils.presentation import (
     print_section,
 )
 from cookbook.utils.runtime import add_runtime_args, build_config_or_exit, usage_tokens
-from pollux import Config, Options, Source, create_cache, run_many
+from pollux import CachePolicy, Config, Source, prepare_environment, run_many
 
 if TYPE_CHECKING:
-    from pollux.result import ResultEnvelope
+    from pollux import OutputCollection
 
 PROMPTS = (
     "List 5 key concepts with one-sentence explanations.",
@@ -38,16 +41,14 @@ PROMPTS = (
 )
 
 
-def describe(run_name: str, envelope: ResultEnvelope) -> None:
+def describe(run_name: str, collection: OutputCollection) -> None:
     """Print compact run diagnostics."""
-    metrics = envelope.get("metrics")
-    cache_used = None
-    if isinstance(metrics, dict):
-        cache_used = metrics.get("cache_used")
-
+    cache_used = (
+        collection.outputs[0].metrics.cache_used if collection.outputs else None
+    )
     print(
-        f"- {run_name}: status={envelope.get('status', 'ok')} "
-        f"cache_used={cache_used} tokens={usage_tokens(envelope) or 'n/a'}"
+        f"- {run_name}: status={collection.status} "
+        f"cache_used={cache_used} tokens={usage_tokens(collection) or 'n/a'}"
     )
 
 
@@ -58,10 +59,14 @@ async def main_async(directory: Path, *, limit: int, config: Config, ttl: int) -
 
     sources = [Source.from_file(path) for path in files]
 
-    handle = await create_cache(sources, config=config, ttl_seconds=ttl)
+    environment = await prepare_environment(
+        sources=sources,
+        cache=CachePolicy(ttl_seconds=ttl),
+        config=config,
+    )
 
-    warm = await run_many(PROMPTS, config=config, options=Options(cache=handle))
-    reuse = await run_many(PROMPTS, config=config, options=Options(cache=handle))
+    warm = await run_many(PROMPTS, environment=environment, config=config)
+    reuse = await run_many(PROMPTS, environment=environment, config=config)
     warm_tokens = usage_tokens(warm)
     reuse_tokens = usage_tokens(reuse)
     saved = None

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,7 +1,7 @@
 <!-- Intent: Teach context caching mechanics: the redundant-context problem,
-     creating a cache, cache identity, TTL tuning, when caching pays off,
-     reading cache hit token counts from result["usage"]["cached_tokens"], and
-     the distinction between Pollux-controlled caching and provider-side
+     preparing a cached environment, cache identity, TTL tuning, when caching
+     pays off, reading cache hit token counts from output.usage.cached_tokens,
+     and the distinction between Pollux-controlled caching and provider-side
      automatic prompt caching. Do NOT cover source patterns or structured output
      in depth — link to those pages. Assumes the reader understands run_many()
      and fan-out workflows. Register: conceptual opening → guided applied. -->
@@ -13,13 +13,17 @@ turning redundant re-uploads into cheap cache references. Providers implement
 caching differently, and Pollux gives you different levels of control
 depending on the provider.
 
+Caching belongs to the **environment**: the stable instructions, sources, and
+tools around your interactions. You express a cache preference on an
+`Environment`, and Pollux derives cache identity from that environment's
+content.
+
 !!! info "Boundary"
-    **Pollux owns:** creating and reusing cached context via `create_cache()`
-    (Gemini), toggling Anthropic prompt caching via
-    `Options(implicit_caching=...)`, cache identity from content hashes,
-    single-flight deduplication, the `metrics.cache_used` signal, and
-    surfacing provider-reported cache hit counts in
-    `result["usage"]["cached_tokens"]`.
+    **Pollux owns:** creating and reusing cached context from an
+    `Environment` cache preference, provider-managed caching via `cache="auto"`
+    / `cache="none"`, cache identity from content hashes, single-flight
+    deduplication, the `metrics.cache_used` signal, and surfacing
+    provider-reported cache hit counts in `output.usage.cached_tokens`.
 
     **You own:** deciding when caching is worth the overhead, tuning TTL to
     match your reuse window, and accounting for billing differences by
@@ -82,33 +86,35 @@ More questions on the same content = greater savings.
 
 ## Three Caching Paths
 
-Pollux gives you two caching controls, and a third path exists at the
-provider level:
+Pollux exposes caching through the environment's `cache` preference, plus a
+third path that exists at the provider level:
 
-- **Explicit caching (Gemini):** You upload content once with
-  `create_cache()`, get a handle back, and pass that handle to later calls.
-- **Implicit caching (Anthropic):** Pollux maps
-  `Options(implicit_caching=...)` to Anthropic's automatic prompt caching
-  behavior.
+- **Persistent caching (Gemini):** Set `cache=CachePolicy(ttl_seconds=...)` on
+  an environment. Pollux uploads the environment's sources once, creates a
+  provider-side cache, and references it on every interaction over that
+  environment.
+- **Provider-managed caching (Anthropic):** With `cache="auto"` (the default)
+  Pollux lets the provider's automatic prompt caching apply. `cache="none"`
+  opts out.
 - **Automatic prompt caching (OpenAI, Gemini, OpenRouter):** These providers
   can discount repeated long prefixes on their own. Pollux does not control
   or configure this, but you can benefit from it without doing anything.
 
-`metrics.cache_used` only reflects explicit cache handles. If you need to
-verify automatic prompt caching, check provider-native usage or billing.
+`metrics.cache_used` is `True` for the persistent path. To verify provider
+automatic prompt caching, check `output.usage.cached_tokens` or provider-native
+billing.
 
-## Implicit Caching (Anthropic)
+## Provider-Managed Caching (Anthropic)
 
 Anthropic currently describes this provider feature as automatic prompt
-caching. Pollux calls the toggle `implicit_caching` to distinguish it from
-Gemini's explicit `create_cache()` handles. Anthropic caches shared prefixes
-from the top of the request downward: system instruction, tools, conversation
-history, and repeated prompt context. You do not create a cache object
-yourself. Pollux toggles this with `Options(implicit_caching=...)`.
+caching: it caches shared prefixes from the top of the request downward
+(system instruction, tools, conversation history, and repeated prompt
+context). You do not create a cache object yourself. In Pollux this is the
+default; set `cache="none"` on the environment to opt out.
 
 ### Cost Mechanics
 
-Unlike explicit caching, Anthropic changes token pricing per request:
+Unlike persistent caching, Anthropic changes token pricing per request:
 
 - **Cache writes:** +25% (1.25x standard cost)
 - **Cache reads:** -90% (0.10x standard cost)
@@ -119,10 +125,10 @@ caching, sending the same prefix twice costs 2.0x. With caching, it costs
 
 ### Default Behavior
 
-Because cache writes cost more, Pollux does not treat implicit caching as a
-blanket default:
+Because cache writes cost more, Pollux does not treat provider-managed caching
+as a blanket default:
 
-- **Single provider call:** Pollux enables implicit caching by default.
+- **Single provider call:** Pollux enables it by default.
 - **Multi-call fan-out:** Pollux disables it by default.
 
 This is a request-shape rule, not an API-entrypoint rule. `run()` always makes
@@ -134,17 +140,18 @@ The reason is cost. In a conversation, the write premium lands once and later
 turns benefit from cheap cache reads. In a wide fan-out, many identical calls
 arrive before the cache is warm, so you pay the write premium repeatedly.
 
-You can override the default when you need to:
+You opt out with the environment's cache preference:
 
 ```python
-from pollux import Options
+from pollux import Environment
 
-# Disable Anthropic implicit caching for a one-off call.
-options = Options(implicit_caching=False)
+# Disable provider-managed caching for this environment.
+environment = Environment(instructions="...", cache="none")
 ```
 
-Setting `implicit_caching=True` on a provider that does not support it raises
-`ConfigurationError`. Pollux does not silently ignore the request.
+Requesting persistent caching (`CachePolicy`) on a provider that does not
+support it raises `ConfigurationError`. Pollux does not silently ignore the
+request.
 
 ### Current Pollux Scope
 
@@ -152,79 +159,81 @@ Pollux currently exposes Anthropic's default ephemeral caching behavior. It
 does not expose Anthropic's 1-hour TTL or manual block-level cache breakpoints
 in the public API.
 
-## Explicit Caching (Gemini)
+## Persistent Caching (Gemini)
 
-For Gemini, use `create_cache()` to upload content to the provider once, then pass the
-returned handle to `run()` or `run_many()` via `Options(cache=handle)`:
+For Gemini, prepare an environment with a `CachePolicy`. Pollux uploads the
+environment's sources to the provider once, then references the cache on every
+`run()` / `run_many()` / `interact()` call over that environment:
 
 ```python
 import asyncio
-from pollux import Config, Options, Source, create_cache, run_many
+from pollux import CachePolicy, Config, Source, prepare_environment, run_many
 
 async def main() -> None:
     config = Config(
         provider="gemini",
         model="gemini-2.5-flash-lite",
     )
-    sources = [Source.from_text(
-        "ACME Corp Q3 2025 earnings: revenue $4.2B (+12% YoY), "
-        "operating margin 18.5%, guidance raised for Q4."
-    )]
-
-    handle = await create_cache(sources, config=config, ttl_seconds=3600)
+    environment = await prepare_environment(
+        sources=[Source.from_text(
+            "ACME Corp Q3 2025 earnings: revenue $4.2B (+12% YoY), "
+            "operating margin 18.5%, guidance raised for Q4."
+        )],
+        cache=CachePolicy(ttl_seconds=3600),
+        config=config,
+    )
 
     prompts = ["Summarize in one sentence.", "List 3 keywords."]
-    first = await run_many(prompts=prompts, config=config, options=Options(cache=handle))
-    second = await run_many(prompts=prompts, config=config, options=Options(cache=handle))
+    first = await run_many(prompts, environment=environment, config=config)
+    second = await run_many(prompts, environment=environment, config=config)
 
-    print("first:", first["status"])
-    print("second:", second["status"])
-    print("cache_used:", second.get("metrics", {}).get("cache_used"))
+    print("first:", first.status)
+    print("second:", second.status)
+    print("cache_used:", second.outputs[0].metrics.cache_used)
 
 asyncio.run(main())
 ```
 
 ### Step-by-Step Walkthrough
 
-1. **Call `create_cache()`.** Pass your sources, config, and a TTL. Pollux
-   uploads the content to the provider and returns a `CacheHandle`. If you
-   bake in `system_instruction` or `tools`, those become part of the cached
-   bundle too.
+1. **Call `prepare_environment()`.** Pass your sources, config, and a cache
+   policy. Pollux uploads the content to the provider, creates the cache, and
+   returns a reusable `Environment`. If you set `instructions` or `tools`,
+   those become part of the cached bundle too.
 
-2. **Set `ttl_seconds`.** The TTL controls how long the cached content lives on
-   the provider. Match it to your reuse window. 3600s (1 hour) is a
-   reasonable default for interactive sessions.
+2. **Set `ttl_seconds` on the `CachePolicy`.** The TTL controls how long the
+   cached content lives on the provider. Match it to your reuse window. 3600s
+   (1 hour) is a reasonable default for interactive sessions.
 
-3. **Pass the handle via `Options(cache=handle)`.** Each `run()` or `run_many()`
-   call that uses this handle references the cached content instead of
-   re-uploading it.
+3. **Pass the environment via `environment=`.** Each `run()` / `run_many()` /
+   `interact()` call over this environment references the cached content
+   instead of re-uploading it.
 
-4. **Verify with `metrics.cache_used`.** Check
-   `result["metrics"]["cache_used"]` on subsequent calls. `True` confirms
-   the provider served content from cache rather than re-uploading.
+4. **Verify with `metrics.cache_used`.** The example reads it per output
+   (`second.outputs[0].metrics.cache_used`); `run()` exposes it directly as
+   `output.metrics.cache_used`. `True` confirms the persistent cache was used.
 
-Pollux computes cache identity deterministically. Calls with the same handle
-reuse the cached context automatically.
+Pollux computes cache identity deterministically. Interactions over the same
+environment reuse the cached context automatically, even across separate calls
+in the same process.
 
-!!! warning "Options restricted when using a cache handle"
-    When `Options(cache=handle)` is set, the following fields **cannot** be
-    passed alongside it:
+!!! note "The environment is the cache"
+    When an environment carries a `CachePolicy`, its instructions, sources, and
+    tools are baked into the cache, so Pollux does not resend them on each
+    request. You do not pass them separately. They live on the `Environment`.
+    This mirrors a hard constraint in the Gemini API, where `cached_content`
+    cannot coexist with `system_instruction`, `tools`, or `tool_config` in the
+    same `GenerateContent` request.
 
-    - `system_instruction` — bake it into `create_cache(system_instruction=...)`
-      instead.
-    - `tools` — bake them into `create_cache(tools=...)` instead (when
-      supported).
-    - `tool_choice` — remove it when using cached content.
-    - `sources` — bake them into `create_cache()` instead.
-
-    Pollux raises `ConfigurationError` immediately if it detects these
-    conflicts.  This mirrors a hard constraint in the Gemini API, where
-    `cached_content` cannot coexist with `system_instruction`, `tools`, or
-    `tool_config` in the same `GenerateContent` request.
+!!! tip "Lazy preparation"
+    `prepare_environment()` front-loads the upload and cache creation so errors
+    surface early. If you would rather defer the work, construct
+    `Environment(..., cache=CachePolicy(...))` directly and pass it to a call.
+    Pollux creates the cache on first use and reuses it thereafter.
 
 ## Cache Identity
 
-For explicit caches, keys are deterministic:
+For persistent caches, keys are deterministic:
 `hash(model + provider + api_key + system_instruction + tools + source identity hashes)`.
 
 This means:
@@ -235,8 +244,8 @@ This means:
   for `gemini-2.5-flash-lite` won't be reused for `gemini-2.5-pro`, and a
   Gemini cache key won't collide with one from another provider.
 - **Different API keys** → different cache keys in the same Python process.
-  Pollux scopes explicit cache reuse to the provider account that created it.
-- **Different baked-in `system_instruction` or `tools`** → different cache
+  Pollux scopes persistent cache reuse to the provider account that created it.
+- **Different baked-in `instructions` or `tools`** → different cache
   keys. Changing the cached behavior contract creates a fresh cache entry.
 - **Different Gemini video settings** → different cache keys. Two sources with
   the same content but different clip windows or FPS do not collapse to the
@@ -247,17 +256,17 @@ This means:
 
 ## Single-Flight Protection
 
-When multiple concurrent calls target the same explicit cache key (common in fan-out
-workloads), Pollux deduplicates the creation call: only one coroutine performs
-the upload, and others await the same result. This eliminates duplicate uploads
-without requiring caller-side coordination.
+When multiple concurrent calls target the same persistent cache key (common in
+fan-out workloads), Pollux deduplicates the creation call: only one coroutine
+performs the upload, and others await the same result. This eliminates
+duplicate uploads without requiring caller-side coordination.
 
 ## Verifying Cache Reuse
 
-Check `metrics.cache_used` on subsequent calls:
+Check `metrics.cache_used` on the result:
 
-- `True` — provider confirmed cache hit (explicit cache handles only)
-- `False` — full upload, or cache expired
+- `True`: the persistent cache was used
+- `False`: full upload, provider-managed caching, or cache expired
 
 Keep prompts and sources stable between runs when comparing warm vs reuse
 behavior. Automatic prompt caching at the provider level can still reduce
@@ -265,34 +274,33 @@ costs even when `cache_used` is `False`.
 
 ## Observing Cache Hits
 
-`result["usage"]["cached_tokens"]` reports how many input tokens were served
-from cache. The key is absent when no provider call reported it; in a fan-out
-it is summed across all calls:
+`output.usage.cached_tokens` reports how many input tokens were served from
+cache. In a fan-out it is summed across all calls on the `OutputCollection`:
 
 ```python
-# result from any run() or run_many() call with caching active
-cached = result["usage"].get("cached_tokens", 0)
-total_input = result["usage"]["input_tokens"]
+# output from any run() call (or collection from run_many())
+cached = output.usage.cached_tokens
+total_input = output.usage.input_tokens
 print(f"{cached:,} / {total_input:,} input tokens served from cache")
 ```
 
 For a per-call breakdown in a fan-out:
 
 ```python
-for i, raw in enumerate(result["diagnostics"]["raw_responses"]):
-    hit = raw["usage"].get("cached_tokens", 0)
-    print(f"  prompt {i}: {hit:,} cached tokens")
+for i, out in enumerate(collection.outputs):
+    print(f"  prompt {i}: {out.usage.cached_tokens:,} cached tokens")
 ```
 
 **Anthropic billing differs from Gemini and OpenAI.** For Gemini and OpenAI,
-`cached_tokens` is a subset of `input_tokens` — cache reads are billed at a
+`cached_tokens` is a subset of `input_tokens`: cache reads are billed at a
 discount from the same pool. For Anthropic, `cached_tokens` is additive: the
 total billable input is `input_tokens + cached_tokens`.
 
-## Tuning Explicit Cache TTL
+## Tuning Persistent Cache TTL
 
-Pass `ttl_seconds` to `create_cache()` to control the explicit cache lifetime. The
-default is 3600 seconds (1 hour). Tune it to match your expected reuse window:
+Set `ttl_seconds` on the `CachePolicy` to control the persistent cache
+lifetime. The default is 3600 seconds (1 hour). Tune it to match your expected
+reuse window:
 
 - **Too short:** the cache expires before you reuse it, wasting the
   warm-up cost.
@@ -302,7 +310,7 @@ default is 3600 seconds (1 hour). Tune it to match your expected reuse window:
 For interactive workloads where you run a prompt set and then refine prompts
 within the same session, 3600s is a reasonable starting point. For one-shot
 scripts, shorter TTLs (300-600s) avoid lingering cache entries. Anthropic
-manages the lifetime of implicit caches on its side.
+manages the lifetime of its provider-managed caches on its side.
 
 ## When Caching Pays Off
 
@@ -310,21 +318,20 @@ Caching is most effective when:
 
 - **Sources are large:** video, long PDFs, multi-image sets
 - **Prompt sets are repeated:** fan-out workflows with 3+ prompts per source
-  using explicit caching
+  using persistent caching
 - **Conversations are deep:** multi-turn dialogues with large system prompts
-  using implicit caching
+  using provider-managed caching
 - **Prompt prefixes repeat across calls:** automatic prompt caching at the
-  provider level can help even without a Pollux cache handle
+  provider level can help even without a Pollux cache
 
 Caching adds overhead for single-prompt, small-source calls. Start without
 caching and enable it when you see repeated context in your workload.
 
 ## Provider Dependency
 
-Calling `create_cache()` with a provider that lacks explicit cache support
-raises an actionable error. `Options(implicit_caching=True)` raises in the
-same way on providers without implicit caching support. Automatic prompt
-caching at the provider level is separate and not gated by Pollux. See
+Requesting persistent caching (`CachePolicy`) on a provider that lacks support
+raises an actionable error. Automatic prompt caching at the provider level is
+separate and not gated by Pollux. See
 [Provider Capabilities](reference/provider-capabilities.md) for the full
 matrix.
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -46,8 +46,8 @@ before dispatch or the provider page below calls out why it is out of scope.
 
 | Capability | Gemini | OpenAI | Anthropic | OpenRouter | Local | Notes |
 |---|---|---|---|---|---|---|
-| Explicit caching (`create_cache`) | ✅ | ❌ | ❌ | ❌ | ❌ | Persistent cache handles are Gemini-only |
-| Implicit caching (`Options.implicit_caching`) | ❌ | ❌ | ✅ | ❌ | ❌ | Anthropic-only; see [caching docs](../caching.md#implicit-caching-anthropic) |
+| Persistent caching (`CachePolicy`) | ✅ | ❌ | ❌ | ❌ | ❌ | Persistent caches are Gemini-only |
+| Provider-managed caching (`cache`) | ❌ | ❌ | ✅ | ❌ | ❌ | Anthropic-only; see [caching docs](../caching.md#provider-managed-caching-anthropic) |
 | Automatic prompt caching (provider-side) | ✅ | ✅ | ❌ | ⚠️ route-dependent | ⚠️ server-dependent | Provider behavior, not a Pollux API; see [caching docs](../caching.md#three-caching-paths) |
 
 ### Reasoning And Agents
@@ -69,7 +69,7 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 
 ### Gemini
 
-- Explicit caching uses the Gemini Files API.
+- Persistent caching uses the Gemini Files API.
 - Deferred delivery uses the Gemini Batch API through Pollux's deferred entry
   points.
 - Video sources can carry Gemini-specific clipping and FPS controls via
@@ -77,7 +77,7 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - HTTP(S) URI sources can opt into Gemini URL Context via
   `Source.from_uri(...).with_gemini_url_context()`. This performs request-time
   retrieval, surfaces URL retrieval metadata in diagnostics, and cannot be used
-  with explicit cache handles.
+  with persistent caching.
 - Those controls are intentionally not normalized across providers. Pollux
   keeps them explicit so portability decisions stay in caller code.
 - Gemini also caches repeated long prefixes automatically. Pollux does not
@@ -127,9 +127,9 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - Deferred delivery uses the Anthropic Message Batches API through Pollux's
   deferred entry points.
 - Remote URL support is intentionally narrow: images and PDFs only.
-- Implicit caching is enabled with `Options(implicit_caching=True)`.
-  Pollux defaults it on for single-call workloads and off for multi-call
-  fan-out. Requesting it on unsupported providers raises `ConfigurationError`.
+- Provider-managed (automatic prompt) caching is on by default for single-call
+  workloads and off for multi-call fan-out. Set `cache="none"` on the
+  `Environment` to opt out.
 - See [current caching scope](../caching.md#current-pollux-scope) for what
   Pollux exposes from Anthropic's caching surface.
 - Reasoning: thinking text appears in `ResultEnvelope.reasoning`.
@@ -181,7 +181,7 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   downloading the PDF locally and sending it with `Source.from_file()`.
 - Unsupported OpenRouter file types fail fast. For example, local CSV uploads
   raise `ConfigurationError`.
-- Persistent cache handles remain unsupported on OpenRouter in the current release.
+- Persistent caching remains unsupported on OpenRouter in the current release.
 - OpenRouter supports automatic prompt caching on many routed providers.
   Pollux does not expose OpenRouter-specific cache controls.
 - Reasoning: works on OpenRouter models that support reasoning. Thinking text
@@ -228,19 +228,21 @@ instead of degrading silently.
 For example, creating a persistent cache with OpenAI:
 
 ```python
-from pollux import Config, Source, create_cache
+from pollux import CachePolicy, Config, Source, prepare_environment
 
 config = Config(provider="openai", model="gpt-5-nano")
 # This raises immediately:
 # ConfigurationError: Provider 'openai' does not support persistent caching
 # hint: "Use a provider that supports persistent_cache (e.g. Gemini)."
-handle = await create_cache(
-    [Source.from_text("hello")], config=config
+environment = await prepare_environment(
+    sources=[Source.from_text("hello")],
+    cache=CachePolicy(),
+    config=config,
 )
 ```
 
-The error is raised at `create_cache()` call time because persistent caching
-is a provider capability checked before the upload attempt.
+The error is raised at `prepare_environment()` call time because persistent
+caching is a provider capability checked before the upload attempt.
 
 For the deferred lifecycle contract and out-of-scope options, see
 [Submitting Work for Later Collection](../submitting-work-for-later-collection.md).

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -253,7 +253,7 @@ provider.
 | `confidence` | `float` | Yes | Heuristic: `0.9` for ok, `0.5` otherwise |
 | `extraction_method` | `str` | Yes | Always `"text"` |
 | `usage` | `dict[str, int]` | Yes | Token counts (`input_tokens`, `output_tokens`, `total_tokens`, and optional `reasoning_tokens`, `cached_tokens`). See [Observing Cache Hits](caching.md#observing-cache-hits) for `cached_tokens` semantics. |
-| `metrics` | `dict[str, Any]` | Yes | `duration_s`, `n_calls`, `cache_used` ([explicit caching](caching.md#explicit-caching-gemini) only), `finish_reasons` (per-prompt, e.g. `"stop"`, `"max_tokens"`). Deferred results also add `metrics["deferred"] = True`. |
+| `metrics` | `dict[str, Any]` | Yes | `duration_s`, `n_calls`, `cache_used` ([persistent caching](caching.md#persistent-caching-gemini) only), `finish_reasons` (per-prompt, e.g. `"stop"`, `"max_tokens"`). Deferred results also add `metrics["deferred"] = True`. |
 | `diagnostics` | `dict[str, Any]` | Yes | Low-level diagnostics. All calls include `raw_responses`. Deferred results also add `diagnostics["deferred"]` with `job_id`, timing, and per-request lifecycle items. |
 
 Example of a complete envelope:

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -4,6 +4,7 @@ Public API:
     - run(): Single prompt execution
     - run_many(): Multi-prompt source-pattern execution
     - interact(): One explicit v2 interaction over an Environment and Input
+    - prepare_environment(): Build a reusable Environment, front-loading cache I/O
     - defer(): Single deferred request submission
     - defer_many(): Multi-prompt deferred submission
     - inspect_deferred(): Inspect a deferred job
@@ -47,8 +48,11 @@ from pollux.errors import (
     SourceError,
 )
 from pollux.interaction import (
+    CachePolicy,
+    CacheSetting,
     Continuation,
     Environment,
+    EnvironmentSnapshot,
     Input,
     Message,
     Output,
@@ -59,7 +63,11 @@ from pollux.interaction import (
     ToolDeclaration,
     ToolResult,
 )
-from pollux.interaction.execute import execute_interaction, execute_interactions
+from pollux.interaction.execute import (
+    execute_interaction,
+    execute_interactions,
+    resolve_persistent_cache,
+)
 from pollux.options import Options, ResponseSchemaInput
 from pollux.plan import build_plan
 from pollux.providers.base import CloseableProvider
@@ -118,6 +126,7 @@ async def run(
     source: Source | None = None,
     sources: Sequence[Source] = (),
     config: Config,
+    environment: Environment | None = None,
     instructions: str | None = None,
     output: ResponseSchemaInput | None = None,
     temperature: float | None = None,
@@ -141,6 +150,10 @@ async def run(
         source: A single source for context (convenience for ``sources=[source]``).
         sources: Stable sources for context.
         config: Configuration specifying provider and model.
+        environment: Optional prepared :class:`Environment` (e.g. from
+            :func:`prepare_environment`) carrying instructions, sources, tools,
+            and cache preference. Cannot be combined with inline
+            ``instructions``/``source``/``sources``/``tools``.
         instructions: Optional system-level instruction.
         output: Optional Pydantic model or JSON Schema for structured output.
         temperature: Optional sampling temperature.
@@ -161,11 +174,17 @@ async def run(
         result = await run("Summarize.", source=Source.from_file("doc.pdf"), config=config)
         print(result.text)
     """
+    if environment is not None and source is not None:
+        raise ConfigurationError(
+            "environment cannot be combined with inline source/sources",
+            hint="Build the Environment with the sources, or drop the environment.",
+        )
     all_sources = (source,) if source is not None else tuple(sources)
     collection = await run_many(
         prompt,
         sources=all_sources,
         config=config,
+        environment=environment,
         instructions=instructions,
         output=output,
         temperature=temperature,
@@ -270,6 +289,7 @@ async def run_many(
     *,
     sources: Sequence[Source] = (),
     config: Config,
+    environment: Environment | None = None,
     instructions: str | None = None,
     output: ResponseSchemaInput | None = None,
     temperature: float | None = None,
@@ -291,6 +311,10 @@ async def run_many(
         prompts: One or more prompts to run.
         sources: Stable sources shared across the prompts.
         config: Configuration specifying provider and model.
+        environment: Optional prepared :class:`Environment` (e.g. from
+            :func:`prepare_environment`) carrying instructions, sources, tools,
+            and cache preference. Cannot be combined with inline
+            ``instructions``/``sources``/``tools``.
         instructions: Optional system-level instruction.
         output: Optional Pydantic model or JSON Schema for structured output.
         temperature: Optional sampling temperature.
@@ -319,11 +343,20 @@ async def run_many(
     prompt_tuple = (
         (prompts,) if isinstance(prompts, (str, type(None))) else tuple(prompts)
     )
-    environment = Environment(
-        instructions=instructions,
-        sources=tuple(sources),
-        tools=tuple(tools) if tools else (),
-    )
+    if environment is not None:
+        if sources or instructions is not None or tools is not None:
+            raise ConfigurationError(
+                "environment cannot be combined with inline instructions/sources/tools",
+                hint="Put instructions, sources, and tools on the Environment, "
+                "or drop the environment argument.",
+            )
+        resolved_environment = environment
+    else:
+        resolved_environment = Environment(
+            instructions=instructions,
+            sources=tuple(sources),
+            tools=tuple(tools) if tools else (),
+        )
     inputs = [Input(content=prompt) for prompt in prompt_tuple]
     requirements = _build_requirements(
         output=output,
@@ -339,10 +372,68 @@ async def run_many(
     provider = _get_provider(config)
     try:
         return await execute_interactions(
-            environment, inputs, requirements, config, provider
+            resolved_environment, inputs, requirements, config, provider
         )
     finally:
         await _close_provider(provider)
+
+
+async def prepare_environment(
+    *,
+    sources: Sequence[Source] = (),
+    config: Config,
+    instructions: str | None = None,
+    tools: Sequence[ToolDeclaration] | None = None,
+    cache: CacheSetting = None,
+    metadata: dict[str, Any] | None = None,
+) -> Environment:
+    """Prepare a reusable :class:`Environment`, front-loading cache/upload I/O.
+
+    Build the stable model-facing setup once and reuse it across
+    :func:`interact`, :func:`run`, and :func:`run_many` calls. When ``cache`` is
+    a :class:`CachePolicy`, the persistent cache is created now (uploading
+    sources and surfacing capability errors early); later interactions over the
+    returned environment reuse it by identity.
+
+    Args:
+        sources: Stable sources to bake into the environment (and its cache).
+        config: Configuration specifying provider and model.
+        instructions: Optional system-level instruction.
+        tools: Optional tool declarations.
+        cache: Cache preference: a :class:`CachePolicy` for persistent caching,
+            ``"auto"`` for provider-managed caching, ``"none"`` to disable, or
+            ``None`` for the default.
+        metadata: Optional provider-neutral metadata for planning.
+
+    Returns:
+        The prepared :class:`Environment`.
+
+    Example:
+        environment = await prepare_environment(
+            sources=[Source.from_file("paper.pdf")],
+            instructions=system_prompt,
+            cache=CachePolicy(ttl_seconds=3600),
+            config=config,
+        )
+        results = await run_many(prompts, environment=environment, config=config)
+    """
+    environment = Environment(
+        instructions=instructions,
+        sources=tuple(sources),
+        tools=tuple(tools) if tools else (),
+        cache=cache,
+        metadata=metadata,
+    )
+    if isinstance(cache, CachePolicy):
+        provider = _get_provider(config)
+        try:
+            snapshot = EnvironmentSnapshot.from_environment(
+                environment, provider=config.provider
+            )
+            await resolve_persistent_cache(snapshot, config, provider)
+        finally:
+            await _close_provider(provider)
+    return environment
 
 
 async def defer_many(
@@ -558,6 +649,8 @@ def _resolve_deferred_provider(handle: DeferredHandle) -> Provider:
 __all__ = [
     "APIError",
     "CacheError",
+    "CachePolicy",
+    "CacheSetting",
     "Config",
     "ConfigurationError",
     "Continuation",
@@ -589,6 +682,7 @@ __all__ = [
     "defer_many",
     "inspect_deferred",
     "interact",
+    "prepare_environment",
     "run",
     "run_many",
 ]

--- a/src/pollux/interaction/compile.py
+++ b/src/pollux/interaction/compile.py
@@ -101,31 +101,41 @@ def compile_request(
     cache_name: str | None = None,
     implicit_caching: bool = False,
 ) -> ProviderRequest:
-    """Compile v2 primitives into a ``ProviderRequest`` (file parts unresolved)."""
+    """Compile v2 primitives into a ``ProviderRequest`` (file parts unresolved).
+
+    When ``cache_name`` is set, the snapshot's sources, instructions, and tools
+    are baked into the persistent cache, so they are dropped from the request:
+    providers (e.g. Gemini) reject resending content that the cache already
+    carries. The cache *is* the environment identity in the v2 model.
+    """
+    cached = cache_name is not None
     shared_parts = (
-        []
-        if cache_name is not None
-        else build_shared_parts(snapshot.sources, provider=config.provider)
+        [] if cached else build_shared_parts(snapshot.sources, provider=config.provider)
     )
     parts = (
         [*shared_parts, input.content] if input.content is not None else shared_parts
     )
 
-    tools = [
-        {
-            "name": decl.name,
-            "description": decl.description,
-            "parameters": decl.parameters,
-        }
-        for decl in snapshot.tools
-    ] or None
+    tools = (
+        None
+        if cached
+        else [
+            {
+                "name": decl.name,
+                "description": decl.description,
+                "parameters": decl.parameters,
+            }
+            for decl in snapshot.tools
+        ]
+        or None
+    )
 
     history, previous_response_id, provider_state = _resolve_prior_turns(input)
 
     return ProviderRequest(
         model=config.model,
         parts=parts,
-        system_instruction=snapshot.instructions,
+        system_instruction=None if cached else snapshot.instructions,
         cache_name=cache_name,
         response_schema=requirements.output_schema_json(),
         temperature=requirements.temperature,

--- a/src/pollux/interaction/execute.py
+++ b/src/pollux/interaction/execute.py
@@ -18,6 +18,7 @@ from dataclasses import replace
 import time
 from typing import TYPE_CHECKING
 
+from pollux.cache import create_cache_impl
 from pollux.continuation import build_conversation_state, history_text_from_parts
 from pollux.errors import APIError, InternalError, PolluxError
 from pollux.execute import (
@@ -30,7 +31,7 @@ from pollux.interaction.capabilities import resolve_capabilities
 from pollux.interaction.collection import OutputCollection
 from pollux.interaction.compile import compile_request
 from pollux.interaction.continuation import Continuation
-from pollux.interaction.environment import EnvironmentSnapshot
+from pollux.interaction.environment import CachePolicy, EnvironmentSnapshot
 from pollux.interaction.extract import provider_response_to_output
 from pollux.interaction.validate import validate_interaction
 from pollux.providers.models import ProviderResponse
@@ -87,6 +88,43 @@ def _build_continuation(
     return continuation_from_state(state) if state is not None else None
 
 
+#: Fallback TTL when a ``CachePolicy`` leaves ``ttl_seconds`` unset.
+_DEFAULT_CACHE_TTL_SECONDS = 3600
+
+
+async def resolve_persistent_cache(
+    snapshot: EnvironmentSnapshot,
+    config: Config,
+    provider: Provider,
+) -> str | None:
+    """Create or reuse a persistent cache for the environment's stable context.
+
+    Returns the provider cache name, or ``None`` when the environment does not
+    request a :class:`CachePolicy`. The cache is keyed by the environment's
+    instructions, sources, and tools (its identity), so concurrent or repeated
+    calls share one provider-side cache via the module registry's single-flight.
+    """
+    if not isinstance(snapshot.cache, CachePolicy):
+        return None
+    tools = [
+        {
+            "name": decl.name,
+            "description": decl.description,
+            "parameters": decl.parameters,
+        }
+        for decl in snapshot.tools
+    ] or None
+    handle = await create_cache_impl(
+        snapshot.sources,
+        provider=provider,
+        config=config,
+        system_instruction=snapshot.instructions,
+        tools=tools,
+        ttl_seconds=snapshot.cache.ttl_seconds or _DEFAULT_CACHE_TTL_SECONDS,
+    )
+    return handle.name
+
+
 async def execute_interactions(
     environment: Environment,
     inputs: Sequence[Input],
@@ -105,10 +143,20 @@ async def execute_interactions(
         environment, provider=config.provider
     )
     caps = resolve_capabilities(provider.capabilities, config.capabilities)
-    validate_interaction(requirements, inputs, snapshot, caps, cache_requested=False)
+    persistent_requested = isinstance(snapshot.cache, CachePolicy)
+    validate_interaction(
+        requirements, inputs, snapshot, caps, cache_requested=persistent_requested
+    )
 
-    implicit_caching = caps.implicit_caching and len(inputs) == 1
-    cache_mode = "implicit" if implicit_caching else "none"
+    cache_name = await resolve_persistent_cache(snapshot, config, provider)
+    if cache_name is not None:
+        cache_mode = "persistent"
+        implicit_caching = False
+    else:
+        implicit_caching = (
+            caps.implicit_caching and len(inputs) == 1 and snapshot.cache != "none"
+        )
+        cache_mode = "implicit" if implicit_caching else "none"
 
     upload_cache: dict[tuple[str, str], ProviderFileAsset] = {}
     upload_inflight: dict[tuple[str, str], asyncio.Future[ProviderFileAsset]] = {}
@@ -125,6 +173,7 @@ async def execute_interactions(
                     inputs[call_idx],
                     requirements,
                     config,
+                    cache_name=cache_name,
                     implicit_caching=implicit_caching,
                 )
                 user_contents[call_idx] = history_text_from_parts(req.parts)
@@ -191,10 +240,16 @@ async def execute_interactions(
 
     duration_s = time.perf_counter() - start_time
 
+    cache_used = cache_mode == "persistent"
     outputs: list[Output] = []
     for idx, response in enumerate(responses):
         cached = response.usage.get("cached_tokens", 0)
-        cache_hit = cache_mode == "implicit" and isinstance(cached, int) and cached > 0
+        if cache_mode == "persistent":
+            cache_hit = True
+        else:
+            cache_hit = (
+                cache_mode == "implicit" and isinstance(cached, int) and cached > 0
+            )
         continuation = _build_continuation(
             inputs[idx], response, user_contents[idx], config.provider
         )
@@ -203,7 +258,7 @@ async def execute_interactions(
                 response,
                 requirements=requirements,
                 duration_s=duration_s,
-                cache_used=False,
+                cache_used=cache_used,
                 cache_mode=cache_mode,
                 cache_hit=cache_hit,
                 continuation=continuation,

--- a/tests/interaction/test_caching.py
+++ b/tests/interaction/test_caching.py
@@ -1,0 +1,212 @@
+"""Persistent caching over the v2 interaction path.
+
+These cover the 3b-2 wiring: an ``Environment`` carrying a ``CachePolicy`` makes
+the execution path create (or reuse) a provider-side cache, bake the stable
+context into it, and reflect that on ``Output`` metrics. ``prepare_environment``
+front-loads that work; ``run``/``run_many`` accept the prepared environment.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import pollux
+from pollux.cache import _registry
+from pollux.config import Config
+from pollux.errors import ConfigurationError
+from pollux.interaction.environment import CachePolicy, Environment
+from pollux.providers.base import ProviderCapabilities
+from pollux.source import Source
+from tests.conftest import GEMINI_MODEL, FakeProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_registry() -> Iterator[None]:
+    """Isolate the module-level cache registry between tests."""
+    _registry._entries.clear()
+    _registry._inflight.clear()
+    yield
+    _registry._entries.clear()
+    _registry._inflight.clear()
+
+
+def _cfg() -> Config:
+    return Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+
+
+@pytest.mark.asyncio
+async def test_persistent_cache_created_once_for_fan_out(monkeypatch):
+    """A CachePolicy environment creates one cache and reuses it across prompts."""
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = Environment(
+        sources=[Source.from_text("SHARED CONTEXT")],
+        cache=CachePolicy(ttl_seconds=600),
+    )
+    coll = await pollux.run_many(
+        ["Q1", "Q2", "Q3"], environment=environment, config=_cfg()
+    )
+
+    assert provider.cache_calls == 1
+    assert coll.answers == ["ok:Q1", "ok:Q2", "ok:Q3"]
+    assert all(o.metrics.cache_mode == "persistent" for o in coll.outputs)
+    assert all(o.metrics.cache_used for o in coll.outputs)
+    assert all(o.metrics.cache_hit for o in coll.outputs)
+
+
+@pytest.mark.asyncio
+async def test_cached_sources_not_resent_in_request(monkeypatch):
+    """When a cache is in use, sources are baked in, not resent as parts."""
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = Environment(
+        sources=[Source.from_text("SHARED CONTEXT")],
+        cache=CachePolicy(ttl_seconds=600),
+    )
+    await pollux.run("Q1", environment=environment, config=_cfg())
+
+    assert provider.last_parts == ["Q1"]
+    assert "SHARED CONTEXT" not in (provider.last_parts or [])
+
+
+@pytest.mark.asyncio
+async def test_cache_suppresses_instructions_and_tools_on_request(monkeypatch):
+    """Instructions and tools live in the cache, so they are not resent."""
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = Environment(
+        instructions="Be terse.",
+        sources=[Source.from_text("SHARED CONTEXT")],
+        tools=[
+            pollux.ToolDeclaration(
+                name="lookup", description="d", parameters={"type": "object"}
+            )
+        ],
+        cache=CachePolicy(ttl_seconds=600),
+    )
+    await pollux.run("Q1", environment=environment, config=_cfg())
+
+    assert provider.last_generate_kwargs is not None
+    assert provider.last_generate_kwargs["system_instruction"] is None
+    assert provider.last_generate_kwargs["tools"] is None
+
+
+@pytest.mark.asyncio
+async def test_persistent_cache_reused_across_separate_calls(monkeypatch):
+    """A cache created once is reused by identity across later calls."""
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = Environment(
+        sources=[Source.from_text("SHARED CONTEXT")],
+        cache=CachePolicy(ttl_seconds=600),
+    )
+    await pollux.run("Q1", environment=environment, config=_cfg())
+    await pollux.run("Q2", environment=environment, config=_cfg())
+
+    assert provider.cache_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_environment_creates_cache_eagerly(monkeypatch):
+    """prepare_environment front-loads cache creation; later runs reuse it."""
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = await pollux.prepare_environment(
+        sources=[Source.from_text("SHARED CONTEXT")],
+        cache=CachePolicy(ttl_seconds=600),
+        config=_cfg(),
+    )
+    assert provider.cache_calls == 1
+
+    await pollux.run_many(["Q1", "Q2"], environment=environment, config=_cfg())
+    assert provider.cache_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_environment_does_no_io_without_policy(monkeypatch):
+    """Without a CachePolicy, prepare_environment is a pure constructor."""
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = await pollux.prepare_environment(
+        sources=[Source.from_text("SHARED CONTEXT")],
+        cache="auto",
+        config=_cfg(),
+    )
+    assert provider.cache_calls == 0
+    assert environment.cache == "auto"
+
+
+@pytest.mark.asyncio
+async def test_persistent_cache_rejected_when_unsupported(monkeypatch):
+    """A CachePolicy against a provider without persistent_cache fails clearly."""
+    provider = FakeProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=False, uploads=True, structured_outputs=False
+        )
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = Environment(
+        sources=[Source.from_text("SHARED CONTEXT")],
+        cache=CachePolicy(ttl_seconds=600),
+    )
+    with pytest.raises(ConfigurationError, match="persistent caching"):
+        await pollux.run("Q1", environment=environment, config=_cfg())
+    assert provider.cache_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_cache_none_disables_implicit_caching(monkeypatch):
+    """cache='none' opts out of provider-managed caching too."""
+    provider = FakeProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=False, uploads=True, implicit_caching=True
+        )
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = Environment(cache="none")
+    out = await pollux.run("Q1", environment=environment, config=_cfg())
+    assert out.metrics.cache_mode == "none"
+
+
+@pytest.mark.asyncio
+async def test_run_many_rejects_environment_with_inline_kwargs(monkeypatch):
+    """Mixing a prepared environment with inline setup is a configuration error."""
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = Environment(sources=[Source.from_text("CTX")])
+    with pytest.raises(ConfigurationError, match="environment cannot be combined"):
+        await pollux.run_many(
+            ["Q1"], environment=environment, instructions="sys", config=_cfg()
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_environment_with_inline_source(monkeypatch):
+    """run() also guards against environment + inline source."""
+    provider = FakeProvider()
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    environment = Environment(sources=[Source.from_text("CTX")])
+    with pytest.raises(ConfigurationError, match="environment cannot be combined"):
+        await pollux.run(
+            "Q1",
+            environment=environment,
+            source=Source.from_text("OTHER"),
+            config=_cfg(),
+        )


### PR DESCRIPTION
## Summary

Restores persistent caching after the #196 step-back, wiring it into the v2 path under the **environment-as-cache-identity** model. An `Environment` carrying a `CachePolicy` bakes its instructions/sources/tools into a provider-side cache and references it on every interaction over that environment, replacing v1's separate `create_cache()` handle + conflict-rejection shape.

## Related issue

None

## Test plan

- `just check` → **410 passed / 1 skipped / 19 deselected** (was 400); ruff + rumdl + mypy strict clean.
- `uv run mkdocs build --strict` → clean.
- `uv run python -m cookbook optimization/cache-warming-and-ttl.py --mock` → runs end to end, reports `cache_used=True`.
- New `tests/interaction/test_caching.py` (10): create-once across fan-out, source/instruction/tool suppression on cached requests, cross-call reuse via the registry, eager `prepare_environment`, capability rejection, `cache="none"` disabling implicit, and `environment=` conflict guards.

## Notes

- **Surface:** new public `prepare_environment(...)` (async; eagerly creates the cache to front-load I/O and surface capability errors early); `run()`/`run_many()` gain `environment=` (mixing it with inline `instructions`/`sources`/`tools` raises `ConfigurationError`). Exports `CachePolicy`, `CacheSetting`, `prepare_environment`.
- **Reuse:** `resolve_persistent_cache()` reuses the retained `cache.create_cache_impl` + module registry (single-flight, idempotent) — no new cache machinery.
- **Compile change:** when `cache_name` is set, `compile_request` now also drops `system_instruction` and `tools` (they live in the cache; Gemini rejects resending them).

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)