### PR TITLE
feat(core): stream from the Anthropic and OpenRouter providers

### DIFF
--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -60,7 +60,7 @@ before dispatch or the provider page below calls out why it is out of scope.
 | Function tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Pollux-normalized client/application tools; local trusts the server, no capability probe |
 | Provider-hosted tools | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ server-dependent | Raw provider escape hatch; not normalized by Pollux |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Local replays assistant tool calls and `tool`-role results verbatim |
-| Streaming (`stream()` → `Event`) | ❌ | ❌ | ❌ | ❌ | ✅ | Streamed `done.output` matches the non-streaming `Output`; cloud providers land in a later slice |
+| Streaming (`stream()` → `Event`) | ❌ | ❌ | ✅ | ✅ | ✅ | Streamed `done.output` matches the non-streaming `Output`; OpenAI and Gemini land in a later slice |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
 For when deferred delivery is a fit and how to structure code around provider
@@ -140,7 +140,10 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   models through Anthropic's adaptive thinking mode.
 - Thinking block replay: when Anthropic returns `thinking` or
   `redacted_thinking` blocks, Pollux preserves them in conversation state and
-  replays them verbatim on continuation turns so tool loops remain valid.
+  replays them verbatim on continuation turns so tool loops remain valid. This
+  holds for `stream()` too: signed thinking blocks are reassembled from the
+  stream, so a streamed extended-thinking + tool turn continues identically to
+  the non-streaming path.
 - `Options.max_tokens`: limits the output length. Default is `16384` for Anthropic,
   which leaves room for thinking output at all effort levels. Other providers
   currently ignore this option.
@@ -189,7 +192,9 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   appears in `ResultEnvelope.reasoning`, and token counts in
   `ResultEnvelope.usage["reasoning_tokens"]` when available. OpenRouter does
   not accept `reasoning_budget_tokens`; Pollux raises `ConfigurationError`
-  before dispatch.
+  before dispatch. Under `stream()`, reasoning text is surfaced for display but
+  the `reasoning_details` replay state is not reconstructed from the stream
+  (best-effort context, not a continuation requirement).
 
 ### Local
 

--- a/src/pollux/interaction/execute.py
+++ b/src/pollux/interaction/execute.py
@@ -420,6 +420,7 @@ async def stream_interaction(
     reasoning_parts: list[str] = []
     tool_calls = _ToolCallAssembler()
     usage: dict[str, int] = {}
+    provider_state: dict[str, Any] = {}
     finish_reason: str | None = None
     response_id: str | None = None
 
@@ -438,8 +439,13 @@ async def stream_interaction(
                 tool_calls.add(delta)
                 yield Event(type="tool_call_delta", delta=delta)
             if chunk.usage:
-                usage = chunk.usage
-                yield Event(type="usage", usage=Usage.from_dict(chunk.usage))
+                # Usage may stream across several chunks (e.g. Anthropic reports
+                # input at message_start and output at message_delta), so merge
+                # rather than replace and surface the cumulative snapshot.
+                usage.update(chunk.usage)
+                yield Event(type="usage", usage=Usage.from_dict(usage))
+            if chunk.provider_state:
+                provider_state.update(chunk.provider_state)
             if chunk.finish_reason:
                 finish_reason = chunk.finish_reason
             if chunk.response_id:
@@ -458,6 +464,7 @@ async def stream_interaction(
             tool_calls=[transport for _public, transport in assembled] or None,
             response_id=response_id,
             finish_reason=finish_reason,
+            provider_state=provider_state or None,
         )
         duration_s = time.perf_counter() - start_time
         cached = usage.get("cached_tokens", 0)

--- a/src/pollux/providers/_openai_compat.py
+++ b/src/pollux/providers/_openai_compat.py
@@ -254,9 +254,13 @@ def parse_chat_stream_chunk(data: Mapping[str, Any]) -> ProviderStreamChunk | No
             content = delta.get("content")
             if isinstance(content, str):
                 text = content
+            # ``reasoning_content`` is the local/OpenAI-compatible field;
+            # OpenRouter streams reasoning text under ``reasoning`` instead.
             reasoning_content = delta.get("reasoning_content")
             if isinstance(reasoning_content, str):
                 reasoning = reasoning_content
+            elif isinstance(delta.get("reasoning"), str):
+                reasoning = delta["reasoning"]
             tool_calls = _parse_tool_call_deltas(delta.get("tool_calls"))
         raw_finish = choice.get("finish_reason")
         if isinstance(raw_finish, str):

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -10,6 +10,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from pollux.errors import APIError, ConfigurationError
+from pollux.interaction.tools import ToolCallDelta
 from pollux.parts import build_shared_parts
 from pollux.providers import _compile
 from pollux.providers._errors import wrap_provider_error
@@ -29,12 +30,14 @@ from pollux.providers.models import (
     Message,
     ProviderFileAsset,
     ProviderResponse,
+    ProviderStreamChunk,
     ToolCall,
     is_file_part,
     provider_response_to_dict,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from pollux.config import Config
@@ -594,6 +597,50 @@ class AnthropicProvider:
                 message="Anthropic generate failed",
             ) from e
 
+    async def stream_generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,
+        config: Config,
+    ) -> AsyncIterator[ProviderStreamChunk]:
+        """Stream normalized deltas using Anthropic's Messages API.
+
+        Signed ``thinking`` blocks are reassembled from the stream and surfaced
+        as provider_state on a terminal chunk, so a streamed extended-thinking +
+        tool turn continues exactly like the non-streaming path (Anthropic
+        requires those signed blocks to be replayed verbatim).
+        """
+        client = self._get_client()
+        parts = _compile.request_parts(snapshot, input)
+        create_kwargs = self._build_messages_create_kwargs(
+            parts, snapshot, input, requirements, config
+        )
+        create_kwargs["stream"] = True
+
+        assembler = _AnthropicStreamAssembler()
+        try:
+            stream = await client.messages.create(**create_kwargs)
+            async for event in stream:
+                chunk = assembler.feed(event)
+                if chunk is not None:
+                    yield chunk
+            final = assembler.final_chunk()
+            if final is not None:
+                yield final
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="anthropic",
+                phase="stream",
+                allow_network_errors=True,
+                message="Anthropic stream failed",
+            ) from e
+
     async def _resolve_deferred_parts(
         self,
         snapshot: EnvironmentSnapshot,
@@ -1037,6 +1084,149 @@ def _synthesize_terminal_batch_items(
         )
         for request_id in missing_request_ids
     ]
+
+
+class _AnthropicStreamAssembler:
+    """Map Anthropic Messages stream events to normalized stream chunks.
+
+    Holds the cross-event state streaming needs: the input token count (reported
+    at ``message_start``, needed to compute ``total_tokens`` at ``message_delta``)
+    and per-block ``thinking`` text + signatures, which are reassembled into the
+    same signed-thinking-block provider_state the non-streaming path produces.
+    Text, tool-call fragments, reasoning text, usage, and finish reason map
+    one-to-one onto :class:`ProviderStreamChunk` facets.
+    """
+
+    def __init__(self) -> None:
+        self._thinking: dict[int, dict[str, Any]] = {}
+        self._thinking_order: list[int] = []
+        self._input_tokens = 0
+
+    def feed(self, event: Any) -> ProviderStreamChunk | None:
+        """Translate one stream event into a chunk, or ``None`` to skip it."""
+        etype = getattr(event, "type", None)
+        if etype == "message_start":
+            return self._message_start(event)
+        if etype == "content_block_start":
+            return self._block_start(event)
+        if etype == "content_block_delta":
+            return self._block_delta(event)
+        if etype == "message_delta":
+            return self._message_delta(event)
+        return None
+
+    def final_chunk(self) -> ProviderStreamChunk | None:
+        """Emit reassembled signed thinking blocks as provider_state, if any."""
+        blocks: list[dict[str, str]] = []
+        for index in self._thinking_order:
+            slot = self._thinking[index]
+            if "redacted" in slot:
+                blocks.append({"type": "redacted_thinking", "data": slot["redacted"]})
+                continue
+            text = "".join(slot["thinking"])
+            signature = slot["signature"]
+            if text and isinstance(signature, str):
+                blocks.append(
+                    {"type": "thinking", "thinking": text, "signature": signature}
+                )
+        if blocks:
+            return ProviderStreamChunk(
+                provider_state={_ANTHROPIC_THINKING_BLOCKS_KEY: blocks}
+            )
+        return None
+
+    def _message_start(self, event: Any) -> ProviderStreamChunk | None:
+        message = getattr(event, "message", None)
+        response_id = getattr(message, "id", None)
+        response_id = response_id if isinstance(response_id, str) else None
+        usage: dict[str, int] = {}
+        usage_obj = getattr(message, "usage", None)
+        if usage_obj is not None:
+            input_tokens = getattr(usage_obj, "input_tokens", None)
+            if isinstance(input_tokens, int):
+                self._input_tokens = input_tokens
+                usage["input_tokens"] = input_tokens
+            cached = getattr(usage_obj, "cache_read_input_tokens", None)
+            if isinstance(cached, int):
+                usage["cached_tokens"] = cached
+        if usage or response_id:
+            return ProviderStreamChunk(usage=usage or None, response_id=response_id)
+        return None
+
+    def _block_start(self, event: Any) -> ProviderStreamChunk | None:
+        index = getattr(event, "index", 0)
+        index = index if isinstance(index, int) else 0
+        block = getattr(event, "content_block", None)
+        block_type = getattr(block, "type", None)
+        if block_type == "tool_use":
+            delta = ToolCallDelta(
+                index=index,
+                id=_str_or_none(getattr(block, "id", None)),
+                name=_str_or_none(getattr(block, "name", None)),
+            )
+            return ProviderStreamChunk(tool_calls=(delta,))
+        if block_type == "thinking":
+            self._thinking[index] = {"thinking": [], "signature": None}
+            self._thinking_order.append(index)
+        elif block_type == "redacted_thinking":
+            data = getattr(block, "data", None)
+            if isinstance(data, str):
+                self._thinking[index] = {"redacted": data}
+                self._thinking_order.append(index)
+        return None
+
+    def _block_delta(self, event: Any) -> ProviderStreamChunk | None:
+        index = getattr(event, "index", 0)
+        index = index if isinstance(index, int) else 0
+        delta = getattr(event, "delta", None)
+        delta_type = getattr(delta, "type", None)
+        if delta_type == "text_delta":
+            text = getattr(delta, "text", "")
+            return (
+                ProviderStreamChunk(text=text)
+                if isinstance(text, str) and text
+                else None
+            )
+        if delta_type == "input_json_delta":
+            partial = getattr(delta, "partial_json", "")
+            if isinstance(partial, str) and partial:
+                return ProviderStreamChunk(
+                    tool_calls=(ToolCallDelta(index=index, arguments=partial),)
+                )
+            return None
+        if delta_type == "thinking_delta":
+            thinking = getattr(delta, "thinking", "")
+            if isinstance(thinking, str) and thinking:
+                slot = self._thinking.get(index)
+                if slot is not None and "thinking" in slot:
+                    slot["thinking"].append(thinking)
+                return ProviderStreamChunk(reasoning=thinking)
+            return None
+        if delta_type == "signature_delta":
+            signature = getattr(delta, "signature", None)
+            slot = self._thinking.get(index)
+            if slot is not None and isinstance(signature, str):
+                slot["signature"] = signature
+        return None
+
+    def _message_delta(self, event: Any) -> ProviderStreamChunk | None:
+        delta = getattr(event, "delta", None)
+        finish_reason = _normalize_stop_reason(getattr(delta, "stop_reason", None))
+        usage: dict[str, int] = {}
+        usage_obj = getattr(event, "usage", None)
+        if usage_obj is not None:
+            output_tokens = getattr(usage_obj, "output_tokens", None)
+            if isinstance(output_tokens, int):
+                usage["output_tokens"] = output_tokens
+                usage["total_tokens"] = self._input_tokens + output_tokens
+        if finish_reason is None and not usage:
+            return None
+        return ProviderStreamChunk(finish_reason=finish_reason, usage=usage or None)
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Return the value when it is a non-empty string, else ``None``."""
+    return value if isinstance(value, str) and value else None
 
 
 def _normalize_stop_reason(stop_reason: Any) -> str | None:

--- a/src/pollux/providers/models.py
+++ b/src/pollux/providers/models.py
@@ -98,6 +98,7 @@ class ProviderStreamChunk:
     usage: dict[str, int] | None = None
     finish_reason: str | None = None
     response_id: str | None = None
+    provider_state: dict[str, Any] | None = None
 
 
 def provider_response_to_dict(response: ProviderResponse) -> dict[str, Any]:

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -25,6 +25,8 @@ from pollux.providers._openai_compat import (
     first_choice_message,
     map_tool_choice,
     normalize_tools,
+    parse_chat_stream_chunk,
+    parse_sse_line,
     parse_tool_calls,
     parse_usage,
     serialize_tool_calls,
@@ -35,6 +37,7 @@ from pollux.providers.models import (
     Message,
     ProviderFileAsset,
     ProviderResponse,
+    ProviderStreamChunk,
 )
 
 _OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
@@ -43,6 +46,7 @@ _OPENROUTER_REASONING_KEY = "openrouter_reasoning"
 _OPENROUTER_REASONING_DETAILS_KEY = "openrouter_reasoning_details"
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
     from pathlib import Path
 
     from pollux.config import Config
@@ -97,16 +101,18 @@ class OpenRouterProvider:
             )
         return cast("httpx.AsyncClient", self._client)
 
-    async def generate(
+    def _build_payload(
         self,
         snapshot: EnvironmentSnapshot,
         input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
         requirements: OutputRequirements,
         config: Config,
-    ) -> ProviderResponse:
-        """Generate a response using OpenRouter chat completions."""
-        await self.validate_request(snapshot, input, requirements, config)
+    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        """Build the chat-completions request body and the response schema, if any.
 
+        Shared by ``generate`` and ``stream_generate``; the streaming path adds
+        only the ``stream`` flags on top of this body.
+        """
         # OpenRouter uses history replay, not ID-based continuation.
         history, _previous_response_id, provider_state = _compile.prior_turns(input)
         parts = _compile.request_parts(snapshot, input)
@@ -151,6 +157,21 @@ class OpenRouterProvider:
             requirements.provider_options_for("openrouter"),
             provider="openrouter",
         )
+        return payload, response_schema
+
+    async def generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,
+        config: Config,
+    ) -> ProviderResponse:
+        """Generate a response using OpenRouter chat completions."""
+        await self.validate_request(snapshot, input, requirements, config)
+
+        payload, response_schema = self._build_payload(
+            snapshot, input, requirements, config
+        )
 
         client = self._get_client()
         try:
@@ -180,6 +201,57 @@ class OpenRouterProvider:
             )
 
         return _parse_response(data, response_schema=response_schema)
+
+    async def stream_generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,
+        config: Config,
+    ) -> AsyncIterator[ProviderStreamChunk]:
+        """Stream normalized deltas using OpenRouter chat completions.
+
+        Reasoning text is surfaced for display via the shared chunk parser;
+        OpenRouter's ``reasoning_details`` replay state is not reconstructed from
+        the stream (best-effort context, not a continuation requirement).
+        """
+        await self.validate_request(snapshot, input, requirements, config)
+
+        payload, _response_schema = self._build_payload(
+            snapshot, input, requirements, config
+        )
+        payload["stream"] = True
+        payload["stream_options"] = {"include_usage": True}
+
+        client = self._get_client()
+        try:
+            async with client.stream(
+                "POST", "/chat/completions", json=payload
+            ) as response:
+                if response.is_error:
+                    await response.aread()
+                    raise httpx.HTTPStatusError(
+                        _extract_error_message(response),
+                        request=response.request,
+                        response=response,
+                    )
+                async for line in response.aiter_lines():
+                    data = parse_sse_line(line)
+                    if data is None:
+                        continue
+                    chunk = parse_chat_stream_chunk(data)
+                    if chunk is not None:
+                        yield chunk
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="openrouter",
+                phase="stream",
+                allow_network_errors=True,
+                message="OpenRouter stream failed",
+            ) from e
 
     async def validate_request(
         self,

--- a/tests/providers/test_anthropic_stream.py
+++ b/tests/providers/test_anthropic_stream.py
@@ -1,0 +1,225 @@
+"""Anthropic streaming contract: event mapping and signed thinking-block replay.
+
+The load-bearing case is reassembling signed ``thinking`` blocks from the stream:
+Anthropic requires them replayed verbatim when continuing an extended-thinking +
+tool turn, so a streamed turn must surface them in provider_state exactly like the
+non-streaming path.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from pollux import Environment, Input
+from pollux.config import Config
+from pollux.errors import APIError
+from pollux.interaction.execute import stream_interaction
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.tools import ToolDeclaration
+from pollux.providers.anthropic import AnthropicProvider
+from tests.conftest import ANTHROPIC_MODEL
+from tests.helpers import make_interaction
+
+pytestmark = pytest.mark.contract
+
+
+def _anthropic(**kwargs: Any) -> tuple[Any, Any, Any, Any]:
+    kwargs.setdefault("model", ANTHROPIC_MODEL)
+    return make_interaction(provider="anthropic", **kwargs)
+
+
+def _event(type_: str, **kwargs: Any) -> SimpleNamespace:
+    return SimpleNamespace(type=type_, **kwargs)
+
+
+def _thinking_tool_stream() -> list[SimpleNamespace]:
+    """A stream that thinks, signs, answers, then calls a tool."""
+    return [
+        _event(
+            "message_start",
+            message=SimpleNamespace(id="msg_1", usage=SimpleNamespace(input_tokens=12)),
+        ),
+        _event(
+            "content_block_start",
+            index=0,
+            content_block=SimpleNamespace(type="thinking"),
+        ),
+        _event(
+            "content_block_delta",
+            index=0,
+            delta=SimpleNamespace(type="thinking_delta", thinking="Let me "),
+        ),
+        _event(
+            "content_block_delta",
+            index=0,
+            delta=SimpleNamespace(type="thinking_delta", thinking="think."),
+        ),
+        _event(
+            "content_block_delta",
+            index=0,
+            delta=SimpleNamespace(type="signature_delta", signature="sig-anthropic"),
+        ),
+        _event("content_block_stop", index=0),
+        _event(
+            "content_block_start", index=1, content_block=SimpleNamespace(type="text")
+        ),
+        _event(
+            "content_block_delta",
+            index=1,
+            delta=SimpleNamespace(type="text_delta", text="The answer"),
+        ),
+        _event("content_block_stop", index=1),
+        _event(
+            "content_block_start",
+            index=2,
+            content_block=SimpleNamespace(
+                type="tool_use", id="toolu_1", name="get_weather"
+            ),
+        ),
+        _event(
+            "content_block_delta",
+            index=2,
+            delta=SimpleNamespace(
+                type="input_json_delta", partial_json='{"city":"NYC"}'
+            ),
+        ),
+        _event("content_block_stop", index=2),
+        _event(
+            "message_delta",
+            delta=SimpleNamespace(stop_reason="tool_use"),
+            usage=SimpleNamespace(output_tokens=20),
+        ),
+        _event("message_stop"),
+    ]
+
+
+class _FakeStream:
+    def __init__(
+        self, events: list[SimpleNamespace], *, raise_exc: Exception | None = None
+    ):
+        self._events = events
+        self._raise = raise_exc
+
+    def __aiter__(self) -> _FakeStream:
+        return self
+
+    async def __anext__(self) -> SimpleNamespace:
+        if self._raise is not None:
+            raise self._raise
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+
+class _FakeMessages:
+    def __init__(
+        self, events: list[SimpleNamespace], *, raise_exc: Exception | None = None
+    ):
+        self._events = events
+        self._raise = raise_exc
+        self.last_kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> _FakeStream:
+        self.last_kwargs = kwargs
+        return _FakeStream(self._events, raise_exc=self._raise)
+
+
+def _provider_with_stream(
+    events: list[SimpleNamespace], *, raise_exc: Exception | None = None
+) -> tuple[AnthropicProvider, _FakeMessages]:
+    messages = _FakeMessages(events, raise_exc=raise_exc)
+    provider = AnthropicProvider("test-key")
+    provider._client = type("Client", (), {"messages": messages})()
+    return provider, messages
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_generate_reassembles_signed_thinking_blocks() -> None:
+    """The terminal chunk carries the reconstructed signed thinking block."""
+    provider, messages = _provider_with_stream(_thinking_tool_stream())
+
+    chunks = [
+        chunk async for chunk in provider.stream_generate(*_anthropic(content="Q"))
+    ]
+
+    assert messages.last_kwargs is not None
+    assert messages.last_kwargs["stream"] is True
+
+    state_chunks = [c for c in chunks if c.provider_state is not None]
+    assert len(state_chunks) == 1
+    assert state_chunks[0].provider_state == {
+        "anthropic_thinking_blocks": [
+            {
+                "type": "thinking",
+                "thinking": "Let me think.",
+                "signature": "sig-anthropic",
+            }
+        ]
+    }
+
+    # total_tokens is computed from message_start input + message_delta output.
+    final_usage = [c.usage for c in chunks if c.usage and "total_tokens" in c.usage]
+    assert final_usage[-1]["total_tokens"] == 32
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_through_interaction_assembles_output() -> None:
+    """End to end: facets assemble and thinking blocks survive into continuation."""
+    provider, _messages = _provider_with_stream(_thinking_tool_stream())
+    config = Config(provider="anthropic", model=ANTHROPIC_MODEL, use_mock=True)
+    environment = Environment(
+        tools=[
+            ToolDeclaration(
+                name="get_weather",
+                description="Get weather",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            )
+        ]
+    )
+
+    events = [
+        event
+        async for event in stream_interaction(
+            environment, Input("Weather?"), OutputRequirements(), config, provider
+        )
+    ]
+
+    types = [e.type for e in events]
+    assert types[0] == "start"
+    assert "reasoning_delta" in types
+    assert "text_delta" in types
+    assert "tool_call" in types
+    assert types[-1] == "done"
+
+    done = events[-1].output
+    assert done is not None
+    assert done.text == "The answer"
+    assert done.reasoning == "Let me think."
+    assert done.tool_calls[0].name == "get_weather"
+    assert done.tool_calls[0].arguments == {"city": "NYC"}
+    assert done.metrics.finish_reason == "tool_calls"
+
+    # The signed thinking block must survive into the continuation for replay.
+    assert done.continuation is not None
+    serialized = json.dumps(done.continuation.to_jsonable())
+    assert "sig-anthropic" in serialized
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_error_raises_api_error() -> None:
+    """A failure mid-stream surfaces as an APIError attributed to anthropic."""
+    provider, _messages = _provider_with_stream([], raise_exc=RuntimeError("boom"))
+
+    with pytest.raises(APIError) as exc:
+        async for _chunk in provider.stream_generate(*_anthropic(content="Q")):
+            pass
+
+    assert exc.value.provider == "anthropic"
+    assert exc.value.phase == "stream"

--- a/tests/providers/test_openrouter_stream.py
+++ b/tests/providers/test_openrouter_stream.py
@@ -1,0 +1,163 @@
+"""OpenRouter streaming contract: SSE reuse and reasoning display."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from pollux.errors import APIError
+from pollux.providers.openrouter import OpenRouterProvider
+from tests.conftest import OPENROUTER_MODEL
+from tests.helpers import make_interaction
+
+pytestmark = pytest.mark.contract
+
+_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def _openrouter(**kwargs: Any) -> tuple[Any, Any, Any, Any]:
+    kwargs.setdefault("model", OPENROUTER_MODEL)
+    return make_interaction(provider="openrouter", **kwargs)
+
+
+def _sse(obj: dict[str, Any]) -> str:
+    return f"data: {json.dumps(obj)}"
+
+
+_TEXT_STREAM = [
+    _sse({"id": "gen_1", "choices": [{"index": 0, "delta": {"role": "assistant"}}]}),
+    _sse({"id": "gen_1", "choices": [{"index": 0, "delta": {"content": "Hel"}}]}),
+    _sse(
+        {"id": "gen_1", "choices": [{"index": 0, "delta": {"reasoning": "thinking"}}]}
+    ),
+    _sse({"id": "gen_1", "choices": [{"index": 0, "delta": {"content": "lo"}}]}),
+    _sse(
+        {"id": "gen_1", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]}
+    ),
+    _sse(
+        {
+            "id": "gen_1",
+            "choices": [],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+        }
+    ),
+    "data: [DONE]",
+]
+
+_MODELS_PAYLOAD = {
+    "data": [
+        {
+            "id": OPENROUTER_MODEL,
+            "architecture": {
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+            },
+            "supported_parameters": ["max_tokens", "temperature", "top_p"],
+        }
+    ]
+}
+
+
+class _FakeStreamResponse:
+    def __init__(self, lines: list[str], status_code: int, error_body: Any) -> None:
+        self._lines = lines
+        self.status_code = status_code
+        self.is_error = status_code >= 400
+        self.request = httpx.Request("POST", f"{_BASE_URL}/chat/completions")
+        self._error_body = error_body
+        self.text = json.dumps(error_body) if error_body is not None else ""
+
+    async def aiter_lines(self) -> Any:
+        for line in self._lines:
+            yield line
+
+    async def aread(self) -> bytes:
+        return self.text.encode()
+
+    def json(self) -> Any:
+        return self._error_body
+
+
+class _FakeStreamCM:
+    def __init__(self, response: _FakeStreamResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeStreamResponse:
+        return self._response
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+class _FakeOpenRouterStreamClient:
+    def __init__(
+        self,
+        lines: list[str] | None = None,
+        *,
+        status_code: int = 200,
+        error_body: Any = None,
+    ) -> None:
+        self.last_json: dict[str, Any] | None = None
+        self._lines = lines if lines is not None else _TEXT_STREAM
+        self._status_code = status_code
+        self._error_body = error_body
+
+    async def get(self, path: str) -> Any:
+        request = httpx.Request("GET", f"{_BASE_URL}{path}")
+        return httpx.Response(200, json=_MODELS_PAYLOAD, request=request)
+
+    def stream(self, method: str, path: str, *, json: dict[str, Any]) -> _FakeStreamCM:
+        del method, path
+        self.last_json = json
+        return _FakeStreamCM(
+            _FakeStreamResponse(self._lines, self._status_code, self._error_body)
+        )
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _make_provider(client: _FakeOpenRouterStreamClient) -> OpenRouterProvider:
+    provider = OpenRouterProvider("test-key")
+    provider._client = client
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_generate_parses_sse_and_reasoning() -> None:
+    """OpenRouter streams reuse the shared SSE parser, incl. delta.reasoning."""
+    fake = _FakeOpenRouterStreamClient()
+    provider = _make_provider(fake)
+
+    chunks = [
+        chunk async for chunk in provider.stream_generate(*_openrouter(content="Hi"))
+    ]
+
+    assert fake.last_json is not None
+    assert fake.last_json["stream"] is True
+    assert fake.last_json["stream_options"] == {"include_usage": True}
+
+    assert "".join(c.text for c in chunks) == "Hello"
+    assert any(c.reasoning == "thinking" for c in chunks)
+    assert any(c.finish_reason == "stop" for c in chunks)
+    assert any(c.usage and c.usage.get("total_tokens") == 5 for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_http_error_raises_api_error() -> None:
+    """A non-2xx stream response surfaces as an APIError attributed to openrouter."""
+    fake = _FakeOpenRouterStreamClient(
+        status_code=502,
+        error_body={"error": {"message": "upstream is down"}},
+    )
+    provider = _make_provider(fake)
+
+    with pytest.raises(APIError) as exc:
+        async for _chunk in provider.stream_generate(*_openrouter(content="Hi")):
+            pass
+
+    assert exc.value.provider == "openrouter"
+    assert exc.value.phase == "stream"


### PR DESCRIPTION
## Summary

Extend streaming (mock + local) to the first two cloud providers:
OpenRouter and Anthropic. `stream()` against either now yields the same `Event`
timeline as local, and a streamed turn's `done.output` matches what `interact()`
returns - including, for Anthropic, the signed `thinking` blocks needed to
continue an extended-thinking + tool turn.

OpenAI and Gemini streaming follow as the next slice; their adapters still
lack `stream_generate`, so `stream()` against them raises `ConfigurationError`.

## Related issue

None

## Test plan

- `just check` → **401 passed, 6 skipped** (ruff format/lint, rumdl, mypy, pytest).
- `uv run mkdocs build --strict` → clean.
- `tests/providers/test_openrouter_stream.py` (2): `stream_generate` reuses the
  shared SSE parser (incl. `delta.reasoning`), sets the stream flags, and
  surfaces a non-2xx stream response as an `APIError` attributed to `openrouter`.
- `tests/providers/test_anthropic_stream.py` (3): the terminal chunk carries the
  reassembled signed thinking block and a correctly computed `total_tokens`; an
  end-to-end run through `stream_interaction` assembles text/reasoning/tool-call
  facets and the signed block survives into `done.output.continuation`; a
  mid-stream failure raises an `APIError` attributed to `anthropic`.
- The streaming tests (mock + local) still pass unchanged, confirming the
  core usage-merge and `provider_state` additions are backward compatible.

## Notes

**Targeted reasoning-replay parity, not blanket.** Both providers' non-streaming
paths stash reasoning into `Continuation.provider_state` for replay. Streaming
reconstructs it only where it is load-bearing:

- **Anthropic signed `thinking` blocks - full parity.** The API requires these be
  replayed verbatim when continuing an extended-thinking + tool turn (the marquee
  agent-loop case), so the stream reassembles them via `signature_delta` /
  content-block boundaries into the same provider_state shape the non-streaming
  path produces.
- **OpenRouter `reasoning` / local `reasoning_content` - display-only.** Best-effort
  context, not a continuation requirement; reconstructing replay state there would
  be boilerplate, so reasoning text is surfaced for display but `reasoning_details`
  replay state is not rebuilt from the stream.

To carry the load-bearing case, two small backward-compatible boundary changes:
`ProviderStreamChunk` gains an optional `provider_state` channel that core threads
into the assembled response, and core now **merges** `usage` across chunks rather
than replacing it (Anthropic reports input tokens at `message_start` and output at
`message_delta`). Both are no-ops for the single-usage-chunk providers.

The OpenAI-compatible SSE parsing stays shared in `_openai_compat`
(`parse_sse_line`, `parse_chat_stream_chunk`); OpenRouter reuses it directly.