### PR TITLE
feat(core): enforce continuation provider compatibility at runtime

### DIFF
--- a/src/pollux/interaction/continuation.py
+++ b/src/pollux/interaction/continuation.py
@@ -74,7 +74,18 @@ class Message:
 
 @dataclass(frozen=True, slots=True)
 class Continuation:
-    """Serializable state for continuing a provider-correct interaction."""
+    """Serializable state for continuing a provider-correct interaction.
+
+    Read it from ``output.continuation`` and pass it back as
+    ``Input(continuation=...)`` to take the next turn. Persist it across processes
+    with :meth:`to_jsonable` / :meth:`from_jsonable`, which stamp and verify a
+    schema version (and, optionally, the producing provider).
+
+    A continuation is bound to the provider that produced it — its
+    ``provider_state`` (response ids, provider-specific replay blocks) is not
+    portable. Reusing one under a different provider is rejected before dispatch.
+    It is not memory: Pollux does not summarize, rank, or compact it.
+    """
 
     SCHEMA_VERSION: ClassVar[int] = SCHEMA_VERSION
 

--- a/src/pollux/interaction/validate.py
+++ b/src/pollux/interaction/validate.py
@@ -29,6 +29,35 @@ def _wants_conversation(inputs: Sequence[Input]) -> bool:
     )
 
 
+def _reject_incompatible_continuations(
+    inputs: Sequence[Input], snapshot: EnvironmentSnapshot
+) -> None:
+    """Reject reusing a continuation produced by a different provider.
+
+    A live :class:`Continuation` records the provider that produced it. Its
+    ``provider_state`` — response ids and provider-specific replay blocks such as
+    Anthropic's signed thinking blocks — is not portable, so replaying it under
+    another provider would corrupt the turn. This is the runtime half of the
+    continuation-compatibility contract; the serialized half lives in
+    ``Continuation.from_jsonable(expected_provider=...)``. Continuations without a
+    provider marker (hand-built, or derived from plain ``history``) are left alone.
+    """
+    active = snapshot.provider
+    if active is None:
+        return
+    for inp in inputs:
+        continuation = inp.continuation
+        if continuation is None or continuation.provider is None:
+            continue
+        if continuation.provider != active:
+            raise ConfigurationError(
+                f"Continuation was produced by provider {continuation.provider!r}, "
+                f"but the active provider is {active!r}",
+                hint="Reuse a continuation only with the provider that produced "
+                "it, or start a new interaction.",
+            )
+
+
 def validate_interaction(
     requirements: OutputRequirements,
     inputs: Sequence[Input],
@@ -82,6 +111,8 @@ def validate_interaction(
             "Conversation continuity currently supports exactly one input per call",
             hint="Continue from a single input when passing continuation/history.",
         )
+
+    _reject_incompatible_continuations(inputs, snapshot)
 
     if cache_requested and not caps.persistent_cache:
         raise ConfigurationError(

--- a/tests/interaction/test_continuation_compat.py
+++ b/tests/interaction/test_continuation_compat.py
@@ -1,0 +1,79 @@
+"""Integration tests: the runtime continuation-compatibility contract.
+
+A live ``Continuation`` records the provider that produced it. Reusing it under a
+different provider is rejected before dispatch, because its ``provider_state``
+(response ids, provider-specific replay blocks) is not portable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pollux.config import Config
+from pollux.errors import ConfigurationError
+from pollux.interaction.continuation import Continuation, Message
+from pollux.interaction.environment import Environment
+from pollux.interaction.execute import execute_interaction
+from pollux.interaction.input import Input
+from pollux.interaction.requirements import OutputRequirements
+from pollux.providers.base import ProviderCapabilities
+from tests.conftest import ANTHROPIC_MODEL, FakeProvider
+
+pytestmark = pytest.mark.integration
+
+
+def _conversational_provider() -> FakeProvider:
+    return FakeProvider(
+        _capabilities=ProviderCapabilities(
+            persistent_cache=True, uploads=True, conversation=True
+        )
+    )
+
+
+def _cfg() -> Config:
+    return Config(provider="anthropic", model=ANTHROPIC_MODEL, use_mock=True)
+
+
+def _continuation(provider: str | None) -> Continuation:
+    return Continuation(
+        messages=(Message(role="user", content="earlier"),),
+        provider=provider,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rejects_continuation_from_a_different_provider() -> None:
+    with pytest.raises(ConfigurationError, match="active provider"):
+        await execute_interaction(
+            Environment(),
+            Input(content="next", continuation=_continuation("openai")),
+            OutputRequirements(),
+            _cfg(),
+            _conversational_provider(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_accepts_continuation_from_the_matching_provider() -> None:
+    out = await execute_interaction(
+        Environment(),
+        Input(content="next", continuation=_continuation("anthropic")),
+        OutputRequirements(),
+        _cfg(),
+        _conversational_provider(),
+    )
+    assert out.text == "ok:next"
+
+
+@pytest.mark.asyncio
+async def test_accepts_continuation_without_a_provider_marker() -> None:
+    # Hand-built or history-derived continuations carry no provider marker and
+    # are left alone by the compatibility check.
+    out = await execute_interaction(
+        Environment(),
+        Input(content="next", continuation=_continuation(None)),
+        OutputRequirements(),
+        _cfg(),
+        _conversational_provider(),
+    )
+    assert out.text == "ok:next"


### PR DESCRIPTION
## Summary

Complete the public `Continuation` primitive. The type, its
version/provider-stamped `to_jsonable`/`from_jsonable` round-trip, and the api
reference were already in place. The missing piece was the *runtime* half of the
"Continuation compatibility is a Pollux contract" requirement: nothing stopped an
app from passing `Input(continuation=output.continuation)` back under a different
provider.

`validate_interaction` now rejects, before dispatch, reusing a continuation whose
producing provider differs from the active one. A live continuation records its
provider, and its `provider_state` (response ids, provider-specific replay blocks
such as Anthropic's signed thinking blocks) is not portable, so replaying it under
another provider would corrupt the turn. This mirrors the serialized-side check in
`Continuation.from_jsonable(expected_provider=...)`.

## Related issue

None

## Test plan

- `just check` → **408 passed, 6 skipped** (ruff format/lint, rumdl, mypy, pytest).
- `uv run mkdocs build --strict` → clean.
- `tests/interaction/test_continuation_compat.py` (3): a cross-provider
  continuation is rejected with an actionable error; a matching-provider
  continuation runs; a continuation without a provider marker (hand-built or
  history-derived) is left alone.
- Existing `tests/interaction/test_continuation.py` (serialization round-trip,
  version/provider rejection) still passes.

## Notes

Continuations without a provider marker are deliberately not rejected - they arise
from plain `history` or hand construction and carry no provider-specific state.