### PR TITLE
feat(api)!: move defer()/collect_deferred() to the v2 model

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -70,7 +70,7 @@ Use this order when debugging. Most failures resolve by step 2.
 
 3. **Unsupported feature.** Compare your options against
    [Provider Capabilities](reference/provider-capabilities.md).
-   Deferred work uses `defer()` / `defer_many()` rather than `run()` /
+   Deferred work uses `defer()` rather than `run()` /
    `run_many()`. Conversation continuity and tool calling are
    provider-dependent.
 

--- a/docs/migrating-to-v2.md
+++ b/docs/migrating-to-v2.md
@@ -26,9 +26,8 @@ You should read this page if your 1.x code uses any of these:
 
 - `Options(...)` for output shape, tools, reasoning, caching, or provider
   controls.
-- The removed `Options.delivery_mode` setting. In v1.8+, use `run()` /
-  `run_many()` for realtime calls and `defer()` / `defer_many()` for
-  provider-side deferred work.
+- The removed `Options.delivery_mode` setting. Use `run()` /
+  `run_many()` for realtime calls and `defer()` for provider-side deferred work.
 - `continue_from`, `history`, `continue_tool()`, or persisted continuation
   blobs.
 - `create_cache(...)` and explicit cache handles.
@@ -119,9 +118,8 @@ migration easier:
   Store them, but do not inspect or mutate their internals.
 - Keep tool execution policy in your application code: dispatch, approval,
   logging, retries, and stop conditions.
-- Use `run()` and `run_many()` for realtime source patterns, and `defer()` /
-  `defer_many()` only when provider-side deferred delivery is the workflow you
-  want.
+- Use `run()` and `run_many()` for realtime source patterns, and `defer()`
+  only when provider-side deferred delivery is the workflow you want.
 
 ## What Is Available Now
 
@@ -139,9 +137,10 @@ The 2.0 interaction model is landing incrementally on `main`:
   conversation or tool loop by passing the prior `Output`'s `continuation` and any
   `tool_results` in the next `Input` — the replacement for `continue_tool()`.
 
-Still in progress: `defer()` moves onto the same model, and persistent caching
-returns through environment preparation (it briefly steps back during the
-cutover). `create_cache()` and `Options` are removed from the realtime path.
+`defer()` now follows the same model: it accepts one prompt or a collection,
+and `collect_deferred()` returns an `OutputCollection`. Persistent caching
+returns through `prepare_environment()` / `Environment(cache=...)`.
+`create_cache()`, `defer_many()`, and `Options` are removed.
 
 ## As The Design Settles
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -17,13 +17,16 @@ For provider-level feature differences, see [Provider Capabilities](provider-cap
 | Ask one prompt about one source (or no source) | `run()` → `Output` | [Sending Content to Models](../sending-content.md) |
 | Ask many prompts against shared sources | `run_many()` → `OutputCollection` | [Analyzing Collections with Source Patterns](../source-patterns.md) |
 | Run one explicit interaction (environment + input), incl. tools/continuation | `interact()` | [Building an Agent Loop](../agent-loop.md) |
-| Submit non-urgent work and collect it later | `defer()` / `defer_many()` | [Building With Deferred Delivery](../building-with-deferred-delivery.md) |
+| Prepare a reusable environment (and front-load cache/upload I/O) | `prepare_environment()` → `Environment` | [Reducing Costs with Context Caching](../caching.md) |
+| Submit non-urgent work and collect it later | `defer()` → `DeferredHandle` | [Building With Deferred Delivery](../building-with-deferred-delivery.md) |
 | Check deferred job status or collect terminal results | `inspect_deferred()` / `collect_deferred()` / `cancel_deferred()` | [Submitting Work for Later Collection](../submitting-work-for-later-collection.md) |
 
-> **2.0 cutover:** `run()` / `run_many()` now return the `Output` / `OutputCollection`
+> **2.0 cutover:** `run()` / `run_many()` return the `Output` / `OutputCollection`
 > model (named facets, not dict envelopes). `continue_tool()` is replaced by
-> `interact(environment, Input(continuation=..., tool_results=...))`, and persistent
-> caching moves to environment preparation (a later 2.0 change).
+> `interact(environment, Input(continuation=..., tool_results=...))`; persistent
+> caching moves to `prepare_environment()` / `Environment(cache=...)`; and `defer()`
+> returns an `OutputCollection` from `collect_deferred()` (the single `defer_many()`
+> entry point is removed).
 
 ## Entry Points
 
@@ -35,9 +38,9 @@ The primary execution functions are exported from `pollux`:
 
 ::: pollux.interact
 
-::: pollux.defer
+::: pollux.prepare_environment
 
-::: pollux.defer_many
+::: pollux.defer
 
 ::: pollux.inspect_deferred
 

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -219,13 +219,13 @@ Q2: Key findings: (1) fan-out caching saves 85-92% of input tokens; (2) broad...
 | Same question across shared sources | `run_many()` | Fan-in analysis |
 | Many questions against the same shared source set | `run_many()` | Fan-out over a combined context |
 | Many questions per file in a collection | Outer loop + `run_many()` | Broadcast pattern; see [Source Patterns](source-patterns.md) |
-| Non-urgent work you will collect later | `defer()` / `defer_many()` | Background provider execution with a serializable handle |
+| Non-urgent work you will collect later | `defer()` | Background provider execution with a serializable handle |
 | Returning tool results to the model | `continue_tool()` | Feeds tool outputs back into the conversation |
 
 Rule of thumb: if prompts or sources are plural and every prompt should receive
 the same shared context, reach for `run_many()`. If you need one result record
 per file, write the outer file loop yourself and call `run_many()` inside it.
-If the workload can wait, reach for `defer_many()`.
+If the workload can wait, reach for `defer()`.
 
 `continue_tool()` is a specialized entry point for agent loops. It takes a
 previous `ResultEnvelope` containing tool calls and your tool results, and
@@ -275,7 +275,7 @@ Example of a complete envelope:
 - Conversation continuity (`history`, `continue_from`) works with one
   prompt per call. See
   [Continuing Conversations Across Turns](conversations-and-agents.md).
-- Deferred work uses `defer()`, `defer_many()`, `inspect_deferred()`,
+- Deferred work uses `defer()`, `inspect_deferred()`,
   `collect_deferred()`, and `cancel_deferred()`.
 - Deferred lifecycle calls take a `DeferredHandle`, not `Config`. Persist the
   handle and restore it later. See

--- a/docs/submitting-work-for-later-collection.md
+++ b/docs/submitting-work-for-later-collection.md
@@ -2,7 +2,7 @@
      persist the handle, inspect status, and collect results later. Do NOT
      teach workflow engines, schedulers, queues, or multi-job orchestration.
      Assumes the reader already knows run(), run_many(), Source, Config, and
-     ResultEnvelope. Register: guided applied. -->
+     the Output/OutputCollection model. Register: guided applied. -->
 
 # Submitting Work for Later Collection
 
@@ -20,9 +20,9 @@ to structure code around long-running provider jobs, read
 this page. This page stays focused on the lifecycle API itself.
 
 !!! info "Boundary"
-    **Pollux owns:** request normalization, provider submission, stable request
-    ids, normalized status snapshots, ordered collection, and extraction into a
-    standard `ResultEnvelope`.
+    **Pollux owns:** request compilation, provider submission, stable request
+    ids, normalized status snapshots, ordered collection, and extraction into an
+    `OutputCollection` (the same shape `run_many()` returns).
 
     **You own:** handle persistence, polling cadence, scheduling, cross-job
     orchestration, and downstream storage.
@@ -39,7 +39,7 @@ from pollux import (
     DeferredHandle,
     Source,
     collect_deferred,
-    defer_many,
+    defer,
     inspect_deferred,
 )
 
@@ -48,7 +48,7 @@ JOB_PATH = Path("outputs/deferred-job.json")
 
 async def submit_job() -> None:
     config = Config(provider="openai", model="gpt-5-nano")
-    handle = await defer_many(
+    handle = await defer(
         [
             "Summarize the report in five bullets.",
             "List the three biggest execution risks.",
@@ -74,8 +74,8 @@ async def collect_job() -> None:
         return
 
     result = await collect_deferred(handle)
-    print(result["status"])
-    for answer in result["answers"]:
+    print(result.status)
+    for answer in result.answers:
         print(answer)
 
 
@@ -88,8 +88,8 @@ Run `submit_job()` once. You should see a provider job id and a JSON file at
 `outputs/deferred-job.json`. Run `collect_job()` later. `inspect_deferred()`
 normalizes the lifecycle into `queued`, `running`, `cancelling`, `completed`,
 `partial`, `failed`, `cancelled`, or `expired`. Once `snapshot.is_terminal`
-turns `True`, `collect_deferred()` returns the same `ResultEnvelope` shape that
-`run()` and `run_many()` return.
+turns `True`, `collect_deferred()` returns an `OutputCollection` — the same
+shape `run_many()` returns.
 
 ### Why this example is shaped this way
 
@@ -102,48 +102,47 @@ turns `True`, `collect_deferred()` returns the same `ResultEnvelope` shape that
   one provider's raw status strings.
 - `collect_deferred()` is not a polling helper. If the job is still active, it
   raises `DeferredNotReadyError`.
-- For a single prompt, use `defer()`. It wraps `defer_many()` the same way
-  `run()` wraps `run_many()`.
+- `defer()` submits one prompt or a source-pattern collection through a single
+  entry point, the same way `run_many()` accepts one or many prompts.
 - Collection preserves prompt order. If you submitted two prompts, the first
   answer still maps to the first prompt.
 
 ## Structured Output Across Processes
 
 Deferred collection can still return structured data. Submit with
-`Options(response_schema=YourModel)`, then pass the same schema back to
+`output=YourModel`, then pass the same schema back to
 `collect_deferred(handle, response_schema=YourModel)`.
 
 Pollux stores a schema fingerprint in the handle. If the schema changed between
 submit and collect, Pollux raises `ConfigurationError` instead of silently
-rehydrating into the wrong shape. If you omit `response_schema` at collect
-time, Pollux returns plain dicts in `result["structured"]` when the provider
-returned structured payloads.
+rehydrating into the wrong shape. As with `run_many()`, structured output is
+only populated when you supply the schema at collect time; omitting it leaves
+`output.structured` unset even if the provider returned a structured payload.
 
 ## Current Scope
 
-- Deferred delivery uses dedicated entry points: `defer()`, `defer_many()`,
+- Deferred delivery uses dedicated entry points: `defer()`,
   `inspect_deferred()`, `collect_deferred()`, and `cancel_deferred()`.
 - `run()` and `run_many()` remain realtime entry points.
-- Deferred delivery does not support conversation continuity, tool calling,
-  persistent cache handles, or implicit caching.
+- Deferred delivery does not support conversation continuity, tool calling, or
+  persistent caching.
 - `cancel_deferred(handle)` requests provider-side cancellation. Final status is
   still provider-driven.
 
 ## Deferred Results
 
-Collected deferred jobs return a standard `ResultEnvelope` plus deferred
-diagnostics:
+Collected deferred jobs return an `OutputCollection`. Each `Output` carries the
+same facets as realtime results, plus per-item deferred provenance under
+`diagnostics.raw["deferred"]`:
 
-- `result["metrics"]["deferred"]` is `True`
-- `result["diagnostics"]["deferred"]["job_id"]` identifies the remote job
-- `result["diagnostics"]["deferred"]["items"]` includes per-request status,
-  finish reason, provider status, and any item-level error text
+- `job_id` identifies the remote job
+- `request_id` and `status` identify the item and its terminal state
+- `finish_reason`, `provider_status`, and `error` capture the per-item outcome
 
-Those are deferred-only additions on top of the standard envelope shape
-documented in [ResultEnvelope Reference](sending-content.md#resultenvelope-reference).
-
-That keeps downstream code small. Your post-processing path can usually treat
-realtime and deferred results the same way.
+A failed item reports `metrics.completion_status == "error"`, and the
+collection's `status` is `partial` when only some items succeeded. That keeps
+downstream code small: your post-processing path can usually treat realtime and
+deferred results the same way.
 
 ---
 

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -5,8 +5,7 @@ Public API:
     - run_many(): Multi-prompt source-pattern execution
     - interact(): One explicit v2 interaction over an Environment and Input
     - prepare_environment(): Build a reusable Environment, front-loading cache I/O
-    - defer(): Single deferred request submission
-    - defer_many(): Multi-prompt deferred submission
+    - defer(): Deferred submission of one or more interactions
     - inspect_deferred(): Inspect a deferred job
     - collect_deferred(): Collect terminal deferred results
     - cancel_deferred(): Cancel a deferred job
@@ -69,9 +68,7 @@ from pollux.interaction.execute import (
     resolve_persistent_cache,
 )
 from pollux.options import Options, ResponseSchemaInput
-from pollux.plan import build_plan
 from pollux.providers.base import CloseableProvider
-from pollux.request import normalize_request
 from pollux.result import ResultEnvelope
 from pollux.retry import RetryPolicy
 from pollux.source import Source
@@ -273,15 +270,76 @@ async def interact(
 
 
 async def defer(
-    prompt: str | None = None,
+    prompts: str | Sequence[str | None] | None = None,
     *,
-    source: Source | None = None,
+    sources: Sequence[Source] = (),
     config: Config,
-    options: Options | None = None,
+    instructions: str | None = None,
+    output: ResponseSchemaInput | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    seed: int | None = None,
+    reasoning_effort: str | None = None,
+    reasoning_budget_tokens: int | None = None,
+    provider_options: dict[str, dict[str, Any]] | None = None,
 ) -> DeferredHandle:
-    """Submit a single deferred request and return a serializable handle."""
-    sources = (source,) if source else ()
-    return await defer_many(prompt, sources=sources, config=config, options=options)
+    """Submit one or more deferred requests and return a serializable handle.
+
+    The v2 deferred frontdoor: submit a single interaction or a source-pattern
+    collection on a provider-side timeline, then :func:`inspect_deferred` and
+    :func:`collect_deferred` later. Collection returns an
+    :class:`OutputCollection`, the same shape as :func:`run_many`.
+
+    Tool calling, continuation, and persistent caching are out of scope for
+    deferred delivery and are intentionally not part of this surface.
+
+    Args:
+        prompts: One or more prompts to submit.
+        sources: Stable sources shared across the prompts.
+        config: Configuration specifying provider and model.
+        instructions: Optional system-level instruction.
+        output: Optional Pydantic model or JSON Schema for structured output.
+            Pass the same schema to :func:`collect_deferred` to rehydrate.
+        temperature: Optional sampling temperature.
+        top_p: Optional nucleus-sampling probability.
+        max_tokens: Optional hard cap on output tokens.
+        seed: Optional sampling seed where supported.
+        reasoning_effort: Optional qualitative reasoning effort.
+        reasoning_budget_tokens: Optional explicit reasoning token budget.
+        provider_options: Optional raw provider-scoped generation options.
+
+    Returns:
+        A serializable :class:`DeferredHandle` for the submitted job.
+    """
+    prompt_tuple = (
+        (prompts,) if isinstance(prompts, (str, type(None))) else tuple(prompts)
+    )
+    if not prompt_tuple:
+        raise ConfigurationError(
+            "defer() requires at least one prompt",
+            hint="Pass one or more prompts to submit for deferred collection.",
+        )
+    environment = Environment(instructions=instructions, sources=tuple(sources))
+    inputs = [Input(content=prompt) for prompt in prompt_tuple]
+    requirements = _build_requirements(
+        output=output,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+        seed=seed,
+        reasoning_effort=reasoning_effort,
+        reasoning_budget_tokens=reasoning_budget_tokens,
+        tool_choice=None,
+        provider_options=provider_options,
+    )
+    provider = _get_provider(config)
+    try:
+        return await submit_deferred(
+            environment, inputs, requirements, config, provider
+        )
+    finally:
+        await _close_provider(provider)
 
 
 async def run_many(
@@ -436,34 +494,6 @@ async def prepare_environment(
     return environment
 
 
-async def defer_many(
-    prompts: str | Sequence[str | None] | None = None,
-    *,
-    sources: Sequence[Source] = (),
-    config: Config,
-    options: Options | None = None,
-) -> DeferredHandle:
-    """Submit deferred work and return a handle for later inspection/collection.
-
-    Planned for Pollux 2.0: deferred submission moves to one entry point that
-    can submit a single interaction or a source-pattern collection. See the
-    *Migrating to 2.0* guide.
-    """
-    request = normalize_request(prompts, sources, config, options=options)
-    if not request.prompts:
-        raise ConfigurationError(
-            "defer_many() requires at least one prompt",
-            hint="Pass one or more prompts, or use run_many(prompts=[]) for a realtime no-op.",
-        )
-    plan = build_plan(request)
-    provider = _get_provider(request.config)
-
-    try:
-        return await submit_deferred(plan, provider)
-    finally:
-        await _close_provider(provider)
-
-
 async def inspect_deferred(
     handle: DeferredHandle,
 ) -> DeferredSnapshot:
@@ -479,11 +509,15 @@ async def collect_deferred(
     handle: DeferredHandle,
     *,
     response_schema: type[Any] | dict[str, Any] | None = None,
-) -> ResultEnvelope:
-    """Collect a terminal deferred job into the standard ResultEnvelope.
+) -> OutputCollection:
+    """Collect a terminal deferred job into an :class:`OutputCollection`.
+
+    Returns the same shape as :func:`run_many`: one :class:`Output` per
+    submitted request, in submission order. Each output's
+    ``diagnostics.raw["deferred"]`` carries the job id and per-item status.
 
     Args:
-        handle: The deferred handle returned by ``defer()`` / ``defer_many()``.
+        handle: The deferred handle returned by :func:`defer`.
         response_schema: Optional Pydantic model or JSON Schema for structured
             output rehydration. Must match the schema used at submission time.
     """
@@ -679,7 +713,6 @@ __all__ = [
     "cancel_deferred",
     "collect_deferred",
     "defer",
-    "defer_many",
     "inspect_deferred",
     "interact",
     "prepare_environment",

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 import time
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pollux.errors import ConfigurationError, DeferredNotReadyError, InternalError
+from pollux.interaction.capabilities import resolve_capabilities
+from pollux.interaction.collection import OutputCollection
+from pollux.interaction.compile import compile_request
+from pollux.interaction.environment import EnvironmentSnapshot
+from pollux.interaction.extract import provider_response_to_output
+from pollux.interaction.output import Diagnostics, Output
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.validate import validate_interaction
 from pollux.options import (
     ResponseSchemaInput,
     response_schema_hash,
@@ -23,15 +31,14 @@ from pollux.providers.models import (
     ProviderRequest,
     ProviderResponse,
     ToolCall,
-    is_file_part,
 )
-from pollux.result import build_result_from_responses
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
-    from pollux.plan import Plan
-    from pollux.result import ResultEnvelope
+    from pollux.config import Config
+    from pollux.interaction.environment import Environment
+    from pollux.interaction.input import Input
 
 DeferredStatus = Literal[
     "queued",
@@ -144,87 +151,6 @@ def _provider_handle_from_handle(handle: DeferredHandle) -> ProviderDeferredHand
     )
 
 
-def _validate_deferred_plan(plan: Plan, provider: Provider) -> None:
-    options = plan.request.options
-    caps = provider.capabilities
-
-    _get_deferred_provider(provider)
-    if options.cache is not None:
-        raise ConfigurationError(
-            "Persistent cache handles are not supported with deferred delivery",
-            hint="Remove options.cache for deferred requests.",
-        )
-    if options.history is not None or options.continue_from is not None:
-        raise ConfigurationError(
-            "Conversation continuity is not supported with deferred delivery",
-            hint="Remove history/continue_from or use run().",
-        )
-    if options.tools is not None or options.tool_choice is not None:
-        raise ConfigurationError(
-            "Tool calling is not supported with deferred delivery",
-            hint="Remove tools/tool_choice or use run().",
-        )
-    if options.implicit_caching is not None:
-        raise ConfigurationError(
-            "implicit_caching is not supported with deferred delivery",
-            hint="Remove implicit_caching for deferred requests.",
-        )
-    if options.response_schema is not None and not caps.structured_outputs:
-        raise ConfigurationError(
-            "Provider does not support structured outputs",
-            hint="Remove response_schema or choose a provider with schema support.",
-        )
-    if options.reasoning_effort is not None and not caps.reasoning:
-        raise ConfigurationError(
-            "Provider does not support reasoning controls",
-            hint=(
-                "Remove reasoning_effort or choose a provider with reasoning "
-                "controls. Some providers may still surface model-native "
-                "reasoning output without this option."
-            ),
-        )
-    if options.reasoning_budget_tokens is not None and not caps.reasoning_budget_tokens:
-        raise ConfigurationError(
-            "Provider does not support reasoning_budget_tokens",
-            hint=(
-                "Use reasoning_effort, or choose a provider that accepts "
-                "an explicit reasoning token budget."
-            ),
-        )
-    if (not caps.uploads) and any(is_file_part(part) for part in plan.shared_parts):
-        raise ConfigurationError(
-            "Provider does not support file uploads",
-            hint="Choose a provider with uploads support, or remove file sources.",
-        )
-
-
-def _build_provider_requests(plan: Plan) -> list[ProviderRequest]:
-    options = plan.request.options
-    schema = options.response_schema_json()
-    requests: list[ProviderRequest] = []
-    for prompt in plan.request.prompts:
-        parts = list(plan.shared_parts)
-        if prompt is not None:
-            parts.append(prompt)
-        requests.append(
-            ProviderRequest(
-                model=plan.request.config.model,
-                parts=parts,
-                system_instruction=options.system_instruction,
-                response_schema=schema,
-                temperature=options.temperature,
-                top_p=options.top_p,
-                reasoning_effort=options.reasoning_effort,
-                reasoning_budget_tokens=options.reasoning_budget_tokens,
-                max_tokens=options.max_tokens,
-                provider_options=options.provider_options_for(
-                    plan.request.config.provider
-                ),
-            )
-        )
-    return requests
-
-
 async def _validate_provider_requests(
     provider: Provider,
     requests: list[ProviderRequest],
@@ -238,13 +164,35 @@ async def _validate_provider_requests(
         await provider.validate_request(request)
 
 
-async def submit_deferred(plan: Plan, provider: Provider) -> DeferredHandle:
-    """Submit provider-backed deferred work and return the Pollux handle."""
-    _validate_deferred_plan(plan, provider)
-    requests = _build_provider_requests(plan)
-    await _validate_provider_requests(provider, requests)
+async def submit_deferred(
+    environment: Environment,
+    inputs: Sequence[Input],
+    requirements: OutputRequirements,
+    config: Config,
+    provider: Provider,
+) -> DeferredHandle:
+    """Submit provider-backed deferred work and return the Pollux handle.
+
+    Compiles the v2 interaction primitives into provider requests and submits
+    them to the provider's deferred lifecycle. Tool calling, continuation, and
+    persistent caching are out of scope for deferred delivery and are not part
+    of the ``defer()`` surface; capability gaps (uploads, structured outputs,
+    reasoning) are rejected by :func:`validate_interaction` before submission.
+    """
+    # Gate on deferred support first so an unsupported provider fails with the
+    # clearest message before any compilation or capability checks.
     deferred_provider = _get_deferred_provider(provider)
-    request_ids = _request_ids(len(plan.request.prompts))
+    inputs = tuple(inputs)
+    snapshot = EnvironmentSnapshot.from_environment(
+        environment, provider=config.provider
+    )
+    caps = resolve_capabilities(provider.capabilities, config.capabilities)
+    validate_interaction(requirements, inputs, snapshot, caps, cache_requested=False)
+
+    requests = [compile_request(snapshot, inp, requirements, config) for inp in inputs]
+    await _validate_provider_requests(provider, requests)
+
+    request_ids = _request_ids(len(inputs))
     provider_handle = await deferred_provider.submit_deferred(
         requests,
         request_ids=request_ids,
@@ -256,11 +204,11 @@ async def submit_deferred(plan: Plan, provider: Provider) -> DeferredHandle:
     )
     return DeferredHandle(
         job_id=provider_handle.job_id,
-        provider=plan.request.config.provider,
-        model=plan.request.config.model,
-        request_count=len(plan.request.prompts),
+        provider=config.provider,
+        model=config.model,
+        request_count=len(inputs),
         submitted_at=submitted_at,
-        schema_hash=plan.request.options.response_schema_hash(),
+        schema_hash=requirements.output_schema_hash(),
         provider_state=(
             dict(provider_handle.provider_state)
             if isinstance(provider_handle.provider_state, dict)
@@ -326,15 +274,6 @@ def _validate_collect_schema(
         )
 
 
-def _aggregate_usage(responses: list[ProviderResponse]) -> dict[str, int]:
-    total_usage: dict[str, int] = {}
-    for response in responses:
-        for key, value in response.usage.items():
-            if isinstance(value, int):
-                total_usage[key] = total_usage.get(key, 0) + value
-    return total_usage
-
-
 def _response_from_item(item: ProviderDeferredItem) -> ProviderResponse:
     if item.status != "succeeded":
         return ProviderResponse(text="", usage={}, finish_reason=item.finish_reason)
@@ -369,13 +308,60 @@ def _response_from_item(item: ProviderDeferredItem) -> ProviderResponse:
     )
 
 
+def _deferred_diagnostics(
+    handle: DeferredHandle,
+    snapshot: DeferredSnapshot,
+    item: ProviderDeferredItem,
+) -> dict[str, Any]:
+    """Per-item deferred provenance attached to an output's diagnostics."""
+    return {
+        "job_id": handle.job_id,
+        "request_id": item.request_id,
+        "status": item.status,
+        "error": item.error,
+        "provider_status": item.provider_status,
+        "finish_reason": item.finish_reason,
+        "submitted_at": snapshot.submitted_at,
+        "completed_at": snapshot.completed_at,
+    }
+
+
+def _output_from_item(
+    item: ProviderDeferredItem,
+    *,
+    handle: DeferredHandle,
+    snapshot: DeferredSnapshot,
+    requirements: OutputRequirements,
+    duration_s: float,
+) -> Output:
+    """Assemble one v2 ``Output`` from a collected deferred item."""
+    response = _response_from_item(item)
+    # A failed item carries no usable completion, so mark it as an error rather
+    # than letting an empty finish reason read as a clean stop.
+    error_category = None if item.status == "succeeded" else (item.error or "failed")
+    output = provider_response_to_output(
+        response,
+        requirements=requirements,
+        duration_s=duration_s,
+        error_category=error_category,
+    )
+    raw = dict(output.diagnostics.raw or {})
+    raw["deferred"] = _deferred_diagnostics(handle, snapshot, item)
+    return replace(output, diagnostics=Diagnostics(raw=raw))
+
+
 async def collect_deferred_handle(
     handle: DeferredHandle,
     provider: Provider,
     *,
     response_schema: ResponseSchemaInput | None = None,
-) -> ResultEnvelope:
-    """Collect a terminal deferred job into a standard ResultEnvelope."""
+) -> OutputCollection:
+    """Collect a terminal deferred job into an :class:`OutputCollection`.
+
+    Deferred work returns the same shape as ``run_many()``: one ``Output`` per
+    submitted request, in submission order. Each output's
+    ``diagnostics.raw["deferred"]`` carries the job id and per-item status.
+    """
     deferred_provider = _get_deferred_provider(provider)
     _validate_collect_schema(handle, response_schema)
 
@@ -396,58 +382,31 @@ async def collect_deferred_handle(
             )
         items_by_id[item.request_id] = item
 
-    request_ids = _request_ids(handle.request_count)
-    responses: list[ProviderResponse] = []
-    deferred_items: list[dict[str, Any]] = []
-    for request_id in request_ids:
+    requirements = OutputRequirements(output_schema=response_schema)
+    duration_s = time.perf_counter() - start_time
+
+    outputs: list[Output] = []
+    for request_id in _request_ids(handle.request_count):
         collected_item = items_by_id.get(request_id)
         if collected_item is None:
             raise InternalError(
                 f"Deferred provider did not return item {request_id!r}",
                 hint="Deferred providers must return one item for every submitted request id.",
             )
-        responses.append(_response_from_item(collected_item))
-        deferred_items.append(
-            {
-                "request_id": request_id,
-                "status": collected_item.status,
-                "error": collected_item.error,
-                "provider_status": collected_item.provider_status,
-                "finish_reason": collected_item.finish_reason,
-            }
+        outputs.append(
+            _output_from_item(
+                collected_item,
+                handle=handle,
+                snapshot=snapshot,
+                requirements=requirements,
+                duration_s=duration_s,
+            )
         )
 
-    usage = _aggregate_usage(responses)
-    duration_s = time.perf_counter() - start_time
-
-    result = build_result_from_responses(
-        responses,
-        schema=response_schema,
-        duration_s=duration_s,
-        usage=usage,
-        n_calls=handle.request_count,
+    return OutputCollection(
+        outputs=tuple(outputs),
+        prompt_indexes=tuple(range(handle.request_count)),
     )
-
-    # When no schema was provided at collect time but providers returned
-    # structured payloads, surface them as plain dicts.
-    if response_schema is None and any(
-        response.structured is not None for response in responses
-    ):
-        result["structured"] = [response.structured for response in responses]
-
-    result["metrics"]["deferred"] = True
-    result["diagnostics"]["deferred"] = {
-        "job_id": handle.job_id,
-        "submitted_at": snapshot.submitted_at,
-        "completed_at": snapshot.completed_at,
-        "elapsed_s": (
-            None
-            if snapshot.completed_at is None
-            else snapshot.completed_at - snapshot.submitted_at
-        ),
-        "items": deferred_items,
-    }
-    return result
 
 
 async def cancel_deferred_handle(handle: DeferredHandle, provider: Provider) -> None:

--- a/tests/pipeline/test_deferred.py
+++ b/tests/pipeline/test_deferred.py
@@ -9,15 +9,13 @@ from pydantic import BaseModel
 import pytest
 
 import pollux
-import pollux.cache
-from pollux.cache import CacheHandle
 from pollux.config import Config
 from pollux.deferred import DeferredHandle
 from pollux.errors import (
     ConfigurationError,
     DeferredNotReadyError,
 )
-from pollux.options import Options
+from pollux.interaction.collection import OutputCollection
 from pollux.providers.anthropic import AnthropicProvider
 from pollux.providers.base import (
     ProviderDeferredItem,
@@ -33,6 +31,18 @@ from tests.conftest import (
 from tests.helpers import InMemoryDeferredProvider, RejectingValidatingDeferredProvider
 
 pytestmark = pytest.mark.integration
+
+#: Per-item deferred fields each collected output exposes under
+#: ``diagnostics.raw["deferred"]``, projected for order-preserving assertions.
+_ITEM_FIELDS = ("request_id", "status", "error", "provider_status", "finish_reason")
+
+
+def _deferred_items(collection: OutputCollection) -> list[dict[str, Any]]:
+    """Project each output's deferred provenance to the comparable subset."""
+    return [
+        {field: output.diagnostics.raw["deferred"][field] for field in _ITEM_FIELDS}  # type: ignore[index]
+        for output in collection.outputs
+    ]
 
 
 def test_deferred_handle_round_trip_serialization() -> None:
@@ -51,7 +61,7 @@ def test_deferred_handle_round_trip_serialization() -> None:
 
 
 @pytest.mark.asyncio
-async def test_defer_many_requires_at_least_one_prompt(
+async def test_defer_requires_at_least_one_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Deferred jobs should not allow the realtime no-op prompt shape."""
@@ -60,7 +70,7 @@ async def test_defer_many_requires_at_least_one_prompt(
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
 
     with pytest.raises(ConfigurationError, match="requires at least one prompt"):
-        await pollux.defer_many([], config=cfg)
+        await pollux.defer([], config=cfg)
 
 
 @pytest.mark.asyncio
@@ -76,7 +86,7 @@ async def test_deferred_provider_validation_runs_before_uploads(
 
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
     with pytest.raises(ConfigurationError, match="validation failed"):
-        await pollux.defer_many(
+        await pollux.defer(
             ("Q1?",),
             sources=(Source.from_file(file_path, mime_type="application/pdf"),),
             config=cfg,
@@ -93,7 +103,7 @@ async def test_defer_rejects_global_mock_provider() -> None:
     cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
     with pytest.raises(ConfigurationError, match="does not support deferred delivery"):
-        await pollux.defer_many(
+        await pollux.defer(
             ("Summarize this text", "List two risks"),
             sources=(Source.from_text("shared context"),),
             config=cfg,
@@ -109,7 +119,7 @@ async def test_defer_collect_smoke_without_lifecycle_config(
     monkeypatch.setattr(pollux, "_create_provider", lambda *_a, **_kw: fake)
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
 
-    job = await pollux.defer_many(
+    job = await pollux.defer(
         ("Q1?", "Q2?"),
         sources=(Source.from_text("shared"),),
         config=cfg,
@@ -124,10 +134,12 @@ async def test_defer_collect_smoke_without_lifecycle_config(
 
     assert snapshot.is_terminal is True
     assert snapshot.status == "completed"
-    assert result["answers"] == ["ok:Q1?", "ok:Q2?"]
-    assert result["metrics"]["deferred"] is True
-    assert result["diagnostics"]["deferred"]["job_id"] == job.job_id
-    assert [item["status"] for item in result["diagnostics"]["deferred"]["items"]] == [
+    assert isinstance(result, OutputCollection)
+    assert result.answers == ["ok:Q1?", "ok:Q2?"]
+    raw = result.outputs[0].diagnostics.raw
+    assert raw is not None
+    assert raw["deferred"]["job_id"] == job.job_id
+    assert [item["status"] for item in _deferred_items(result)] == [
         "succeeded",
         "succeeded",
     ]
@@ -167,21 +179,17 @@ async def test_collect_deferred_validates_schema_fingerprint(
     monkeypatch.setattr(pollux, "_create_provider", lambda *_a, **_kw: fake)
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
 
-    job = await pollux.defer(
-        "Q1?",
-        config=cfg,
-        options=Options(response_schema=SubmitSchema),
-    )
+    job = await pollux.defer("Q1?", config=cfg, output=SubmitSchema)
 
     with pytest.raises(ConfigurationError, match="does not match"):
         await pollux.collect_deferred(job, response_schema=OtherSchema)
 
 
 @pytest.mark.asyncio
-async def test_collect_deferred_without_schema_returns_plain_structured_dicts(
+async def test_collect_deferred_without_schema_does_not_rehydrate_structured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Omitting response_schema at collect time should return plain dicts."""
+    """Without a collect-time schema, structured stays unset (realtime parity)."""
 
     class SubmitSchema(BaseModel):
         title: str
@@ -204,14 +212,45 @@ async def test_collect_deferred_without_schema_returns_plain_structured_dicts(
     monkeypatch.setattr(pollux, "_create_provider", lambda *_a, **_kw: fake)
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
 
-    job = await pollux.defer(
-        "Q1?",
-        config=cfg,
-        options=Options(response_schema=SubmitSchema),
-    )
+    job = await pollux.defer("Q1?", config=cfg, output=SubmitSchema)
     result = await pollux.collect_deferred(job)
 
-    assert result["structured"] == [{"title": "A"}]
+    assert result.structured == [None]
+    assert result.answers == ['{"title":"A"}']
+
+
+@pytest.mark.asyncio
+async def test_collect_deferred_with_schema_rehydrates_structured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing the submission schema at collect time rehydrates structured output."""
+
+    class SubmitSchema(BaseModel):
+        title: str
+
+    fake = InMemoryDeferredProvider(
+        item_overrides={
+            "pollux-000000": ProviderDeferredItem(
+                request_id="pollux-000000",
+                status="succeeded",
+                response={
+                    "text": '{"title":"A"}',
+                    "structured": {"title": "A"},
+                    "usage": {"total_tokens": 1},
+                },
+                provider_status="succeeded",
+                finish_reason="stop",
+            )
+        }
+    )
+    monkeypatch.setattr(pollux, "_create_provider", lambda *_a, **_kw: fake)
+    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+
+    job = await pollux.defer("Q1?", config=cfg, output=SubmitSchema)
+    result = await pollux.collect_deferred(job, response_schema=SubmitSchema)
+
+    assert isinstance(result.outputs[0].structured, SubmitSchema)
+    assert result.outputs[0].structured.title == "A"
 
 
 @pytest.mark.asyncio
@@ -234,12 +273,12 @@ async def test_deferred_partial_failures_preserve_order_and_diagnostics(
     monkeypatch.setattr(pollux, "_create_provider", lambda *_a, **_kw: fake)
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
 
-    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    job = await pollux.defer(("Q1?", "Q2?"), config=cfg)
     result = await pollux.collect_deferred(job)
 
-    assert result["status"] == "partial"
-    assert result["answers"] == ["ok:Q1?", ""]
-    assert result["diagnostics"]["deferred"]["items"] == [
+    assert result.status == "partial"
+    assert result.answers == ["ok:Q1?", ""]
+    assert _deferred_items(result) == [
         {
             "request_id": "pollux-000000",
             "status": "succeeded",
@@ -255,47 +294,7 @@ async def test_deferred_partial_failures_preserve_order_and_diagnostics(
             "finish_reason": "error",
         },
     ]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("options", "match"),
-    [
-        (
-            Options(cache=CacheHandle("c", "openai", OPENAI_MODEL, 9999999999.0)),
-            "cache",
-        ),
-        (
-            Options(history=[{"role": "user", "content": "hi"}]),
-            "Conversation continuity",
-        ),
-        (
-            Options(tools=[{"type": "function", "function": {"name": "x"}}]),
-            "Tool calling",
-        ),
-        (Options(implicit_caching=True), "implicit_caching"),
-        (Options(implicit_caching=False), "implicit_caching"),
-    ],
-    ids=[
-        "cache",
-        "history",
-        "tools",
-        "implicit_caching_true",
-        "implicit_caching_false",
-    ],
-)
-async def test_defer_rejects_out_of_scope_options(
-    monkeypatch: pytest.MonkeyPatch,
-    options: Options,
-    match: str,
-) -> None:
-    """Deferred APIs should reject options that are explicitly out of scope."""
-    fake = InMemoryDeferredProvider()
-    monkeypatch.setattr(pollux, "_create_provider", lambda *_a, **_kw: fake)
-    cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
-
-    with pytest.raises(ConfigurationError, match=match):
-        await pollux.defer("Q1?", config=cfg, options=options)
+    assert result.outputs[1].metrics.completion_status == "error"
 
 
 @pytest.mark.asyncio
@@ -409,15 +408,15 @@ async def test_openai_deferred_backend_integrates_with_public_api(
     monkeypatch.setattr(pollux, "_create_provider", _make_provider)
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
 
-    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    job = await pollux.defer(("Q1?", "Q2?"), config=cfg)
     snapshot = await pollux.inspect_deferred(job)
     result = await pollux.collect_deferred(job)
     await pollux.cancel_deferred(job)
 
     assert snapshot.status == "partial"
-    assert result["status"] == "partial"
-    assert result["answers"] == ["", "Answer 2"]
-    assert result["diagnostics"]["deferred"]["items"] == [
+    assert result.status == "partial"
+    assert result.answers == ["", "Answer 2"]
+    assert _deferred_items(result) == [
         {
             "request_id": "pollux-000000",
             "status": "failed",
@@ -516,7 +515,7 @@ async def test_openai_deferred_partial_cancel_returns_partial_result(
     monkeypatch.setattr(pollux, "_create_provider", _make_provider)
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
 
-    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    job = await pollux.defer(("Q1?", "Q2?"), config=cfg)
     snapshot = await pollux.inspect_deferred(job)
     result = await pollux.collect_deferred(job)
 
@@ -525,9 +524,9 @@ async def test_openai_deferred_partial_cancel_returns_partial_result(
     assert snapshot.succeeded == 1
     assert snapshot.failed == 1
     assert snapshot.pending == 0
-    assert result["status"] == "partial"
-    assert result["answers"] == ["Answer 1", ""]
-    assert result["diagnostics"]["deferred"]["items"] == [
+    assert result.status == "partial"
+    assert result.answers == ["Answer 1", ""]
+    assert _deferred_items(result) == [
         {
             "request_id": "pollux-000000",
             "status": "succeeded",
@@ -628,8 +627,8 @@ async def test_openai_deferred_collection_does_not_invent_structured_without_sch
     job = await pollux.defer('Return {"plain":true}', config=cfg)
     result = await pollux.collect_deferred(job)
 
-    assert result["answers"] == ['{"plain":true}']
-    assert "structured" not in result
+    assert result.answers == ['{"plain":true}']
+    assert result.structured == [None]
 
 
 @pytest.mark.asyncio
@@ -690,7 +689,7 @@ async def test_openai_deferred_batch_level_failure_returns_error_envelope(
     monkeypatch.setattr(pollux, "_create_provider", _make_provider)
     cfg = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
 
-    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    job = await pollux.defer(("Q1?", "Q2?"), config=cfg)
     snapshot = await pollux.inspect_deferred(job)
     result = await pollux.collect_deferred(job)
 
@@ -698,9 +697,9 @@ async def test_openai_deferred_batch_level_failure_returns_error_envelope(
     assert snapshot.request_count == 2
     assert snapshot.failed == 2
     assert snapshot.pending == 0
-    assert result["status"] == "error"
-    assert result["answers"] == ["", ""]
-    assert result["diagnostics"]["deferred"]["items"] == [
+    assert result.status == "error"
+    assert result.answers == ["", ""]
+    assert _deferred_items(result) == [
         {
             "request_id": "pollux-000000",
             "status": "failed",
@@ -799,15 +798,15 @@ async def test_gemini_deferred_backend_integrates_with_public_api(
     monkeypatch.setattr(pollux, "_create_provider", _make_provider)
     cfg = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
 
-    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    job = await pollux.defer(("Q1?", "Q2?"), config=cfg)
     snapshot = await pollux.inspect_deferred(job)
     result = await pollux.collect_deferred(job)
     await pollux.cancel_deferred(job)
 
     assert snapshot.status == "partial"
-    assert result["status"] == "partial"
-    assert result["answers"] == ["", "Answer 2"]
-    assert result["diagnostics"]["deferred"]["items"] == [
+    assert result.status == "partial"
+    assert result.answers == ["", "Answer 2"]
+    assert _deferred_items(result) == [
         {
             "request_id": "pollux-000000",
             "status": "failed",
@@ -965,15 +964,15 @@ async def test_anthropic_deferred_backend_integrates_with_public_api(
     monkeypatch.setattr(pollux, "_create_provider", _make_provider)
     cfg = Config(provider="anthropic", model=ANTHROPIC_MODEL, use_mock=True)
 
-    job = await pollux.defer_many(("Q1?", "Q2?"), config=cfg)
+    job = await pollux.defer(("Q1?", "Q2?"), config=cfg)
     snapshot = await pollux.inspect_deferred(job)
     result = await pollux.collect_deferred(job)
     await pollux.cancel_deferred(job)
 
     assert snapshot.status == "partial"
-    assert result["status"] == "partial"
-    assert result["answers"] == ["", "Answer 2"]
-    assert result["diagnostics"]["deferred"]["items"] == [
+    assert result.status == "partial"
+    assert result.answers == ["", "Answer 2"]
+    assert _deferred_items(result) == [
         {
             "request_id": "pollux-000000",
             "status": "cancelled",


### PR DESCRIPTION
## Summary

Aligns the deferred timeline with the v2 interaction model and removes the v1 `Plan`/`Options`/`ResultEnvelope` dependency from the deferred path - de-risking the eventual v1-surface deletion. `defer()` becomes the single deferred entry point and `collect_deferred()` returns the same `OutputCollection` shape as `run_many()`.

## Related issue

None

## Test plan

- `just check` → **406 passed / 1 skipped / 19 deselected**; ruff + rumdl + mypy strict clean.
- `uv run mkdocs build --strict` → clean.
- `tests/pipeline/test_deferred.py` (16) migrated to `OutputCollection` facets and the new `defer()` signature, covering the in-memory provider plus the OpenAI / Gemini / Anthropic deferred backends (partial, cancel, batch-failure, structured-rehydration paths). `tests/providers/test_deferred_delivery.py` is provider-level and unchanged.

## Notes

- **Submission:** `submit_deferred(environment, inputs, requirements, config, provider)` compiles through `compile_request` and validates with `validate_interaction`; the deferred-support gate runs first so an unsupported provider still fails with the clearest message. Uploads continue to happen inside the provider's `submit_deferred` (compile emits file placeholders), so no behavior change there.
- **Collection:** one `Output` per request in submission order; per-item provenance on `output.diagnostics.raw["deferred"]` (`job_id`, `request_id`, `status`, `error`, `provider_status`, `finish_reason`). A failed item reports `metrics.completion_status == "error"`. Structured output is now realtime-consistent - populated only when the schema is passed at collect time (the v1 "plain dict without schema" special-case is dropped).
- **Surface:** `defer()` takes first-class kwargs (no `Options`) and accepts one prompt or a collection; `defer_many()` is removed. The old "reject out-of-scope Options" test is deleted because those kwargs no longer exist on the surface (architectural guarantee).
- **Deliberately deferred:** `request.py` / `plan.py` / `normalize_request` / `build_plan` are now unused by `__init__` - they come out in **3e** (v1-surface deletion), along with `Options`/`ResultEnvelope` which stay exported until then. `test_api.py` remains shelved (it mixes v1 realtime + deferred assertions in one module-skip; a partial un-shelve isn't coherent - whole-module migration is its own task).

BREAKING CHANGE: `defer()` no longer accepts `Options`; `defer_many()` is removed; `collect_deferred()` returns `OutputCollection` instead of `ResultEnvelope`.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] \`just check\` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)