### PR TITLE
feat(core): stream from the OpenAI and Gemini providers

### DIFF
--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -60,7 +60,7 @@ before dispatch or the provider page below calls out why it is out of scope.
 | Function tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Pollux-normalized client/application tools; local trusts the server, no capability probe |
 | Provider-hosted tools | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ server-dependent | Raw provider escape hatch; not normalized by Pollux |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Local replays assistant tool calls and `tool`-role results verbatim |
-| Streaming (`stream()` → `Event`) | ❌ | ❌ | ✅ | ✅ | ✅ | Streamed `done.output` matches the non-streaming `Output`; OpenAI and Gemini land in a later slice |
+| Streaming (`stream()` → `Event`) | ✅ | ✅ | ✅ | ✅ | ✅ | Streamed `done.output` matches the non-streaming `Output` |
 | Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
 For when deferred delivery is a fit and how to structure code around provider

--- a/src/pollux/providers/gemini.py
+++ b/src/pollux/providers/gemini.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 import uuid
 
 from pollux.errors import APIError, ConfigurationError
+from pollux.interaction.tools import ToolCallDelta
 from pollux.parts import build_shared_parts
 from pollux.providers import _compile
 from pollux.providers._errors import wrap_provider_error
@@ -29,12 +30,15 @@ from pollux.providers.models import (
     Message,
     ProviderFileAsset,
     ProviderResponse,
+    ProviderStreamChunk,
     ToolCall,
     is_file_part,
     provider_response_to_dict,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from pollux.config import Config
     from pollux.interaction.environment import EnvironmentSnapshot
     from pollux.interaction.input import Input
@@ -644,6 +648,104 @@ class GeminiProvider:
                 message="Gemini generate failed",
             ) from e
 
+    async def stream_generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,
+        config: Config,
+    ) -> AsyncIterator[ProviderStreamChunk]:
+        """Stream normalized deltas from Gemini's streaming content endpoint.
+
+        Gemini replays conversation via history (no provider_state), so thought
+        text is surfaced for display only. Function calls arrive whole rather
+        than fragmented, so each one is emitted as a single-fragment tool-call
+        delta with its own slot index.
+        """
+        client = self._get_client()
+        from google.genai import types
+
+        parts = _compile.request_parts(snapshot, input)
+        history, _previous_response_id, _provider_state = _compile.prior_turns(input)
+        config_kwargs = self._build_config_kwargs(parts, snapshot, requirements)
+        contents = self._build_contents(parts, history or None)
+
+        tool_call_index = 0
+        try:
+            stream = await client.aio.models.generate_content_stream(
+                model=config.model,
+                contents=contents,
+                config=types.GenerateContentConfig(**config_kwargs),
+            )
+            async for response in stream:
+                for chunk in self._stream_response_to_chunks(response, tool_call_index):
+                    if chunk.tool_calls:
+                        tool_call_index += len(chunk.tool_calls)
+                    yield chunk
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="gemini",
+                phase="stream",
+                allow_network_errors=True,
+                message="Gemini stream failed",
+            ) from e
+
+    def _stream_response_to_chunks(
+        self, response: Any, tool_call_index: int
+    ) -> list[ProviderStreamChunk]:
+        """Map one streamed Gemini response into normalized chunks."""
+        chunks: list[ProviderStreamChunk] = []
+
+        candidates = _field(response, "candidates", []) or []
+        candidate = (
+            candidates[0] if isinstance(candidates, list) and candidates else None
+        )
+        if candidate is not None:
+            content = _field(candidate, "content")
+            parts = _field(content, "parts", []) if content is not None else []
+            local_tool_count = 0
+            for part in parts or []:
+                function_call = _field(part, "function_call")
+                if function_call is not None:
+                    call_id = (
+                        _field(function_call, "id") or f"call_{uuid.uuid4().hex[:8]}"
+                    )
+                    arguments = json.dumps(_field(function_call, "args") or {})
+                    chunks.append(
+                        ProviderStreamChunk(
+                            tool_calls=(
+                                ToolCallDelta(
+                                    index=tool_call_index + local_tool_count,
+                                    id=str(call_id),
+                                    name=str(_field(function_call, "name", "")),
+                                    arguments=arguments,
+                                ),
+                            )
+                        )
+                    )
+                    local_tool_count += 1
+                    continue
+                part_text = _field(part, "text")
+                if isinstance(part_text, str) and part_text:
+                    if _field(part, "thought", default=False):
+                        chunks.append(ProviderStreamChunk(reasoning=part_text))
+                    else:
+                        chunks.append(ProviderStreamChunk(text=part_text))
+
+            finish_reason = _normalize_finish_reason(_field(candidate, "finish_reason"))
+        else:
+            finish_reason = None
+
+        usage = _stream_usage(_field(response, "usage_metadata"))
+        if usage or finish_reason is not None:
+            chunks.append(
+                ProviderStreamChunk(usage=usage or None, finish_reason=finish_reason)
+            )
+        return chunks
+
     async def _wait_for_file_active(
         self,
         file_name: str,
@@ -1177,6 +1279,34 @@ def _field(obj: Any, key: str, default: Any = None) -> Any:
     if isinstance(obj, dict):
         return obj.get(key, default)
     return getattr(obj, key, default)
+
+
+def _stream_usage(usage_metadata: Any) -> dict[str, int]:
+    """Normalize a streamed Gemini ``usage_metadata`` block into usage keys.
+
+    Mirrors the non-streaming usage extraction so a streamed turn's final usage
+    matches ``generate``. Fields are only emitted when present; core merges usage
+    across chunks, so the final cumulative block wins.
+    """
+    if usage_metadata is None:
+        return {}
+    usage: dict[str, int] = {}
+    prompt = _field(usage_metadata, "prompt_token_count")
+    if prompt is not None:
+        usage["input_tokens"] = int(prompt or 0)
+    candidates_toks = _field(usage_metadata, "candidates_token_count")
+    if candidates_toks is not None:
+        usage["output_tokens"] = int(candidates_toks or 0)
+    total = _field(usage_metadata, "total_token_count")
+    if total is not None:
+        usage["total_tokens"] = int(total or 0)
+    thoughts = _field(usage_metadata, "thoughts_token_count")
+    if thoughts is not None:
+        usage["reasoning_tokens"] = int(thoughts)
+    cached = _field(usage_metadata, "cached_content_token_count")
+    if cached is not None:
+        usage["cached_tokens"] = int(cached)
+    return usage
 
 
 def _extract_response_text(response: Any) -> str:

--- a/src/pollux/providers/openai.py
+++ b/src/pollux/providers/openai.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from pollux.errors import APIError, ConfigurationError
+from pollux.interaction.tools import ToolCallDelta
 from pollux.parts import build_shared_parts
 from pollux.providers import _compile
 from pollux.providers._errors import wrap_provider_error
@@ -30,12 +31,15 @@ from pollux.providers.base import (
 from pollux.providers.models import (
     ProviderFileAsset,
     ProviderResponse,
+    ProviderStreamChunk,
     ToolCall,
     is_file_part,
     provider_response_to_dict,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from pollux.config import Config
     from pollux.interaction.environment import EnvironmentSnapshot
     from pollux.interaction.input import Input
@@ -524,6 +528,92 @@ class OpenAIProvider:
             response, response_schema=requirements.output_schema_json()
         )
 
+    async def stream_generate(
+        self,
+        snapshot: EnvironmentSnapshot,
+        input: Input,  # noqa: A002 - "input" is the canonical v2 primitive name
+        requirements: OutputRequirements,
+        config: Config,
+    ) -> AsyncIterator[ProviderStreamChunk]:
+        """Stream normalized deltas from the OpenAI Responses API.
+
+        OpenAI continues via ``previous_response_id`` (no replayed reasoning),
+        so reasoning summary text is surfaced for display only. The terminal
+        ``response.completed`` event carries the final response, which is parsed
+        once for usage, finish reason, and id.
+        """
+        client = self._get_client()
+        parts = _compile.request_parts(snapshot, input)
+        create_kwargs = self._build_responses_create_kwargs(
+            parts, snapshot, input, requirements, config
+        )
+        create_kwargs["stream"] = True
+
+        try:
+            stream = await client.responses.create(**create_kwargs)
+            async for event in stream:
+                chunk = self._stream_event_to_chunk(event)
+                if chunk is not None:
+                    yield chunk
+        except asyncio.CancelledError:
+            raise
+        except APIError:
+            raise
+        except Exception as e:
+            raise wrap_provider_error(
+                e,
+                provider="openai",
+                phase="stream",
+                allow_network_errors=True,
+                message="OpenAI stream failed",
+            ) from e
+
+    def _stream_event_to_chunk(self, event: Any) -> ProviderStreamChunk | None:
+        """Map one Responses API stream event to a normalized chunk."""
+        event_type = _field(event, "type")
+        if event_type == "response.output_text.delta":
+            delta = _field(event, "delta")
+            return ProviderStreamChunk(text=delta) if isinstance(delta, str) else None
+        if event_type == "response.reasoning_summary_text.delta":
+            delta = _field(event, "delta")
+            return (
+                ProviderStreamChunk(reasoning=delta) if isinstance(delta, str) else None
+            )
+        if event_type == "response.output_item.added":
+            item = _field(event, "item")
+            if _field(item, "type") == "function_call":
+                index = _field(event, "output_index", 0)
+                delta = ToolCallDelta(
+                    index=index if isinstance(index, int) else 0,
+                    id=_str_or_none(_field(item, "call_id")),
+                    name=_str_or_none(_field(item, "name")),
+                )
+                return ProviderStreamChunk(tool_calls=(delta,))
+            return None
+        if event_type == "response.function_call_arguments.delta":
+            delta = _field(event, "delta")
+            if isinstance(delta, str) and delta:
+                index = _field(event, "output_index", 0)
+                return ProviderStreamChunk(
+                    tool_calls=(
+                        ToolCallDelta(
+                            index=index if isinstance(index, int) else 0,
+                            arguments=delta,
+                        ),
+                    )
+                )
+            return None
+        if event_type == "response.completed":
+            parsed = self._parse_response(
+                _field(event, "response"), response_schema=None
+            )
+            return ProviderStreamChunk(
+                usage=parsed.usage or None,
+                finish_reason=parsed.finish_reason,
+                response_id=parsed.response_id,
+            )
+        return None
+
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
         """Upload a local file and return an asset."""
         client = self._get_client()
@@ -838,6 +928,11 @@ def _field(obj: Any, key: str, default: Any = None) -> Any:
     if isinstance(obj, dict):
         return obj.get(key, default)
     return getattr(obj, key, default)
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Return the value when it is a non-empty string, else ``None``."""
+    return value if isinstance(value, str) and value else None
 
 
 def _extract_output_text(response: Any) -> str:

--- a/tests/providers/test_gemini_stream.py
+++ b/tests/providers/test_gemini_stream.py
@@ -1,0 +1,162 @@
+"""Gemini streaming contract: generate_content_stream mapping and assembly."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from pollux import Environment, Input
+from pollux.config import Config
+from pollux.errors import APIError
+from pollux.interaction.execute import stream_interaction
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.tools import ToolDeclaration
+from pollux.providers.gemini import GeminiProvider
+from tests.conftest import GEMINI_MODEL
+from tests.helpers import make_interaction
+
+pytestmark = pytest.mark.contract
+
+
+def _gemini(**kwargs: Any) -> tuple[Any, Any, Any, Any]:
+    kwargs.setdefault("model", GEMINI_MODEL)
+    return make_interaction(provider="gemini", **kwargs)
+
+
+def _part(**kwargs: Any) -> SimpleNamespace:
+    kwargs.setdefault("text", None)
+    kwargs.setdefault("thought", False)
+    kwargs.setdefault("function_call", None)
+    return SimpleNamespace(**kwargs)
+
+
+def _chunk(
+    parts: list[SimpleNamespace], *, finish: Any = None, usage: Any = None
+) -> SimpleNamespace:
+    candidate = SimpleNamespace(
+        content=SimpleNamespace(parts=parts), finish_reason=finish
+    )
+    return SimpleNamespace(candidates=[candidate], usage_metadata=usage)
+
+
+def _thinking_tool_chunks() -> list[SimpleNamespace]:
+    return [
+        _chunk(
+            [
+                _part(text="thinking", thought=True),
+                _part(text="Hello"),
+            ]
+        ),
+        _chunk(
+            [
+                _part(
+                    function_call=SimpleNamespace(
+                        id=None, name="get_weather", args={"city": "NYC"}
+                    )
+                )
+            ],
+            finish="STOP",
+            usage=SimpleNamespace(
+                prompt_token_count=10,
+                candidates_token_count=5,
+                total_token_count=15,
+                thoughts_token_count=2,
+                cached_content_token_count=None,
+            ),
+        ),
+    ]
+
+
+class _AsyncChunks:
+    def __init__(
+        self, chunks: list[SimpleNamespace], raise_exc: Exception | None = None
+    ):
+        self._chunks = chunks
+        self._raise = raise_exc
+
+    def __aiter__(self) -> _AsyncChunks:
+        return self
+
+    async def __anext__(self) -> SimpleNamespace:
+        if self._raise is not None:
+            raise self._raise
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+
+def _provider_with(
+    chunks: list[SimpleNamespace], raise_exc: Exception | None = None
+) -> tuple[GeminiProvider, dict[str, Any]]:
+    captured: dict[str, Any] = {}
+
+    async def fake_stream(*, model: str, contents: Any, config: Any) -> _AsyncChunks:
+        captured["model"] = model
+        captured["contents"] = contents
+        captured["config"] = config
+        return _AsyncChunks(chunks, raise_exc=raise_exc)
+
+    provider = GeminiProvider("test-key")
+    provider._client = SimpleNamespace(
+        aio=SimpleNamespace(models=SimpleNamespace(generate_content_stream=fake_stream))
+    )
+    return provider, captured
+
+
+@pytest.mark.asyncio
+async def test_gemini_stream_through_interaction_assembles_output() -> None:
+    """Streamed thought/text/function-call parts assemble into the Output."""
+    provider, captured = _provider_with(_thinking_tool_chunks())
+    config = Config(provider="gemini", model=GEMINI_MODEL, use_mock=True)
+    environment = Environment(
+        tools=[
+            ToolDeclaration(
+                name="get_weather",
+                description="Get weather",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            )
+        ]
+    )
+
+    events = [
+        event
+        async for event in stream_interaction(
+            environment, Input("Weather?"), OutputRequirements(), config, provider
+        )
+    ]
+
+    assert captured["model"] == GEMINI_MODEL
+
+    types = [e.type for e in events]
+    assert types[0] == "start"
+    assert "reasoning_delta" in types
+    assert "tool_call" in types
+    assert types[-1] == "done"
+
+    done = events[-1].output
+    assert done is not None
+    assert done.text == "Hello"
+    assert done.reasoning == "thinking"
+    assert done.tool_calls[0].name == "get_weather"
+    assert done.tool_calls[0].arguments == {"city": "NYC"}
+    assert done.usage.total_tokens == 15
+    assert done.usage.reasoning_tokens == 2
+    assert done.metrics.finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_gemini_stream_error_raises_api_error() -> None:
+    """A failure mid-stream surfaces as an APIError attributed to gemini."""
+    provider, _captured = _provider_with([], raise_exc=RuntimeError("boom"))
+
+    with pytest.raises(APIError) as exc:
+        async for _chunk in provider.stream_generate(*_gemini(content="Hi")):
+            pass
+
+    assert exc.value.provider == "gemini"
+    assert exc.value.phase == "stream"

--- a/tests/providers/test_openai_stream.py
+++ b/tests/providers/test_openai_stream.py
@@ -1,0 +1,167 @@
+"""OpenAI streaming contract: Responses API event mapping and assembly."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from pollux import Environment, Input
+from pollux.config import Config
+from pollux.errors import APIError
+from pollux.interaction.execute import stream_interaction
+from pollux.interaction.requirements import OutputRequirements
+from pollux.interaction.tools import ToolDeclaration
+from pollux.providers.openai import OpenAIProvider
+from tests.conftest import OPENAI_MODEL
+from tests.helpers import make_interaction
+
+pytestmark = pytest.mark.contract
+
+
+def _openai(**kwargs: Any) -> tuple[Any, Any, Any, Any]:
+    kwargs.setdefault("model", OPENAI_MODEL)
+    return make_interaction(provider="openai", **kwargs)
+
+
+def _event(type_: str, **kwargs: Any) -> SimpleNamespace:
+    return SimpleNamespace(type=type_, **kwargs)
+
+
+def _completed_response() -> SimpleNamespace:
+    usage = SimpleNamespace(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        output_tokens_details=None,
+        input_tokens_details=None,
+    )
+    return SimpleNamespace(
+        output_text="Hello",
+        usage=usage,
+        id="resp_1",
+        output=[],
+        status="completed",
+        incomplete_details=None,
+    )
+
+
+def _text_and_tool_events() -> list[SimpleNamespace]:
+    return [
+        _event("response.created", response=SimpleNamespace(id="resp_1")),
+        _event("response.output_text.delta", delta="Hel"),
+        _event("response.reasoning_summary_text.delta", delta="thinking"),
+        _event("response.output_text.delta", delta="lo"),
+        _event(
+            "response.output_item.added",
+            output_index=1,
+            item=SimpleNamespace(
+                type="function_call", call_id="call_1", name="get_weather"
+            ),
+        ),
+        _event(
+            "response.function_call_arguments.delta", output_index=1, delta='{"city":'
+        ),
+        _event(
+            "response.function_call_arguments.delta", output_index=1, delta='"NYC"}'
+        ),
+        _event("response.completed", response=_completed_response()),
+    ]
+
+
+class _AsyncEvents:
+    def __init__(
+        self, events: list[SimpleNamespace], raise_exc: Exception | None = None
+    ):
+        self._events = events
+        self._raise = raise_exc
+
+    def __aiter__(self) -> _AsyncEvents:
+        return self
+
+    async def __anext__(self) -> SimpleNamespace:
+        if self._raise is not None:
+            raise self._raise
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+
+class _FakeResponses:
+    def __init__(
+        self, events: list[SimpleNamespace], raise_exc: Exception | None = None
+    ):
+        self._events = events
+        self._raise = raise_exc
+        self.last_kwargs: dict[str, Any] | None = None
+
+    async def create(self, **kwargs: Any) -> _AsyncEvents:
+        self.last_kwargs = kwargs
+        return _AsyncEvents(self._events, raise_exc=self._raise)
+
+
+def _provider_with(
+    events: list[SimpleNamespace], raise_exc: Exception | None = None
+) -> tuple[OpenAIProvider, _FakeResponses]:
+    responses = _FakeResponses(events, raise_exc=raise_exc)
+    provider = OpenAIProvider("test-key")
+    provider._client = type("Client", (), {"responses": responses})()
+    return provider, responses
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_through_interaction_assembles_output() -> None:
+    """Responses stream events assemble into the same Output as generate()."""
+    provider, responses = _provider_with(_text_and_tool_events())
+    config = Config(provider="openai", model=OPENAI_MODEL, use_mock=True)
+    environment = Environment(
+        tools=[
+            ToolDeclaration(
+                name="get_weather",
+                description="Get weather",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            )
+        ]
+    )
+
+    events = [
+        event
+        async for event in stream_interaction(
+            environment, Input("Weather?"), OutputRequirements(), config, provider
+        )
+    ]
+
+    assert responses.last_kwargs is not None
+    assert responses.last_kwargs["stream"] is True
+
+    types = [e.type for e in events]
+    assert types[0] == "start"
+    assert "reasoning_delta" in types
+    assert "tool_call" in types
+    assert types[-1] == "done"
+
+    done = events[-1].output
+    assert done is not None
+    assert done.text == "Hello"
+    assert done.reasoning == "thinking"
+    assert done.tool_calls[0].name == "get_weather"
+    assert done.tool_calls[0].arguments == {"city": "NYC"}
+    assert done.usage.total_tokens == 15
+    assert done.metrics.finish_reason == "completed"
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_error_raises_api_error() -> None:
+    """A failure mid-stream surfaces as an APIError attributed to openai."""
+    provider, _responses = _provider_with([], raise_exc=RuntimeError("boom"))
+
+    with pytest.raises(APIError) as exc:
+        async for _chunk in provider.stream_generate(*_openai(content="Hi")):
+            pass
+
+    assert exc.value.provider == "openai"
+    assert exc.value.phase == "stream"


### PR DESCRIPTION
## Summary

Complete cloud streaming. This adds `stream_generate` to the OpenAI and Gemini adapters, so
`stream()` now works for every provider and a streamed `done.output` matches the
non-streaming `Output` across the board.

## Related issue

None

## Test plan

- `just check` → **405 passed, 6 skipped** (ruff format/lint, rumdl, mypy, pytest).
- `uv run mkdocs build --strict` → clean.
- `tests/providers/test_openai_stream.py` (2): an end-to-end run through
  `stream_interaction` assembles text / reasoning / tool-call / usage / finish
  from Responses API events, and a mid-stream failure surfaces as an `APIError`
  attributed to `openai`.
- `tests/providers/test_gemini_stream.py` (2): the same end-to-end assertions for
  streamed `generate_content_stream` parts (text, thought, function call), and a
  mid-stream failure attributed to `gemini`.

## Notes

No core or boundary changes; both adapters reuse the recently added assembly as-is.

- **OpenAI** streams over the Responses API (`stream=True`), mapping
  `output_text.delta` / `reasoning_summary_text.delta` /
  `function_call_arguments.delta` events; the terminal `response.completed` event
  is parsed once via the existing `_parse_response` for usage, finish reason, and
  id.
- **Gemini** streams over `generate_content_stream`, mapping candidate parts
  (text, thought → reasoning, function call). Gemini sends function calls whole
  rather than fragmented, so each gets its own tool-call slot index via a running
  counter; usage and finish reason come from `usage_metadata` /
  `candidate.finish_reason`.

Both providers continue via history / `previous_response_id` with no replayed
reasoning, so reasoning is display-only and no `provider_state` channel is needed
(unlike Anthropic's signed thinking blocks).