### PR TITLE
feat(api): add stream() for incremental interaction output

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -17,6 +17,7 @@ For provider-level feature differences, see [Provider Capabilities](provider-cap
 | Ask one prompt about one source (or no source) | `run()` → `Output` | [Sending Content to Models](../sending-content.md) |
 | Ask many prompts against shared sources | `run_many()` → `OutputCollection` | [Analyzing Collections with Source Patterns](../source-patterns.md) |
 | Run one explicit interaction (environment + input), incl. tools/continuation | `interact()` | [Building an Agent Loop](../agent-loop.md) |
+| Stream one explicit interaction as it arrives | `stream()` → `Event` timeline | [Building an Agent Loop](../agent-loop.md) |
 | Prepare a reusable environment (and front-load cache/upload I/O) | `prepare_environment()` → `Environment` | [Reducing Costs with Context Caching](../caching.md) |
 | Submit non-urgent work and collect it later | `defer()` → `DeferredHandle` | [Building With Deferred Delivery](../building-with-deferred-delivery.md) |
 | Check deferred job status or collect terminal results | `inspect_deferred()` / `collect_deferred()` / `cancel_deferred()` | [Submitting Work for Later Collection](../submitting-work-for-later-collection.md) |
@@ -37,6 +38,8 @@ The primary execution functions are exported from `pollux`:
 ::: pollux.run_many
 
 ::: pollux.interact
+
+::: pollux.stream
 
 ::: pollux.prepare_environment
 
@@ -76,6 +79,8 @@ and `ResultEnvelope` types are no longer part of the public API.
 ::: pollux.Input
 
 ::: pollux.Output
+
+::: pollux.Event
 
 ::: pollux.OutputCollection
 

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -60,6 +60,7 @@ before dispatch or the provider page below calls out why it is out of scope.
 | Function tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Pollux-normalized client/application tools; local trusts the server, no capability probe |
 | Provider-hosted tools | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ server-dependent | Raw provider escape hatch; not normalized by Pollux |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Local replays assistant tool calls and `tool`-role results verbatim |
+| Streaming (`stream()` → `Event`) | ❌ | ❌ | ❌ | ❌ | ✅ | Streamed `done.output` matches the non-streaming `Output`; cloud providers land in a later slice |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
 For when deferred delivery is a fit and how to structure code around provider

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -52,12 +52,14 @@ from pollux.interaction import (
     Continuation,
     Environment,
     EnvironmentSnapshot,
+    Event,
     Input,
     Message,
     Output,
     OutputCollection,
     OutputRequirements,
     ToolCall,
+    ToolCallDelta,
     ToolChoice,
     ToolDeclaration,
     ToolResult,
@@ -66,13 +68,14 @@ from pollux.interaction.execute import (
     execute_interaction,
     execute_interactions,
     resolve_persistent_cache,
+    stream_interaction,
 )
 from pollux.providers.base import CloseableProvider
 from pollux.retry import RetryPolicy
 from pollux.source import Source
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import AsyncIterator, Callable, Sequence
 
     from pollux.interaction.schema import ResponseSchemaInput
     from pollux.providers.base import Provider
@@ -264,6 +267,79 @@ async def interact(
         return await execute_interaction(
             environment, input, requirements, config, provider
         )
+    finally:
+        await _close_provider(provider)
+
+
+async def stream(
+    environment: Environment,
+    input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+    *,
+    config: Config,
+    output: ResponseSchemaInput | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    seed: int | None = None,
+    reasoning_effort: str | None = None,
+    reasoning_budget_tokens: int | None = None,
+    tool_choice: ToolChoice | None = None,
+    provider_options: dict[str, dict[str, Any]] | None = None,
+) -> AsyncIterator[Event]:
+    """Stream one explicit v2 interaction as :class:`Event` objects.
+
+    The streaming sibling of :func:`interact`: same environment/input/config and
+    the same completed result, observed as a timeline. Iterate the events
+    (``text_delta``, ``reasoning_delta``, ``tool_call_delta``, ``tool_call``,
+    ``usage``, ``finish``) and read the final assembled :class:`Output` from the
+    terminal ``done`` event, whose ``output`` matches what :func:`interact` would
+    return for the same interaction. Consumers never parse SSE or provider chunks.
+
+    A provider that does not support streaming raises ``ConfigurationError``. A
+    mid-stream provider failure raises from the iterator rather than emitting a
+    ``done`` event, so a failed interaction never yields a final output.
+
+    Args:
+        environment: Reusable model-facing setup for the interaction.
+        input: The per-turn payload (user content, continuation, tool results).
+        config: Configuration specifying provider and model.
+        output: Optional Pydantic model or JSON Schema for structured output.
+        temperature: Optional sampling temperature.
+        top_p: Optional nucleus-sampling probability.
+        max_tokens: Optional hard cap on output tokens.
+        seed: Optional sampling seed where supported.
+        reasoning_effort: Optional qualitative reasoning effort.
+        reasoning_budget_tokens: Optional explicit reasoning token budget.
+        tool_choice: Optional tool-choice control.
+        provider_options: Optional raw provider-scoped generation options.
+
+    Yields:
+        Each :class:`Event` in the interaction's timeline, ending in ``done``.
+
+    Example:
+        async for event in stream(environment, Input("Inspect the repo."), config=cfg):
+            if event.type == "text_delta":
+                print(event.text, end="")
+            elif event.type == "done":
+                result = event.output
+    """
+    requirements = _build_requirements(
+        output=output,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+        seed=seed,
+        reasoning_effort=reasoning_effort,
+        reasoning_budget_tokens=reasoning_budget_tokens,
+        tool_choice=tool_choice,
+        provider_options=provider_options,
+    )
+    provider = _get_provider(config)
+    try:
+        async for event in stream_interaction(
+            environment, input, requirements, config, provider
+        ):
+            yield event
     finally:
         await _close_provider(provider)
 
@@ -691,6 +767,7 @@ __all__ = [
     "DeferredNotReadyError",
     "DeferredSnapshot",
     "Environment",
+    "Event",
     "Input",
     "InternalError",
     "Message",
@@ -704,6 +781,7 @@ __all__ = [
     "Source",
     "SourceError",
     "ToolCall",
+    "ToolCallDelta",
     "ToolChoice",
     "ToolDeclaration",
     "ToolResult",
@@ -715,4 +793,5 @@ __all__ = [
     "prepare_environment",
     "run",
     "run_many",
+    "stream",
 ]

--- a/src/pollux/interaction/__init__.py
+++ b/src/pollux/interaction/__init__.py
@@ -21,6 +21,7 @@ from pollux.interaction.environment import (
     Environment,
     EnvironmentSnapshot,
 )
+from pollux.interaction.event import Event, EventType
 from pollux.interaction.input import Input
 from pollux.interaction.output import (
     CompletionStatus,
@@ -34,6 +35,7 @@ from pollux.interaction.requirements import OutputRequirements, ToolChoice
 from pollux.interaction.tools import (
     JSONValue,
     ToolCall,
+    ToolCallDelta,
     ToolDeclaration,
     ToolResult,
 )
@@ -47,6 +49,8 @@ __all__ = [
     "Diagnostics",
     "Environment",
     "EnvironmentSnapshot",
+    "Event",
+    "EventType",
     "Input",
     "JSONValue",
     "Message",
@@ -55,6 +59,7 @@ __all__ = [
     "OutputCollection",
     "OutputRequirements",
     "ToolCall",
+    "ToolCallDelta",
     "ToolChoice",
     "ToolDeclaration",
     "ToolResult",

--- a/src/pollux/interaction/event.py
+++ b/src/pollux/interaction/event.py
@@ -1,0 +1,62 @@
+"""``Event``: the incremental form of an interaction output.
+
+Streaming is not a separate semantic mode. It is a different timeline for
+observing the same interaction: the events below carry the partial signal, and a
+successful stream ends in a single ``done`` event whose ``output`` is the same
+:class:`~pollux.interaction.output.Output` non-streaming execution would return.
+
+Consumers match on ``Event.type`` and never parse SSE, provider SDK chunks, or
+``delta.tool_calls`` fragments — Pollux normalizes those into the vocabulary
+here and assembles tool-call fragments into final :class:`ToolCall` objects.
+
+Terminal stream errors raise from the iterator (the wrapped provider error)
+rather than emitting a ``done`` event, so a failed interaction never yields a
+final output. A dedicated ``error`` event with recoverable/terminal
+classification is deliberately deferred until a provider needs mid-stream
+recoverable errors; adding it later is additive, not breaking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from pollux.interaction.output import Output, Usage
+    from pollux.interaction.tools import ToolCall, ToolCallDelta
+
+#: The streamed event vocabulary. ``start`` opens the stream; ``text_delta`` and
+#: ``reasoning_delta`` carry visible/reasoning text; ``tool_call_delta`` carries
+#: a partial tool-call fragment and ``tool_call`` a completed normalized call;
+#: ``usage`` reports a usage update when the provider streams one; ``finish``
+#: carries the provider finish reason; ``done`` carries the final assembled
+#: output.
+EventType = Literal[
+    "start",
+    "text_delta",
+    "reasoning_delta",
+    "tool_call_delta",
+    "tool_call",
+    "usage",
+    "finish",
+    "done",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Event:
+    """One event in the timeline of a streamed interaction.
+
+    Only the facet relevant to ``type`` is set: ``text`` for ``text_delta`` /
+    ``reasoning_delta``, ``delta`` for ``tool_call_delta``, ``tool_call`` for
+    ``tool_call``, ``usage`` for ``usage``, ``finish_reason`` for ``finish``, and
+    ``output`` for ``done``.
+    """
+
+    type: EventType
+    text: str = ""
+    delta: ToolCallDelta | None = None
+    tool_call: ToolCall | None = None
+    usage: Usage | None = None
+    finish_reason: str | None = None
+    output: Output | None = None

--- a/src/pollux/interaction/execute.py
+++ b/src/pollux/interaction/execute.py
@@ -18,23 +18,31 @@ from typing import TYPE_CHECKING
 
 from pollux.cache import create_cache_impl
 from pollux.continuation import build_conversation_state, history_text_from_parts
-from pollux.errors import APIError, InternalError, PolluxError
+from pollux.errors import APIError, ConfigurationError, InternalError, PolluxError
 from pollux.interaction._uploads import cleanup_uploads, substitute_upload_parts
 from pollux.interaction.adapters import continuation_from_state, state_from_continuation
 from pollux.interaction.capabilities import resolve_capabilities
 from pollux.interaction.collection import OutputCollection
 from pollux.interaction.continuation import Continuation
 from pollux.interaction.environment import CachePolicy, EnvironmentSnapshot
+from pollux.interaction.event import Event
 from pollux.interaction.extract import provider_response_to_output
+from pollux.interaction.output import Usage
+from pollux.interaction.tools import ToolCall
 from pollux.interaction.validate import validate_interaction
 from pollux.parts import build_shared_parts
 from pollux.providers import _compile
-from pollux.providers.base import FileUploadingProvider, ValidatingProvider
+from pollux.providers.base import (
+    FileUploadingProvider,
+    StreamingProvider,
+    ValidatingProvider,
+)
 from pollux.providers.models import ProviderResponse, is_file_part
+from pollux.providers.models import ToolCall as ProviderToolCall
 from pollux.retry import retry_async, should_retry_generate
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import AsyncIterator, Sequence
     from typing import Any
 
     from pollux.config import Config
@@ -322,3 +330,153 @@ async def execute_interaction(
         environment, [input], requirements, config, provider
     )
     return collection.outputs[0]
+
+
+class _ToolCallAssembler:
+    """Reassemble streamed tool-call fragments into ordered, complete calls.
+
+    Fragments arrive keyed by ``index``: the opening fragment for a slot usually
+    carries ``id``/``name`` and later fragments append argument text. Slots are
+    emitted in first-seen order so the assembled calls match arrival order.
+    """
+
+    def __init__(self) -> None:
+        self._order: list[int] = []
+        self._slots: dict[int, dict[str, Any]] = {}
+
+    def add(self, delta: Any) -> None:
+        """Merge one :class:`ToolCallDelta` fragment into its slot."""
+        slot = self._slots.get(delta.index)
+        if slot is None:
+            slot = {"id": None, "name": None, "arguments": []}
+            self._slots[delta.index] = slot
+            self._order.append(delta.index)
+        if delta.id:
+            slot["id"] = delta.id
+        if delta.name:
+            slot["name"] = delta.name
+        if delta.arguments:
+            slot["arguments"].append(delta.arguments)
+
+    def assembled(self) -> list[tuple[ToolCall, ProviderToolCall]]:
+        """Return ``(public ToolCall, transport ToolCall)`` pairs, in order."""
+        pairs: list[tuple[ToolCall, ProviderToolCall]] = []
+        for index in self._order:
+            slot = self._slots[index]
+            call_id = slot["id"] or f"call_{index}"
+            name = slot["name"] or ""
+            arguments = "".join(slot["arguments"])
+            public = ToolCall.from_text(
+                id=call_id, name=name, arguments_text=arguments, index=index
+            )
+            transport = ProviderToolCall(id=call_id, name=name, arguments=arguments)
+            pairs.append((public, transport))
+        return pairs
+
+
+async def stream_interaction(
+    environment: Environment,
+    input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+    requirements: OutputRequirements,
+    config: Config,
+    provider: Provider,
+) -> AsyncIterator[Event]:
+    """Stream one interaction as :class:`Event` objects, ending in ``done``.
+
+    Same orchestration as :func:`execute_interaction` (capability validation,
+    uploads, cache resolution, continuation, ``Output`` assembly), observed as a
+    timeline: text/reasoning/tool-call deltas as the provider emits them, then a
+    terminal ``done`` whose ``output`` matches the non-streaming result. A
+    mid-stream provider failure raises from the iterator instead of emitting
+    ``done``. Streamed turns are single-input and are not retried mid-stream.
+    """
+    start_time = time.perf_counter()
+    snapshot = EnvironmentSnapshot.from_environment(
+        environment, provider=config.provider
+    )
+    caps = resolve_capabilities(provider.capabilities, config.capabilities)
+    persistent_requested = isinstance(snapshot.cache, CachePolicy)
+    validate_interaction(
+        requirements, [input], snapshot, caps, cache_requested=persistent_requested
+    )
+
+    if not isinstance(provider, StreamingProvider):
+        raise ConfigurationError(
+            "Provider does not support streaming",
+            hint="Use a streaming-capable provider, or call interact() for a "
+            "single blocking Output.",
+        )
+
+    if isinstance(provider, ValidatingProvider):
+        await provider.validate_request(snapshot, input, requirements, config)
+
+    upload_cache: dict[tuple[str, str], ProviderFileAsset] = {}
+    snapshot, cache_mode = await _prepare_snapshot(
+        snapshot, 1, config, provider, caps, upload_cache
+    )
+    user_content = history_text_from_parts(_compile.request_parts(snapshot, input))
+
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls = _ToolCallAssembler()
+    usage: dict[str, int] = {}
+    finish_reason: str | None = None
+    response_id: str | None = None
+
+    try:
+        yield Event(type="start")
+        async for chunk in provider.stream_generate(
+            snapshot, input, requirements, config
+        ):
+            if chunk.text:
+                text_parts.append(chunk.text)
+                yield Event(type="text_delta", text=chunk.text)
+            if chunk.reasoning:
+                reasoning_parts.append(chunk.reasoning)
+                yield Event(type="reasoning_delta", text=chunk.reasoning)
+            for delta in chunk.tool_calls:
+                tool_calls.add(delta)
+                yield Event(type="tool_call_delta", delta=delta)
+            if chunk.usage:
+                usage = chunk.usage
+                yield Event(type="usage", usage=Usage.from_dict(chunk.usage))
+            if chunk.finish_reason:
+                finish_reason = chunk.finish_reason
+            if chunk.response_id:
+                response_id = chunk.response_id
+
+        assembled = tool_calls.assembled()
+        for public_call, _transport in assembled:
+            yield Event(type="tool_call", tool_call=public_call)
+        if finish_reason is not None:
+            yield Event(type="finish", finish_reason=finish_reason)
+
+        response = ProviderResponse(
+            text="".join(text_parts),
+            usage=usage,
+            reasoning="".join(reasoning_parts) or None,
+            tool_calls=[transport for _public, transport in assembled] or None,
+            response_id=response_id,
+            finish_reason=finish_reason,
+        )
+        duration_s = time.perf_counter() - start_time
+        cached = usage.get("cached_tokens", 0)
+        cache_used = cache_mode == "persistent"
+        cache_hit = cache_used or (
+            cache_mode == "implicit" and isinstance(cached, int) and cached > 0
+        )
+        continuation = _build_continuation(
+            input, response, user_content, config.provider
+        )
+        output = provider_response_to_output(
+            response,
+            requirements=requirements,
+            duration_s=duration_s,
+            cache_used=cache_used,
+            cache_mode=cache_mode,
+            cache_hit=cache_hit,
+            continuation=continuation,
+        )
+        yield Event(type="done", output=output)
+    finally:
+        await cleanup_uploads(upload_cache, provider)

--- a/src/pollux/interaction/tools.py
+++ b/src/pollux/interaction/tools.py
@@ -127,6 +127,23 @@ class ToolCall:
 
 
 @dataclass(frozen=True, slots=True)
+class ToolCallDelta:
+    """One incremental fragment of a streamed tool call.
+
+    Providers stream tool calls in pieces: an opening fragment usually carries
+    ``id`` and ``name`` for a slot, and later fragments append ``arguments``
+    text. ``index`` identifies the call slot so fragments reassemble in order.
+    Core accumulates these into a final :class:`ToolCall`; consumers that only
+    want completed calls can ignore ``tool_call_delta`` events.
+    """
+
+    index: int = 0
+    id: str | None = None
+    name: str | None = None
+    arguments: str = ""
+
+
+@dataclass(frozen=True, slots=True)
 class ToolResult:
     """Application-produced output returned to the model for a prior tool call."""
 

--- a/src/pollux/providers/_openai_compat.py
+++ b/src/pollux/providers/_openai_compat.py
@@ -18,8 +18,9 @@ from collections.abc import Mapping
 import json
 from typing import TYPE_CHECKING, Any
 
+from pollux.interaction.tools import ToolCallDelta
 from pollux.providers._utils import to_strict_schema
-from pollux.providers.models import ToolCall
+from pollux.providers.models import ProviderStreamChunk, ToolCall
 
 if TYPE_CHECKING:
     import httpx
@@ -207,3 +208,100 @@ def serialize_tool_calls(tool_calls: list[ToolCall] | None) -> list[dict[str, An
         }
         for tool_call in tool_calls
     ]
+
+
+def parse_sse_line(line: str) -> dict[str, Any] | None:
+    """Parse one Server-Sent Events line into its JSON ``data`` object.
+
+    Returns ``None`` for blank lines, non-``data:`` lines (comments/event names),
+    the terminal ``[DONE]`` sentinel, and any ``data`` payload that is not a JSON
+    object. Callers iterate ``response.aiter_lines()`` and skip ``None``.
+    """
+    stripped = line.strip()
+    if not stripped.startswith("data:"):
+        return None
+    payload = stripped[len("data:") :].strip()
+    if not payload or payload == "[DONE]":
+        return None
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def parse_chat_stream_chunk(data: Mapping[str, Any]) -> ProviderStreamChunk | None:
+    """Map one OpenAI-compatible streaming ``data`` object to a stream chunk.
+
+    Pulls visible text, model-native reasoning text, tool-call fragments, the
+    finish reason, a streamed usage block, and the response id from one chunk.
+    Returns ``None`` when the chunk carries nothing Pollux tracks (e.g. an empty
+    role-priming delta) so the provider can skip it.
+    """
+    response_id = data.get("id")
+    response_id = response_id if isinstance(response_id, str) and response_id else None
+
+    text = ""
+    reasoning = ""
+    tool_calls: list[ToolCallDelta] = []
+    finish_reason: str | None = None
+
+    choices = data.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], Mapping):
+        choice = choices[0]
+        delta = choice.get("delta")
+        if isinstance(delta, Mapping):
+            content = delta.get("content")
+            if isinstance(content, str):
+                text = content
+            reasoning_content = delta.get("reasoning_content")
+            if isinstance(reasoning_content, str):
+                reasoning = reasoning_content
+            tool_calls = _parse_tool_call_deltas(delta.get("tool_calls"))
+        raw_finish = choice.get("finish_reason")
+        if isinstance(raw_finish, str):
+            finish_reason = raw_finish
+
+    usage = parse_usage(data.get("usage")) or None
+
+    if not (text or reasoning or tool_calls or finish_reason or usage or response_id):
+        return None
+
+    return ProviderStreamChunk(
+        text=text,
+        reasoning=reasoning,
+        tool_calls=tuple(tool_calls),
+        usage=usage,
+        finish_reason=finish_reason,
+        response_id=response_id,
+    )
+
+
+def _parse_tool_call_deltas(value: Any) -> list[ToolCallDelta]:
+    """Extract streamed tool-call fragments from a chat-completions delta."""
+    if not isinstance(value, list):
+        return []
+
+    deltas: list[ToolCallDelta] = []
+    for position, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            continue
+        index = item.get("index")
+        if not isinstance(index, int):
+            index = position
+        call_id = item.get("id")
+        call_id = call_id if isinstance(call_id, str) and call_id else None
+        name: str | None = None
+        arguments = ""
+        function = item.get("function")
+        if isinstance(function, Mapping):
+            raw_name = function.get("name")
+            if isinstance(raw_name, str) and raw_name:
+                name = raw_name
+            raw_arguments = function.get("arguments")
+            if isinstance(raw_arguments, str):
+                arguments = raw_arguments
+        deltas.append(
+            ToolCallDelta(index=index, id=call_id, name=name, arguments=arguments)
+        )
+    return deltas

--- a/src/pollux/providers/base.py
+++ b/src/pollux/providers/base.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from pollux.config import Config
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
     from pollux.providers.models import (
         ProviderFileAsset,
         ProviderResponse,
+        ProviderStreamChunk,
     )
 
 DeferredItemStatus = Literal["succeeded", "failed", "cancelled", "expired"]
@@ -94,6 +96,28 @@ class Provider(Protocol):
     @property
     def capabilities(self) -> ProviderCapabilities:
         """Feature capabilities for strict option validation."""
+        ...
+
+
+@runtime_checkable
+class StreamingProvider(Protocol):
+    """Optional provider hook for streaming one interaction turn.
+
+    Implementing this protocol *is* the streaming capability: ``stream()`` detects
+    it via ``isinstance`` and rejects providers that do not. The method parses the
+    upstream stream and yields normalized :class:`ProviderStreamChunk` deltas;
+    core owns event emission and final ``Output`` assembly so a streamed turn's
+    ``done.output`` matches the non-streaming result.
+    """
+
+    def stream_generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,
+        config: Config,
+    ) -> AsyncIterator[ProviderStreamChunk]:
+        """Compile one interaction turn and stream normalized response deltas."""
         ...
 
 

--- a/src/pollux/providers/local.py
+++ b/src/pollux/providers/local.py
@@ -34,6 +34,8 @@ from pollux.providers._openai_compat import (
     first_choice_message,
     map_tool_choice,
     normalize_tools,
+    parse_chat_stream_chunk,
+    parse_sse_line,
     parse_tool_calls,
     parse_usage,
     serialize_tool_calls,
@@ -44,9 +46,11 @@ from pollux.providers.models import (
     Message,
     ProviderFileAsset,
     ProviderResponse,
+    ProviderStreamChunk,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from pollux.config import Config
@@ -140,16 +144,18 @@ class LocalProvider:
                     ),
                 )
 
-    async def generate(
+    def _build_payload(
         self,
         snapshot: EnvironmentSnapshot,
         input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
         requirements: OutputRequirements,
         config: Config,
-    ) -> ProviderResponse:
-        """Generate a response via OpenAI-compatible Chat Completions."""
-        await self.validate_request(snapshot, input, requirements, config)
+    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        """Build the Chat Completions request body and the response schema, if any.
 
+        Shared by ``generate`` and ``stream_generate``; the streaming path adds
+        only the ``stream`` flags on top of this body.
+        """
         history, _previous_response_id, _provider_state = _compile.prior_turns(input)
         response_schema = requirements.output_schema_json()
         tools = _compile.tool_dicts(snapshot)
@@ -190,6 +196,21 @@ class LocalProvider:
             requirements.provider_options_for("local"),
             provider="local",
         )
+        return payload, response_schema
+
+    async def generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,
+        config: Config,
+    ) -> ProviderResponse:
+        """Generate a response via OpenAI-compatible Chat Completions."""
+        await self.validate_request(snapshot, input, requirements, config)
+
+        payload, response_schema = self._build_payload(
+            snapshot, input, requirements, config
+        )
 
         client = self._get_client()
         try:
@@ -223,6 +244,56 @@ class LocalProvider:
             )
 
         return _parse_response(data, response_schema=response_schema)
+
+    async def stream_generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,
+        config: Config,
+    ) -> AsyncIterator[ProviderStreamChunk]:
+        """Stream normalized deltas via OpenAI-compatible Chat Completions."""
+        await self.validate_request(snapshot, input, requirements, config)
+
+        payload, _response_schema = self._build_payload(
+            snapshot, input, requirements, config
+        )
+        payload["stream"] = True
+        # Ask for a terminal usage chunk; servers that ignore it simply omit one.
+        payload["stream_options"] = {"include_usage": True}
+
+        client = self._get_client()
+        try:
+            async with client.stream(
+                "POST", "chat/completions", json=payload
+            ) as response:
+                if response.is_error:
+                    await response.aread()
+                    raise httpx.HTTPStatusError(
+                        extract_error_message(response),
+                        request=response.request,
+                        response=response,
+                    )
+                async for line in response.aiter_lines():
+                    data = parse_sse_line(line)
+                    if data is None:
+                        continue
+                    chunk = parse_chat_stream_chunk(data)
+                    if chunk is not None:
+                        yield chunk
+        except asyncio.CancelledError:
+            raise
+        except (ConfigurationError, APIError):
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="local",
+                phase="stream",
+                allow_network_errors=True,
+                message="Local provider stream failed",
+                hint=_hint_for_local_error(e, base_url=self._base_url),
+            ) from e
 
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
         """Reject uploads because local provider takes inline content only."""

--- a/src/pollux/providers/mock.py
+++ b/src/pollux/providers/mock.py
@@ -6,9 +6,14 @@ from typing import TYPE_CHECKING, Any
 
 from pollux.providers import _compile
 from pollux.providers.base import ProviderCapabilities
-from pollux.providers.models import ProviderFileAsset, ProviderResponse
+from pollux.providers.models import (
+    ProviderFileAsset,
+    ProviderResponse,
+    ProviderStreamChunk,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from pollux.config import Config
@@ -61,6 +66,30 @@ class MockProvider:
         return ProviderResponse(
             text=f"echo: {_echo_text(parts)[:100]}",
             usage={"input_tokens": 10, "total_tokens": 20},
+        )
+
+    async def stream_generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,  # noqa: ARG002
+        config: Config,  # noqa: ARG002
+    ) -> AsyncIterator[ProviderStreamChunk]:
+        """Stream the same echo text as ``generate`` in two text deltas.
+
+        Splitting the body into deltas plus a terminal usage/finish chunk lets
+        streaming tests assert the event timeline while keeping ``done.output``
+        identical to the non-streaming :meth:`generate` result.
+        """
+        parts = _compile.request_parts(snapshot, input)
+        text = f"echo: {_echo_text(parts)[:100]}"
+        midpoint = len(text) // 2
+        yield ProviderStreamChunk(text=text[:midpoint])
+        yield ProviderStreamChunk(text=text[midpoint:])
+        yield ProviderStreamChunk(
+            usage={"input_tokens": 10, "total_tokens": 20},
+            finish_reason="stop",
+            response_id="mock-stream-1",
         )
 
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:

--- a/src/pollux/providers/models.py
+++ b/src/pollux/providers/models.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pollux.interaction.tools import ToolCallDelta
 
 
 @dataclass(frozen=True)
@@ -76,6 +79,25 @@ class ProviderResponse:
     finish_reason: str | None = None
     provider_state: dict[str, Any] | None = None
     artifacts: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ProviderStreamChunk:
+    """One normalized delta from a provider's streamed response.
+
+    A provider's ``stream_generate`` yields these as it parses the upstream
+    stream; core accumulates them into a final :class:`ProviderResponse` and maps
+    them to the public event vocabulary. Every facet is optional so one upstream
+    chunk can carry text, reasoning, tool-call fragments, usage, a finish reason,
+    or a response id together.
+    """
+
+    text: str = ""
+    reasoning: str = ""
+    tool_calls: tuple[ToolCallDelta, ...] = ()
+    usage: dict[str, int] | None = None
+    finish_reason: str | None = None
+    response_id: str | None = None
 
 
 def provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:

--- a/tests/interaction/test_stream.py
+++ b/tests/interaction/test_stream.py
@@ -1,0 +1,231 @@
+"""Coverage for the v2 streaming path: event timeline and assembled output.
+
+These exercise core's ``stream_interaction`` assembly (event vocabulary, tool-call
+fragment reassembly, ``done.output`` parity with non-streaming) and the public
+``stream()`` frontdoor, driven by provider doubles rather than the network.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+import pollux
+from pollux import Environment, Event, Input
+from pollux.config import Config
+from pollux.errors import APIError, ConfigurationError
+from pollux.interaction.execute import execute_interaction, stream_interaction
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.tools import ToolCallDelta
+from pollux.providers.base import ProviderCapabilities
+from pollux.providers.mock import MockProvider
+from pollux.providers.models import ProviderResponse, ProviderStreamChunk
+from tests.conftest import ANTHROPIC_MODEL, FakeProvider
+
+pytestmark = pytest.mark.integration
+
+
+def _cfg() -> Config:
+    return Config(provider="anthropic", model=ANTHROPIC_MODEL, use_mock=True)
+
+
+@dataclass
+class StreamScriptProvider:
+    """Provider double that streams a scripted list of chunks.
+
+    ``raise_at`` makes ``stream_generate`` raise after yielding that many chunks,
+    standing in for a mid-stream provider failure.
+    """
+
+    chunks: list[ProviderStreamChunk] = field(default_factory=list)
+    raise_at: int | None = None
+
+    @property
+    def capabilities(self) -> ProviderCapabilities:
+        return ProviderCapabilities(
+            persistent_cache=False,
+            uploads=False,
+            structured_outputs=True,
+            conversation=True,
+        )
+
+    async def generate(self, *_args: Any) -> ProviderResponse:  # pragma: no cover
+        raise AssertionError("stream tests must not call generate()")
+
+    async def stream_generate(
+        self, snapshot: Any, input: Any, requirements: Any, config: Any
+    ) -> Any:
+        del snapshot, input, requirements, config
+        for position, chunk in enumerate(self.chunks):
+            if self.raise_at is not None and position == self.raise_at:
+                raise APIError("stream exploded", provider="test", phase="stream")
+            yield chunk
+
+
+async def _collect(
+    environment: Environment,
+    input_: Input,
+    provider: Any,
+    requirements: OutputRequirements | None = None,
+) -> list[Event]:
+    requirements = requirements or OutputRequirements()
+    return [
+        event
+        async for event in stream_interaction(
+            environment, input_, requirements, _cfg(), provider
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_event_timeline_and_done_matches_nonstreaming() -> None:
+    """The mock stream yields start/text/usage/finish/done; done == generate()."""
+    events = await _collect(Environment(), Input("hello world"), MockProvider())
+
+    assert [e.type for e in events] == [
+        "start",
+        "text_delta",
+        "text_delta",
+        "usage",
+        "finish",
+        "done",
+    ]
+    streamed_text = "".join(e.text for e in events if e.type == "text_delta")
+    done = events[-1]
+    assert done.output is not None
+    assert streamed_text == done.output.text
+
+    nonstreaming = await execute_interaction(
+        Environment(),
+        Input("hello world"),
+        OutputRequirements(),
+        _cfg(),
+        MockProvider(),
+    )
+    assert done.output.text == nonstreaming.text
+    assert done.output.usage.to_jsonable() == nonstreaming.usage.to_jsonable()
+
+
+@pytest.mark.asyncio
+async def test_stream_assembles_tool_call_fragments() -> None:
+    """Streamed tool-call fragments reassemble into one parsed ToolCall."""
+    provider = StreamScriptProvider(
+        chunks=[
+            ProviderStreamChunk(text="Let me check. "),
+            ProviderStreamChunk(
+                tool_calls=(ToolCallDelta(index=0, id="call_1", name="get_weather"),)
+            ),
+            ProviderStreamChunk(
+                tool_calls=(ToolCallDelta(index=0, arguments='{"city":'),)
+            ),
+            ProviderStreamChunk(
+                tool_calls=(ToolCallDelta(index=0, arguments='"NYC"}'),)
+            ),
+            ProviderStreamChunk(
+                usage={"input_tokens": 5, "total_tokens": 9},
+                finish_reason="tool_calls",
+                response_id="r1",
+            ),
+        ]
+    )
+
+    events = await _collect(Environment(), Input("Weather in NYC?"), provider)
+
+    assert [e.type for e in events] == [
+        "start",
+        "text_delta",
+        "tool_call_delta",
+        "tool_call_delta",
+        "tool_call_delta",
+        "usage",
+        "tool_call",
+        "finish",
+        "done",
+    ]
+
+    completed = next(e for e in events if e.type == "tool_call")
+    assert completed.tool_call is not None
+    assert completed.tool_call.name == "get_weather"
+    assert completed.tool_call.arguments_text == '{"city":"NYC"}'
+    assert completed.tool_call.arguments == {"city": "NYC"}
+
+    done = events[-1].output
+    assert done is not None
+    assert done.text == "Let me check. "
+    assert len(done.tool_calls) == 1
+    assert done.tool_calls[0].arguments == {"city": "NYC"}
+    assert done.metrics.finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_stream_accumulates_reasoning() -> None:
+    """reasoning_delta events accumulate into done.output.reasoning."""
+    provider = StreamScriptProvider(
+        chunks=[
+            ProviderStreamChunk(reasoning="think"),
+            ProviderStreamChunk(reasoning="ing..."),
+            ProviderStreamChunk(text="42"),
+            ProviderStreamChunk(finish_reason="stop"),
+        ]
+    )
+
+    events = await _collect(Environment(), Input("2+2?"), provider)
+
+    reasoning = "".join(e.text for e in events if e.type == "reasoning_delta")
+    assert reasoning == "thinking..."
+    done = events[-1].output
+    assert done is not None
+    assert done.reasoning == "thinking..."
+    assert done.text == "42"
+
+
+@pytest.mark.asyncio
+async def test_stream_rejects_non_streaming_provider() -> None:
+    """A provider without stream_generate fails fast before any event."""
+    with pytest.raises(ConfigurationError, match="does not support streaming"):
+        await _collect(Environment(), Input("hi"), FakeProvider())
+
+
+@pytest.mark.asyncio
+async def test_stream_midstream_error_propagates_without_done() -> None:
+    """A mid-stream failure raises and never emits a done event."""
+    provider = StreamScriptProvider(
+        chunks=[
+            ProviderStreamChunk(text="partial"),
+            ProviderStreamChunk(text="never reached"),
+        ],
+        raise_at=1,
+    )
+
+    seen: list[str] = []
+    with pytest.raises(APIError, match="stream exploded"):
+        async for event in stream_interaction(
+            Environment(), Input("hi"), OutputRequirements(), _cfg(), provider
+        ):
+            seen.append(event.type)
+
+    assert "done" not in seen
+    assert seen == ["start", "text_delta"]
+
+
+@pytest.mark.asyncio
+async def test_stream_frontdoor_yields_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pollux.stream() drives the streaming provider and closes it after."""
+    provider = StreamScriptProvider(
+        chunks=[
+            ProviderStreamChunk(text="hi"),
+            ProviderStreamChunk(finish_reason="stop", usage={"total_tokens": 2}),
+        ]
+    )
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
+
+    types = [
+        event.type
+        async for event in pollux.stream(
+            Environment(instructions="sys"), Input("Hello?"), config=_cfg()
+        )
+    ]
+
+    assert types == ["start", "text_delta", "usage", "finish", "done"]

--- a/tests/providers/test_local_stream.py
+++ b/tests/providers/test_local_stream.py
@@ -1,0 +1,254 @@
+"""Local provider streaming contract: SSE parsing and end-to-end assembly."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from pollux import Environment, Input
+from pollux.config import Config
+from pollux.errors import APIError
+from pollux.interaction.execute import stream_interaction
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.tools import ToolDeclaration
+from pollux.providers.local import LocalProvider
+from tests.conftest import LOCAL_MODEL
+from tests.helpers import make_interaction
+
+pytestmark = pytest.mark.contract
+
+_LOCAL_BASE_URL = "http://localhost:11434/v1"
+
+
+def _sse(obj: dict[str, Any]) -> str:
+    return f"data: {json.dumps(obj)}"
+
+
+_TEXT_STREAM = [
+    _sse({"id": "c1", "choices": [{"index": 0, "delta": {"role": "assistant"}}]}),
+    _sse({"id": "c1", "choices": [{"index": 0, "delta": {"content": "Hel"}}]}),
+    _sse({"id": "c1", "choices": [{"index": 0, "delta": {"content": "lo"}}]}),
+    _sse({"id": "c1", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}),
+    _sse(
+        {
+            "id": "c1",
+            "choices": [],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        }
+    ),
+    "data: [DONE]",
+]
+
+_TOOL_STREAM = [
+    _sse(
+        {
+            "id": "c2",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": ""},
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+    ),
+    _sse(
+        {
+            "id": "c2",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '{"city":'}}
+                        ]
+                    },
+                }
+            ],
+        }
+    ),
+    _sse(
+        {
+            "id": "c2",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '"NYC"}'}}
+                        ]
+                    },
+                }
+            ],
+        }
+    ),
+    _sse(
+        {
+            "id": "c2",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+        }
+    ),
+    "data: [DONE]",
+]
+
+
+class _FakeStreamResponse:
+    def __init__(self, lines: list[str], status_code: int, error_body: Any) -> None:
+        self._lines = lines
+        self.status_code = status_code
+        self.is_error = status_code >= 400
+        self.request = httpx.Request("POST", f"{_LOCAL_BASE_URL}/chat/completions")
+        self._error_body = error_body
+        self.text = json.dumps(error_body) if error_body is not None else ""
+
+    async def aiter_lines(self) -> Any:
+        for line in self._lines:
+            yield line
+
+    async def aread(self) -> bytes:
+        return self.text.encode()
+
+    def json(self) -> Any:
+        return self._error_body
+
+
+class _FakeStreamCM:
+    def __init__(self, response: _FakeStreamResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeStreamResponse:
+        return self._response
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+class _FakeStreamClient:
+    def __init__(
+        self,
+        lines: list[str] | None = None,
+        *,
+        status_code: int = 200,
+        error_body: Any = None,
+    ) -> None:
+        self.last_json: dict[str, Any] | None = None
+        self._lines = lines if lines is not None else _TEXT_STREAM
+        self._status_code = status_code
+        self._error_body = error_body
+        self.closed = False
+
+    def stream(self, method: str, path: str, *, json: dict[str, Any]) -> _FakeStreamCM:
+        del method, path
+        self.last_json = json
+        return _FakeStreamCM(
+            _FakeStreamResponse(self._lines, self._status_code, self._error_body)
+        )
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _make_provider(client: _FakeStreamClient) -> LocalProvider:
+    provider = LocalProvider(base_url=_LOCAL_BASE_URL)
+    provider._client = client
+    return provider
+
+
+def _local(**kwargs: Any) -> tuple[Any, Any, Any, Any]:
+    return make_interaction(
+        provider="local", base_url=_LOCAL_BASE_URL, model=LOCAL_MODEL, **kwargs
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_stream_generate_parses_sse_chunks() -> None:
+    """stream_generate sets stream flags and normalizes SSE into chunks."""
+    fake = _FakeStreamClient()
+    provider = _make_provider(fake)
+
+    chunks = [chunk async for chunk in provider.stream_generate(*_local(content="Hi"))]
+
+    assert fake.last_json is not None
+    assert fake.last_json["stream"] is True
+    assert fake.last_json["stream_options"] == {"include_usage": True}
+
+    text = "".join(c.text for c in chunks)
+    assert text == "Hello"
+    assert any(c.finish_reason == "stop" for c in chunks)
+    assert any(c.usage and c.usage.get("total_tokens") == 5 for c in chunks)
+    assert any(c.response_id == "c1" for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_local_stream_assembles_tool_call_through_interaction() -> None:
+    """Driven through stream_interaction, tool-call SSE assembles into Output."""
+    fake = _FakeStreamClient(lines=_TOOL_STREAM)
+    provider = _make_provider(fake)
+    config = Config(provider="local", model=LOCAL_MODEL, base_url=_LOCAL_BASE_URL)
+    environment = Environment(
+        tools=[
+            ToolDeclaration(
+                name="get_weather",
+                description="Get weather",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            )
+        ]
+    )
+
+    events = [
+        event
+        async for event in stream_interaction(
+            environment,
+            Input("Weather in NYC?"),
+            OutputRequirements(),
+            config,
+            provider,
+        )
+    ]
+
+    assert fake.last_json is not None
+    assert fake.last_json["tools"][0]["function"]["name"] == "get_weather"
+
+    completed = next(e for e in events if e.type == "tool_call")
+    assert completed.tool_call is not None
+    assert completed.tool_call.name == "get_weather"
+    assert completed.tool_call.arguments == {"city": "NYC"}
+
+    done = events[-1]
+    assert done.type == "done"
+    assert done.output is not None
+    assert done.output.tool_calls[0].arguments == {"city": "NYC"}
+    assert done.output.metrics.finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_local_stream_http_error_raises_api_error() -> None:
+    """A non-2xx stream response surfaces as an APIError attributed to local."""
+    fake = _FakeStreamClient(
+        status_code=404,
+        error_body={"error": {"message": f"model '{LOCAL_MODEL}' not found"}},
+    )
+    provider = _make_provider(fake)
+
+    with pytest.raises(APIError) as exc:
+        async for _chunk in provider.stream_generate(*_local(content="Hi")):
+            pass
+
+    err = exc.value
+    assert err.provider == "local"
+    assert err.phase == "stream"
+    assert err.status_code == 404


### PR DESCRIPTION
## Summary

Add the streaming frontdoor and event vocabulary previously deferred.
`stream()` is the streaming sibling of `interact()`: same
environment/input/config, observed as an `Event` timeline rather than one
blocking `Output`. A streamed turn's terminal `done.output` matches what
`interact()` would return for the same interaction, so an agent harness can
stream a turn and continue its loop from `done.output` without a second call.
This is the v2 backend scout needs to stop hand-rolling SSE and tool-call delta
assembly.

Scope for this slice is **mock + local**; cloud-provider streaming
(anthropic/openai/gemini/openrouter) is a tracked follow-up.

## Related issue

None

## Test plan

- `just check` → **396 passed, 6 skipped** (ruff format/lint, rumdl, mypy, pytest).
- `uv run mkdocs build --strict` → clean.
- `tests/interaction/test_stream.py` (6 tests): event timeline + `done.output`
  parity with `execute_interaction`, tool-call fragment reassembly into one
  parsed `ToolCall`, reasoning accumulation, non-streaming-provider rejection,
  mid-stream failure raising without a `done` event, and the `stream()` frontdoor.
- `tests/providers/test_local_stream.py` (3 tests): local `stream_generate` sets
  the stream flags and normalizes SSE into chunks, tool-call SSE assembles into
  `Output` end-to-end through `stream_interaction`, and a non-2xx stream response
  surfaces as an `APIError` attributed to `local`.

## Notes

Design calls:

1. **Core owns assembly.** Providers yield normalized `ProviderStreamChunk`
   deltas; core accumulates them into a `ProviderResponse` and reuses the
   non-streaming Output assembly (`provider_response_to_output` +
   `_build_continuation`). That guarantees `done.output` equals the
   non-streaming result by construction, and consumers never parse SSE or
   `delta.tool_calls` fragments.
2. **Streaming is an optional structural protocol, not a capability flag.**
   `StreamingProvider.stream_generate` mirrors `FileUploadingProvider` /
   `ValidatingProvider`; implementing it *is* the capability, detected via
   `isinstance`. No new `ProviderCapabilities` field - consistent with how tools
   and uploads/caching already work. A provider without it raises
   `ConfigurationError`.
3. **Terminal errors raise; `done` is never emitted for a failed interaction.**
   A dedicated `error` event with recoverable/terminal classification is
   deferred until a provider needs mid-stream recoverable errors (adding it later
   is additive). Streamed turns are single-input and are not retried mid-stream.

The OpenAI-compatible SSE/chunk parsing lives in `_openai_compat`
(`parse_sse_line`, `parse_chat_stream_chunk`) so the cloud adapters will reuse it in.
New public types: `Event`, `ToolCallDelta`.