### PR TITLE
feat(core): add tool calling to the local provider

### DIFF
--- a/docs/migrating-to-v2.md
+++ b/docs/migrating-to-v2.md
@@ -135,7 +135,7 @@ The 2.0 interaction model is landing incrementally on `main`:
 - `interact(environment, input, *, config, **generation_kwargs) -> Output` runs
   one explicit interaction over an `Environment` and `Input`. Continue a
   conversation or tool loop by passing the prior `Output`'s `continuation` and any
-  `tool_results` in the next `Input` — the replacement for `continue_tool()`.
+  `tool_results` in the next `Input`, the replacement for `continue_tool()`.
 
 `defer()` now follows the same model: it accepts one prompt or a collection,
 and `collect_deferred()` returns an `OutputCollection`. Persistent caching

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -68,7 +68,8 @@ provider-specific helpers such as `Source.with_gemini_video_settings(...)` and
 
 The canonical v2 interaction model. `interact()` takes an `Environment` and an
 `Input` and returns an `Output`; `OutputCollection` is the source-pattern
-aggregate. These coexist with the 1.x types during the 2.0 cutover.
+aggregate that `run_many()` and `collect_deferred()` return. The 1.x `Options`
+and `ResultEnvelope` types are no longer part of the public API.
 
 ::: pollux.Environment
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -57,9 +57,9 @@ before dispatch or the provider page below calls out why it is out of scope.
 | Reasoning output (`result["reasoning"]`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ⚠️ server/model-dependent | Pollux surfaces reasoning text when providers return it |
 | `reasoning_effort` | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.); exact model support remains provider-defined |
 | `reasoning_budget_tokens` | ✅ | ❌ | ✅ | ❌ | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
-| Function tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | `Options.tools` is for Pollux-normalized client/application tools |
+| Function tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Pollux-normalized client/application tools; local trusts the server, no capability probe |
 | Provider-hosted tools | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ server-dependent | Raw provider escape hatch; not normalized by Pollux |
-| Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Works on OpenRouter models that support tool calling |
+| Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Local replays assistant tool calls and `tool`-role results verbatim |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
 For when deferred delivery is a fit and how to structure code around provider
@@ -199,12 +199,18 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - `base_url` is required (via `Config(base_url=...)` or the
   `POLLUX_LOCAL_BASE_URL` environment variable). `api_key` is optional; most
   self-hosted servers ignore it.
-- The supported surface is intentionally narrow: text in, text or JSON out.
-  Pollux passively surfaces model-native reasoning text when the server returns
+- The supported surface is text or tool calls in, text or JSON out. Pollux
+  passively surfaces model-native reasoning text when the server returns
   `reasoning_content`, but it does not send portable reasoning controls.
-  File uploads, remote URLs, multimodal parts, tool calling, reasoning controls,
-  explicit and implicit caching, and deferred delivery are not supported.
-  Requesting any of them raises `ConfigurationError` before dispatch.
+  File uploads, remote URLs, multimodal parts, reasoning controls, explicit and
+  implicit caching, and deferred delivery are not supported. Requesting any of
+  them raises `ConfigurationError` before dispatch.
+- Function tool calling is supported through the standard `tools` /
+  `tool_choice` fields: Pollux sends the declarations, replays assistant tool
+  calls and tool results on continuation turns, and surfaces returned tool calls
+  on the response. Like JSON mode, this trusts the server — there is no
+  per-model capability probe, and a server that ignores `tools` simply never
+  emits tool calls.
 - Structured outputs use OpenAI-compatible JSON schema mode
   (`response_format={"type": "json_schema", ...}`). Server-side schema
   enforcement quality varies. Pydantic schema inputs are validated downstream

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -8,7 +8,7 @@
 
 This page defines the current capability contract by provider.
 
-Pollux is **capability-transparent**, not capability-equalizing: providers are allowed to differ, and those differences are surfaced clearly.
+Pollux is **capability-transparent**, not capability-equalizing: providers are allowed to differ, and those differences are surfaced explicitly.
 
 ## Policy
 
@@ -30,7 +30,7 @@ before dispatch or the provider page below calls out why it is out of scope.
 | Text generation | ✅ | ✅ | ✅ | ✅ | ✅ | Core feature |
 | Multi-prompt execution (`run_many`) | ✅ | ✅ | ✅ | ✅ | ✅ | One call per prompt, shared context |
 | Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (JSON schema mode) | Local sends `json_schema`; schema enforcement quality varies by server |
-| Deferred delivery (`defer*`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | ❌ | Use the deferred API directly |
+| Deferred delivery (`defer`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | ❌ | Use the deferred API directly |
 
 ### Inputs
 
@@ -202,15 +202,15 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - The supported surface is text or tool calls in, text or JSON out. Pollux
   passively surfaces model-native reasoning text when the server returns
   `reasoning_content`, but it does not send portable reasoning controls.
-  File uploads, remote URLs, multimodal parts, reasoning controls, explicit and
-  implicit caching, and deferred delivery are not supported. Requesting any of
-  them raises `ConfigurationError` before dispatch.
+  File uploads, remote URLs, multimodal parts, reasoning controls, persistent
+  and provider-managed caching, and deferred delivery are not supported.
+  Requesting any of them raises `ConfigurationError` before dispatch.
 - Function tool calling is supported through the standard `tools` /
   `tool_choice` fields: Pollux sends the declarations, replays assistant tool
   calls and tool results on continuation turns, and surfaces returned tool calls
-  on the response. Like JSON mode, this trusts the server — there is no
-  per-model capability probe, and a server that ignores `tools` simply never
-  emits tool calls.
+  on the response. Like JSON mode, this trusts the server: there is no
+  per-model capability probe, and a server that ignores `tools` never emits
+  tool calls.
 - Structured outputs use OpenAI-compatible JSON schema mode
   (`response_format={"type": "json_schema", ...}`). Server-side schema
   enforcement quality varies. Pydantic schema inputs are validated downstream

--- a/docs/submitting-work-for-later-collection.md
+++ b/docs/submitting-work-for-later-collection.md
@@ -88,7 +88,7 @@ Run `submit_job()` once. You should see a provider job id and a JSON file at
 `outputs/deferred-job.json`. Run `collect_job()` later. `inspect_deferred()`
 normalizes the lifecycle into `queued`, `running`, `cancelling`, `completed`,
 `partial`, `failed`, `cancelled`, or `expired`. Once `snapshot.is_terminal`
-turns `True`, `collect_deferred()` returns an `OutputCollection` — the same
+turns `True`, `collect_deferred()` returns an `OutputCollection`, the same
 shape `run_many()` returns.
 
 ### Why this example is shaped this way

--- a/src/pollux/providers/_openai_compat.py
+++ b/src/pollux/providers/_openai_compat.py
@@ -2,20 +2,24 @@
 
 Both the self-hosted ``local`` provider and the ``openrouter`` provider speak
 OpenAI-compatible Chat Completions over httpx. The request shaping and input
-handling differ (local is text-only; OpenRouter handles multimodal parts,
-tools, and reasoning), but the primitives that read a Chat Completions *response*
-are identical. This module owns that shared wire vocabulary so the two adapters
-parse responses, usage, and errors one way.
+handling differ (local is text-only; OpenRouter handles multimodal parts and
+reasoning), but the primitives that read a Chat Completions *response* and shape
+its tool vocabulary are identical. This module owns that shared wire vocabulary
+so the two adapters parse responses, usage, errors, and tool calls one way.
 
 These helpers are deliberately stateless and provider-neutral. Provider-specific
-behavior (reasoning extraction, tool-call parsing, nested upstream errors) stays
+behavior (reasoning extraction, nested upstream errors, multimodal parts) stays
 in the adapters and layers on top of these primitives.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
+import json
 from typing import TYPE_CHECKING, Any
+
+from pollux.providers._utils import to_strict_schema
+from pollux.providers.models import ToolCall
 
 if TYPE_CHECKING:
     import httpx
@@ -119,3 +123,87 @@ def extract_error_message(response: httpx.Response) -> str:
             return message
     text = response.text.strip()
     return text or f"HTTP {response.status_code}"
+
+
+def normalize_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert Pollux tool dicts to Chat Completions ``function`` tool format."""
+    result: list[dict[str, Any]] = []
+    for tool in tools:
+        name = tool.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+
+        function: dict[str, Any] = {"name": name}
+        description = tool.get("description")
+        if isinstance(description, str) and description:
+            function["description"] = description
+        parameters = tool.get("parameters")
+        if isinstance(parameters, dict):
+            function["parameters"] = to_strict_schema(parameters)
+
+        result.append({"type": "function", "function": function})
+    return result
+
+
+def map_tool_choice(
+    tool_choice: str | dict[str, Any] | None,
+) -> str | dict[str, Any] | None:
+    """Map a Pollux ``tool_choice`` to the Chat Completions shape."""
+    if tool_choice is None:
+        return None
+    if isinstance(tool_choice, str):
+        return tool_choice
+    if isinstance(tool_choice, dict) and isinstance(tool_choice.get("name"), str):
+        return {
+            "type": "function",
+            "function": {"name": tool_choice["name"]},
+        }
+    return None
+
+
+def parse_tool_calls(value: Any) -> list[ToolCall]:
+    """Extract tool calls from a Chat Completions assistant message."""
+    if not isinstance(value, list):
+        return []
+
+    tool_calls: list[ToolCall] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            continue
+        function = item.get("function")
+        if not isinstance(function, Mapping):
+            continue
+
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+
+        raw_arguments = function.get("arguments")
+        if isinstance(raw_arguments, str):
+            arguments = raw_arguments
+        else:
+            arguments = json.dumps(raw_arguments if raw_arguments is not None else {})
+
+        raw_id = item.get("id")
+        call_id = raw_id if isinstance(raw_id, str) and raw_id else f"call_{idx}"
+        tool_calls.append(ToolCall(id=call_id, name=name, arguments=arguments))
+
+    return tool_calls
+
+
+def serialize_tool_calls(tool_calls: list[ToolCall] | None) -> list[dict[str, Any]]:
+    """Serialize Pollux tool calls into the Chat Completions assistant shape."""
+    if not tool_calls:
+        return []
+
+    return [
+        {
+            "id": tool_call.id,
+            "type": "function",
+            "function": {
+                "name": tool_call.name,
+                "arguments": tool_call.arguments,
+            },
+        }
+        for tool_call in tool_calls
+    ]

--- a/src/pollux/providers/local.py
+++ b/src/pollux/providers/local.py
@@ -1,11 +1,17 @@
 """Local Chat Completions provider for self-hosted inference servers.
 
 Pollux targets the OpenAI Chat Completions wire format here, not a specific
-inference engine. The supported surface is deliberately narrow: text in, text or
-JSON out. Model-native reasoning text is surfaced when returned, but reasoning
-controls, file uploads, context caching, tool calling, and deferred delivery are
-intentionally unsupported. Those belong to cloud providers, inference servers,
-or application code, not to Pollux's orchestration layer.
+inference engine. The supported surface is text or tool calls in, text or JSON
+out: model-native reasoning text is surfaced when returned, and tool calling is
+sent through the standard ``tools``/``tool_choice`` fields so a local server can
+drive an agent loop. Reasoning controls, file uploads, context caching, and
+deferred delivery stay unsupported — those belong to cloud providers, inference
+servers, or application code, not to Pollux's orchestration layer.
+
+Tool support trusts the server the same way JSON mode does: Pollux sends the
+declarations and replays tool turns, and a server that ignores ``tools`` simply
+never emits tool calls. There is no per-model capability probe (local servers
+vary too much to query reliably).
 """
 
 from __future__ import annotations
@@ -26,7 +32,11 @@ from pollux.providers._openai_compat import (
     extract_message_text,
     extract_response_id,
     first_choice_message,
+    map_tool_choice,
+    normalize_tools,
+    parse_tool_calls,
     parse_usage,
+    serialize_tool_calls,
 )
 from pollux.providers._utils import merge_provider_options, to_strict_schema
 from pollux.providers.base import ProviderCapabilities
@@ -120,29 +130,6 @@ class LocalProvider:
                     "reasoning controls. Remove reasoning_effort."
                 ),
             )
-        if snapshot.tools or requirements.tool_choice is not None:
-            raise ConfigurationError(
-                "Local provider does not support tool calling",
-                hint=(
-                    "Tool calling is out of scope for the local provider. "
-                    "Use OpenAI, Gemini, or OpenRouter for tool use."
-                ),
-            )
-        history, _previous_response_id, _provider_state = _compile.prior_turns(input)
-        for item in history:
-            if (
-                item.role == "tool"
-                or item.tool_call_id is not None
-                or item.tool_calls is not None
-            ):
-                raise ConfigurationError(
-                    "Local provider does not support tool-call history",
-                    hint=(
-                        "Start a fresh text-only local conversation, summarize "
-                        "tool results into plain text, or use a provider with "
-                        "tool calling."
-                    ),
-                )
         for part in _compile.request_parts(snapshot, input):
             if not _is_text_part(part):
                 raise ConfigurationError(
@@ -165,6 +152,7 @@ class LocalProvider:
 
         history, _previous_response_id, _provider_state = _compile.prior_turns(input)
         response_schema = requirements.output_schema_json()
+        tools = _compile.tool_dicts(snapshot)
         messages = _build_messages(
             _compile.request_parts(snapshot, input),
             history or None,
@@ -180,6 +168,11 @@ class LocalProvider:
             payload["top_p"] = requirements.top_p
         if requirements.max_tokens is not None:
             payload["max_tokens"] = requirements.max_tokens
+        if tools is not None:
+            payload["tools"] = normalize_tools(tools)
+            mapped_tool_choice = map_tool_choice(requirements.tool_choice)
+            if mapped_tool_choice is not None:
+                payload["tool_choice"] = mapped_tool_choice
         if response_schema is not None:
             strict_schema = to_strict_schema(response_schema)
             # Servers that support Chat Completions JSON schema mode can map this
@@ -313,14 +306,28 @@ def _build_messages(
 def _history_message(item: Message) -> dict[str, Any] | None:
     """Map a Pollux history message to Chat Completions format.
 
-    Tool-call history is unsupported and rejected by ``validate_request`` before
-    dispatch; this helper only maps text-only conversation turns.
+    Tool turns replay as the standard ``tool``-role result message and assistant
+    ``tool_calls`` array; empty assistant turns carrying neither text nor a tool
+    call are dropped so the transcript stays well-formed.
     """
     if item.role == "tool":
+        if not item.tool_call_id:
+            return None
+        return {
+            "role": "tool",
+            "tool_call_id": item.tool_call_id,
+            "content": item.content,
+        }
+
+    message: dict[str, Any] = {"role": item.role, "content": item.content}
+    tool_calls = serialize_tool_calls(item.tool_calls)
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    if item.role == "assistant" and not item.content and not tool_calls:
         return None
-    if not item.content:
-        return None
-    return {"role": item.role, "content": item.content}
+
+    return message
 
 
 def _join_text_parts(parts: list[Any]) -> str:
@@ -366,11 +373,14 @@ def _parse_response(
         except Exception:
             structured = None
 
+    tool_calls = parse_tool_calls(message.get("tool_calls"))
+
     return ProviderResponse(
         text=text,
         usage=parse_usage(data.get("usage")),
         reasoning=reasoning,
         structured=structured,
+        tool_calls=tool_calls or None,
         response_id=extract_response_id(data),
         finish_reason=extract_finish_reason(choice),
     )

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -23,7 +23,11 @@ from pollux.providers._openai_compat import (
     extract_message_text,
     extract_response_id,
     first_choice_message,
+    map_tool_choice,
+    normalize_tools,
+    parse_tool_calls,
     parse_usage,
+    serialize_tool_calls,
 )
 from pollux.providers._utils import merge_provider_options, to_strict_schema
 from pollux.providers.base import ProviderCapabilities
@@ -31,7 +35,6 @@ from pollux.providers.models import (
     Message,
     ProviderFileAsset,
     ProviderResponse,
-    ToolCall,
 )
 
 _OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -127,8 +130,8 @@ class OpenRouterProvider:
         if requirements.max_tokens is not None:
             payload["max_tokens"] = requirements.max_tokens
         if tools is not None:
-            payload["tools"] = self._normalize_tools(tools)
-            mapped_tool_choice = self._map_tool_choice(requirements.tool_choice)
+            payload["tools"] = normalize_tools(tools)
+            mapped_tool_choice = map_tool_choice(requirements.tool_choice)
             if mapped_tool_choice is not None:
                 payload["tool_choice"] = mapped_tool_choice
         if requirements.reasoning_effort is not None:
@@ -177,42 +180,6 @@ class OpenRouterProvider:
             )
 
         return _parse_response(data, response_schema=response_schema)
-
-    @staticmethod
-    def _normalize_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Convert Pollux tool dicts to OpenRouter chat-completions format."""
-        result: list[dict[str, Any]] = []
-        for tool in tools:
-            name = tool.get("name")
-            if not isinstance(name, str) or not name:
-                continue
-
-            function: dict[str, Any] = {"name": name}
-            description = tool.get("description")
-            if isinstance(description, str) and description:
-                function["description"] = description
-            parameters = tool.get("parameters")
-            if isinstance(parameters, dict):
-                function["parameters"] = to_strict_schema(parameters)
-
-            result.append({"type": "function", "function": function})
-        return result
-
-    @staticmethod
-    def _map_tool_choice(
-        tool_choice: str | dict[str, Any] | None,
-    ) -> str | dict[str, Any] | None:
-        """Map Pollux tool_choice to OpenRouter chat-completions shape."""
-        if tool_choice is None:
-            return None
-        if isinstance(tool_choice, str):
-            return tool_choice
-        if isinstance(tool_choice, dict) and isinstance(tool_choice.get("name"), str):
-            return {
-                "type": "function",
-                "function": {"name": tool_choice["name"]},
-            }
-        return None
 
     async def validate_request(
         self,
@@ -443,7 +410,7 @@ def _history_message_to_openrouter(
         }
 
     message: dict[str, Any] = {"role": item.role, "content": item.content}
-    tool_calls = _serialize_tool_calls(item.tool_calls)
+    tool_calls = serialize_tool_calls(item.tool_calls)
     if tool_calls:
         message["tool_calls"] = tool_calls
 
@@ -722,7 +689,7 @@ def _parse_response(
 
     usage = parse_usage(data.get("usage"))
 
-    tool_calls = _parse_tool_calls(message.get("tool_calls"))
+    tool_calls = parse_tool_calls(message.get("tool_calls"))
     reasoning = message.get("reasoning")
     reasoning_details = _normalize_reasoning_details(message.get("reasoning_details"))
     provider_state: dict[str, Any] | None = None
@@ -742,56 +709,6 @@ def _parse_response(
         finish_reason=extract_finish_reason(choice),
         provider_state=provider_state,
     )
-
-
-def _parse_tool_calls(value: Any) -> list[ToolCall]:
-    """Extract tool calls from an OpenRouter chat-completions assistant message."""
-    if not isinstance(value, list):
-        return []
-
-    tool_calls: list[ToolCall] = []
-    for idx, item in enumerate(value):
-        if not isinstance(item, Mapping):
-            continue
-        function = item.get("function")
-        if not isinstance(function, Mapping):
-            continue
-
-        name = function.get("name")
-        if not isinstance(name, str) or not name:
-            continue
-
-        raw_arguments = function.get("arguments")
-        if isinstance(raw_arguments, str):
-            arguments = raw_arguments
-        else:
-            arguments = json.dumps(raw_arguments if raw_arguments is not None else {})
-
-        raw_id = item.get("id")
-        call_id = raw_id if isinstance(raw_id, str) and raw_id else f"call_{idx}"
-        tool_calls.append(ToolCall(id=call_id, name=name, arguments=arguments))
-
-    return tool_calls
-
-
-def _serialize_tool_calls(tool_calls: list[ToolCall] | None) -> list[dict[str, Any]]:
-    """Serialize Pollux tool calls into OpenRouter's OpenAI-compatible shape."""
-    if not tool_calls:
-        return []
-
-    serialized: list[dict[str, Any]] = []
-    for tool_call in tool_calls:
-        serialized.append(
-            {
-                "id": tool_call.id,
-                "type": "function",
-                "function": {
-                    "name": tool_call.name,
-                    "arguments": tool_call.arguments,
-                },
-            }
-        )
-    return serialized
 
 
 def _extract_reasoning(item_provider_state: dict[str, Any] | None) -> str | None:

--- a/tests/interaction/test_provider_tool_translation.py
+++ b/tests/interaction/test_provider_tool_translation.py
@@ -7,25 +7,22 @@ so tool calling is provider-complete through the v2 boundary (not just mock).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from pollux.config import Config, ProviderName
-from pollux.errors import ConfigurationError
 from pollux.interaction.environment import Environment, EnvironmentSnapshot
-from pollux.interaction.execute import execute_interaction
-from pollux.interaction.input import Input
-from pollux.interaction.requirements import OutputRequirements
 from pollux.interaction.tools import ToolDeclaration
 from pollux.providers import _compile
+from pollux.providers._openai_compat import normalize_tools
 from pollux.providers.anthropic import AnthropicProvider
-from pollux.providers.local import LocalProvider
 from pollux.providers.openai import OpenAIProvider
+
+if TYPE_CHECKING:
+    from pollux.config import ProviderName
 
 pytestmark = pytest.mark.unit
 
-_LOCAL_BASE_URL = "http://localhost:1234/v1"
 _TOOL = ToolDeclaration(
     name="get_weather",
     description="Get weather",
@@ -56,15 +53,8 @@ def test_translates_to_openai_function():
     assert "parameters" in tools[0]
 
 
-@pytest.mark.asyncio
-async def test_local_rejects_tools_through_v2():
-    provider = LocalProvider(base_url=_LOCAL_BASE_URL)
-    cfg = Config(provider="local", model="m", base_url=_LOCAL_BASE_URL)
-    with pytest.raises(ConfigurationError):
-        await execute_interaction(
-            Environment(tools=[_TOOL]),
-            Input(content="hi"),
-            OutputRequirements(),
-            cfg,
-            provider,
-        )
+def test_translates_to_local_function():
+    tools = normalize_tools(_compiled_tools("local"))
+    assert tools[0]["type"] == "function"
+    assert tools[0]["function"]["name"] == "get_weather"
+    assert "parameters" in tools[0]["function"]

--- a/tests/providers/test_local_contract.py
+++ b/tests/providers/test_local_contract.py
@@ -8,8 +8,8 @@ import httpx
 import pytest
 
 from pollux.errors import APIError, ConfigurationError
-from pollux.interaction.continuation import Message
-from pollux.interaction.tools import ToolCall
+from pollux.interaction.continuation import Continuation, Message
+from pollux.interaction.tools import ToolCall, ToolResult
 from pollux.providers.local import LocalProvider
 from tests.conftest import (
     LOCAL_MODEL,
@@ -339,53 +339,140 @@ async def test_local_generate_rejects_reasoning_budget_tokens() -> None:
 
 
 @pytest.mark.asyncio
-async def test_local_generate_rejects_tools() -> None:
-    """Tool calling is out of scope for the local provider."""
-    provider = _make_local_provider(_FakeLocalClient())
-
-    with pytest.raises(ConfigurationError, match="tool calling"):
-        await provider.generate(
-            *_local(
-                content="hi",
-                tools=[{"name": "get_weather"}],
-            )
-        )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "history",
-    [
-        [Message(role="tool", content="tool result", tool_call_id="call_1")],
-        [
-            Message(
-                role="assistant",
-                tool_calls=(
-                    ToolCall.from_text(
-                        id="call_1", name="lookup", arguments_text='{"q":"x"}'
-                    ),
-                ),
-            )
-        ],
-    ],
-    ids=["tool_message", "assistant_tool_calls"],
-)
-async def test_local_generate_rejects_tool_call_history(
-    history: list[Message],
-) -> None:
-    """Tool-call history must fail fast instead of dropping context."""
+async def test_local_generate_sends_tools_and_tool_choice() -> None:
+    """Tool declarations and tool_choice map to Chat Completions function shape."""
     fake = _FakeLocalClient()
     provider = _make_local_provider(fake)
 
-    with pytest.raises(ConfigurationError, match="tool-call history"):
-        await provider.generate(
-            *_local(
-                content="continue",
-                history=history,
-            )
+    await provider.generate(
+        *_local(
+            content="What's the weather?",
+            tools=[
+                {
+                    "name": "get_weather",
+                    "description": "Look up the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                }
+            ],
+            tool_choice={"name": "get_weather"},
         )
+    )
 
-    assert fake.last_json is None
+    assert fake.last_json is not None
+    assert fake.last_json["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up the weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "additionalProperties": False,
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    assert fake.last_json["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "get_weather"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_local_generate_replays_tool_history() -> None:
+    """Assistant tool_calls and tool results replay as standard chat messages.
+
+    Mirrors an agent loop: prior turns arrive as a continuation, and the tool
+    result for the pending call arrives via ``tool_results`` (no new user text).
+    """
+    fake = _FakeLocalClient()
+    provider = _make_local_provider(fake)
+
+    await provider.generate(
+        *_local(
+            content="",
+            continuation=Continuation(
+                messages=(
+                    Message(role="user", content="What's the weather in NYC?"),
+                    Message(
+                        role="assistant",
+                        content="",
+                        tool_calls=(
+                            ToolCall.from_text(
+                                id="call_1",
+                                name="get_weather",
+                                arguments_text='{"city":"NYC"}',
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            tool_results=[ToolResult(call_id="call_1", content='{"temp":72}')],
+        )
+    )
+
+    assert fake.last_json is not None
+    assert fake.last_json["messages"] == [
+        {"role": "user", "content": "What's the weather in NYC?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"NYC"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": '{"temp":72}'},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_local_generate_parses_tool_calls() -> None:
+    """tool_calls in the response surface on the ProviderResponse."""
+    fake = _FakeLocalClient(
+        payload={
+            "id": "chatcmpl_local_tool",
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_xyz",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"city":"NYC"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"total_tokens": 7},
+        }
+    )
+    provider = _make_local_provider(fake)
+
+    result = await provider.generate(*_local(content="Weather in NYC?"))
+
+    assert result.finish_reason == "tool_calls"
+    assert result.tool_calls is not None
+    assert result.tool_calls[0].id == "call_xyz"
+    assert result.tool_calls[0].name == "get_weather"
+    assert result.tool_calls[0].arguments == '{"city":"NYC"}'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Teach the self-hosted OpenAI-compatible `local` provider to do function tool
calling: it now sends tool declarations and `tool_choice`, replays assistant
tool calls and tool results on continuation turns, and surfaces returned tool
calls on the response. Local previously hard-rejected tools, `tool_choice`, and
any tool-call history. This unblocks driving a local agent loop through Pollux
v2 instead of hand-rolling the Chat Completions tool plumbing.

## Related issue

None

## Test plan

- `just check` → **387 passed, 6 skipped** (format, lint, mypy, pytest).
- `uv run mkdocs build --strict` → clean.
- New/changed coverage in `tests/providers/test_local_contract.py`: replaced the
  two reject tests with `test_local_generate_sends_tools_and_tool_choice`,
  `test_local_generate_replays_tool_history` (agent-loop shape: continuation +
  `tool_results`), and `test_local_generate_parses_tool_calls`.
- `tests/interaction/test_provider_tool_translation.py`: replaced
  `test_local_rejects_tools_through_v2` with a `normalize_tools` translation
  assertion, matching the openai/anthropic checks in that file.
- OpenRouter's existing contract tests (unchanged) pin the shared tool helpers'
  wire shapes, so the extraction is proven equivalent.

## Notes

Two deliberate design calls:

1. **No new `tools` capability flag.** Tools are not centrally capability-gated
   anywhere - `validate_interaction` ignores them and every other tool-capable
   provider just accepts them. Only `local` hard-rejected (in its own
   `validate_request`). So local joins the tool-capable set by dropping its
   rejection; a flag nothing reads would be dead surface. This also means the
   deferred capability mixin-protocol decomposition is **not** forced here.
2. **Shared the Chat Completions tool vocabulary.** `normalize_tools`,
   `map_tool_choice`, `parse_tool_calls`, and `serialize_tool_calls` were
   byte-identical in OpenRouter, so they move into `providers/_openai_compat.py`
   and both adapters consume them (removing ~50 duplicated lines plus
   OpenRouter's now-redundant static methods/module funcs).

Like JSON mode, local tool support trusts the server: no per-model capability
probe (local servers vary too much to query reliably). A server that ignores
`tools` simply never emits tool calls.