### PR TITLE
docs(api): align documentation with v2 API structure and terms

### DIFF
--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -1,10 +1,10 @@
 <!-- Intent: The canonical composition tutorial. Teach users how to build a
      complete tool-calling agent loop using Pollux primitives. This is the page
-     that solves the "Boolean Trap" — it proves that complex workflows are built
-     by composing run() + continue_tool() inside the user's own loop. Do NOT
-     introduce conversation mechanics from scratch — link back to that page.
-     Assumes the reader understands continue_from, tool calling setup, and
-     continue_tool() from the previous page. Register: warm tutorial. -->
+     that solves the "Boolean Trap" and proves that complex workflows are built
+     by composing interact() inside the user's own loop. Do NOT
+     introduce conversation mechanics from scratch. Link back to that page.
+     Assumes the reader understands continuation, tool calling setup, and
+     interact() from the previous page. Register: warm tutorial. -->
 
 # Building an Agent Loop
 
@@ -17,7 +17,7 @@ understanding of *why* it's built this way.
 
 !!! info "Boundary"
     **Pollux owns:** executing each turn (sending the prompt, surfacing tool
-    calls, carrying conversation state forward via `continue_tool()`).
+    calls, carrying conversation state forward via `interact()`).
 
     **You own:** the loop itself: how many turns to allow, which tools to
     implement, what to do between turns, and when to stop.
@@ -31,24 +31,32 @@ Type it out (or paste it) and run it. We'll break it down afterward.
 import asyncio
 import json
 
-from pollux import Config, Options, run, continue_tool
+from pollux import (
+    Config,
+    Environment,
+    Input,
+    ToolCall,
+    ToolDeclaration,
+    ToolResult,
+    interact,
+)
 
 MAX_TURNS = 5
 
 config = Config(provider="openai", model="gpt-5-nano")
 
 tools = [
-    {
-        "name": "get_weather",
-        "description": "Get current weather for a location",
-        "parameters": {
+    ToolDeclaration(
+        name="get_weather",
+        description="Get current weather for a location",
+        parameters={
             "type": "object",
             "properties": {
                 "location": {"type": "string", "description": "City name"},
             },
             "required": ["location"],
         },
-    }
+    )
 ]
 
 # --- Tool implementations (your code) ---
@@ -63,46 +71,49 @@ TOOL_DISPATCH = {
 }
 
 
-def execute_tool_calls(tool_calls: list[dict]) -> list[dict]:
+def execute_tool_calls(tool_calls: tuple[ToolCall, ...]) -> list[ToolResult]:
     """Run each tool call and return tool-result messages."""
     results = []
     for tc in tool_calls:
         try:
-            output = TOOL_DISPATCH[tc["name"]](tc["arguments"])
+            # Arguments are already parsed by ToolCall
+            args = tc.arguments if isinstance(tc.arguments, dict) else {}
+            output = TOOL_DISPATCH[tc.name](args)
             content = json.dumps(output)
         except Exception as exc:
             content = json.dumps({"error": str(exc)})
-        results.append({
-            "role": "tool",
-            "tool_call_id": tc["id"],
-            "content": content,
-        })
+        results.append(ToolResult(
+            call_id=tc.id,
+            content=content,
+        ))
     return results
 
 
 async def agent(user_prompt: str) -> str:
     """Run a tool-calling agent loop and return the final answer."""
-    # history=[] is optional — Pollux auto-populates conversation state when
-    # tool calls are present — but included here for explicitness.
-    options = Options(tools=tools, tool_choice="auto", history=[])
-    result = await run(user_prompt, config=config, options=options)
+    env = Environment(tools=tools)
+    out = await interact(
+        env,
+        Input(content=user_prompt),
+        config=config,
+        tool_choice="auto",
+    )
 
     for turn in range(MAX_TURNS):
-        if "tool_calls" not in result:
-            return result["answers"][0]
+        if not out.tool_calls:
+            return out.text
 
         # Execute every tool the model requested
-        tool_results = execute_tool_calls(result["tool_calls"][0])
+        tool_results = execute_tool_calls(out.tool_calls)
 
-        # Next turn — model sees tool results and may call more tools
-        result = await continue_tool(
-            continue_from=result,
-            tool_results=tool_results,
+        # Next turn: model sees tool results and may call more tools
+        out = await interact(
+            env,
+            Input(continuation=out.continuation, tool_results=tool_results),
             config=config,
-            options=Options(tools=tools),
         )
 
-    return result["answers"][0]  # Best-effort after MAX_TURNS
+    return out.text  # Best-effort after MAX_TURNS
 
 
 print(asyncio.run(agent("What's the weather in NYC and London?")))
@@ -117,7 +128,7 @@ The weather in NYC is 72°F and sunny. In London, it's also 72°F and sunny.
 The model asked for two tool calls (one for each city), your code executed
 them, and the model composed an answer from both results.
 
-## What You Just Built
+## Deconstructing the Loop
 
 Let's take this apart, because the structure matters as much as the code.
 
@@ -154,9 +165,9 @@ This means you control:
 Within each iteration, Pollux handled:
 
 1. Delivering the prompt and tool definitions to the provider.
-2. Surfacing `tool_calls` in the result envelope.
-3. Carrying conversation state forward via `continue_tool()`.
-4. Normalizing the response into a stable `ResultEnvelope`.
+2. Surfacing `tool_calls` in the `Output` object.
+3. Carrying conversation state forward via `interact()`.
+4. Normalizing the response into a stable `Output` model.
 
 The boundary is clean: Pollux executes turns, you decide what happens
 *between* them.
@@ -176,48 +187,49 @@ def search_web(query: str) -> dict:
 
 TOOL_DISPATCH["search_web"] = lambda args: search_web(args["query"])
 
-tools.append({
-    "name": "search_web",
-    "description": "Search the web for information",
-    "parameters": {
+tools.append(ToolDeclaration(
+    name="search_web",
+    description="Search the web for information",
+    parameters={
         "type": "object",
         "properties": {"query": {"type": "string"}},
         "required": ["query"],
     },
-})
+))
 ```
 
 The loop itself doesn't change. It already handles any number of tools.
 
-### Using `history` instead of `continue_from`
+### Using `history` instead of `continuation`
 
-`continue_from` is convenient when you have the prior result object.
+`continuation` is convenient when you have the prior `Output` object.
 If you need more control (injecting a system message mid-conversation,
 trimming old turns), build `history` manually:
 
 ```python
+from pollux import Message
+
 history = [
-    {"role": "user", "content": "What's the weather in NYC?"},
-    {"role": "assistant", "content": "", "tool_calls": tool_calls},
-    {"role": "tool", "tool_call_id": "call_1", "content": '{"temp_f": 72}'},
+    Message(role="user", content="What's the weather in NYC?"),
+    Message(role="assistant", content="", tool_calls=tool_calls),
+    Message(role="tool", tool_call_id="call_1", content='{"temp_f": 72}'),
 ]
 
-result = await run(
-    "Now summarize.",
+out = await interact(
+    env,
+    Input(content="Now summarize.", history=history),
     config=config,
-    options=Options(tools=tools, history=history),
 )
 ```
 
 ### Guiding tool use with system instructions
 
-Use `system_instruction` to constrain when and how the model calls tools:
+Use `instructions` to constrain when and how the model calls tools, passed to the `Environment`:
 
 ```python
-options = Options(
+env = Environment(
     tools=tools,
-    tool_choice="auto",
-    system_instruction=(
+    instructions=(
         "You are a weather assistant. Only call get_weather for cities "
         "the user explicitly mentions. Do not guess locations."
     ),
@@ -230,30 +242,34 @@ Insert an approval step before executing tool calls:
 
 ```python
 async def agent_with_approval(user_prompt: str) -> str:
-    options = Options(tools=tools, tool_choice="auto")
-    result = await run(user_prompt, config=config, options=options)
+    env = Environment(tools=tools)
+    out = await interact(
+        env,
+        Input(content=user_prompt),
+        config=config,
+        tool_choice="auto",
+    )
 
     for turn in range(MAX_TURNS):
-        if "tool_calls" not in result:
-            return result["answers"][0]
+        if not out.tool_calls:
+            return out.text
 
         # Show what the model wants to do
-        for tc in result["tool_calls"][0]:
-            print(f"  Tool: {tc['name']}({tc['arguments']})")
+        for tc in out.tool_calls:
+            print(f"  Tool: {tc.name}({tc.arguments})")
 
         approval = input("Execute these tool calls? [y/n] ")
         if approval.lower() != "y":
             return "Agent stopped by user."
 
-        tool_results = execute_tool_calls(result["tool_calls"][0])
-        result = await continue_tool(
-            continue_from=result,
-            tool_results=tool_results,
+        tool_results = execute_tool_calls(out.tool_calls)
+        out = await interact(
+            env,
+            Input(continuation=out.continuation, tool_results=tool_results),
             config=config,
-            options=Options(tools=tools),
         )
 
-    return result["answers"][0]
+    return out.text
 ```
 
 This is a two-line addition to the loop. That's the benefit of owning
@@ -266,9 +282,8 @@ the control flow.
 - **Return errors as tool results, don't raise.** If a tool fails, return a
   JSON error message so the model can reason about the failure. Raising an
   exception breaks the loop.
-- **`tool_calls` is per-prompt.** `result["tool_calls"]` is a list of
-  lists, one per prompt. For `run()` (single prompt), access
-  `result["tool_calls"][0]`.
+- **`tool_calls` is a flat tuple on `Output`.** When using `interact()` or `run()`,
+  `out.tool_calls` is a flat tuple of `ToolCall` objects.
 - **The model can request multiple tools in one turn.** The example handles
   this naturally: `execute_tool_calls` iterates over all calls and returns
   a result for each.

--- a/docs/building-with-deferred-delivery.md
+++ b/docs/building-with-deferred-delivery.md
@@ -2,7 +2,7 @@
      application code around provider-side job lifecycles. Do NOT reteach the
      deferred method signatures or every lifecycle state in detail. That lives
      on the submission page. Assumes the reader already knows defer(),
-     inspect_deferred(), collect_deferred(), and ResultEnvelope. Register:
+     inspect_deferred(), collect_deferred(), and OutputCollection. Register:
      guided applied. -->
 
 # Building With Deferred Delivery
@@ -30,7 +30,7 @@ Teach your application three persistence states:
 
 1. `pending`: the job was submitted and the handle is stored durably.
 2. `collectable`: `inspect_deferred()` says the job reached a terminal state.
-3. `collected`: your code wrote the `ResultEnvelope` somewhere durable and
+3. `collected`: your code wrote the `OutputCollection` somewhere durable and
    retired the pending handle.
 
 That answers the three important questions:
@@ -40,8 +40,8 @@ That answers the three important questions:
 - Your application decides how a pending handle becomes a collected record.
 
 Terminal does not mean successful. A collectable job can still produce
-`result["status"] == "partial"` or `result["status"] == "error"`, so branch on
-the collected envelope before you decide whether the workflow succeeded.
+`result.status == "partial"` or `result.status == "error"`, so branch on
+the collected collection before you decide whether the workflow succeeded.
 
 This pattern fits cleanly inside a larger system. A cron job, worker queue,
 CLI, or web app can all use the same boundary. Pollux handles provider
@@ -78,7 +78,7 @@ async def submit_reports(paths: list[Path]) -> None:
     for path in paths:
         handle = await defer(
             "Summarize the report in five bullets and list the three biggest execution risks.",
-            source=Source.from_file(path),
+            sources=[Source.from_file(path)],
             config=config,
         )
         record = {
@@ -105,13 +105,13 @@ async def harvest_ready_reports() -> None:
             continue
 
         result = await collect_deferred(handle)
-        outcome_dir = RESULTS_DIR / result["status"]
+        outcome_dir = RESULTS_DIR / result.status
         outcome_dir.mkdir(parents=True, exist_ok=True)
         result_path = outcome_dir / f"{handle.job_id}.json"
         collected = {
             "report_path": str(report_path),
             "snapshot_status": snapshot.status,
-            "result": result,
+            "result": result.to_jsonable(),
         }
         # Store the collected outcome, then retire the pending handle.
         result_path.write_text(json.dumps(collected, indent=2), encoding="utf-8")
@@ -129,11 +129,11 @@ asyncio.run(submit_reports(reports))
 1. Submission is fast. The interactive path stores a durable handle and exits.
 2. Readiness is explicit. `snapshot.is_terminal` is the only gate before
    collection.
-3. Success is explicit. `result["status"]` decides whether the collected job
+3. Success is explicit. `result.status` decides whether the collected job
    landed in `ok`, `partial`, or `error`.
 4. Collection happens once per pending record. After your code writes the
    outcome, it retires the handle from the pending set.
-5. The result still lands in a normal `ResultEnvelope`, so downstream parsing
+5. The result still lands in a normal `OutputCollection`, so downstream parsing
    stays small.
 
 The directories here are placeholders for your real system boundary. Replace

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -96,8 +96,7 @@ file path.
 
 Not all work needs an immediate answer. **Deferred delivery** submits requests
 to a provider-side job system, often at lower cost when deferred pricing is
-available, and returns a serializable handle. Your code persists the handle and
-collects the `ResultEnvelope` later. Some providers call this a batch API, but
+available, and returns a serializable handle. Your code persists the handle and collects the `OutputCollection` later. Some providers call this a batch API, but
 Pollux uses **deferred delivery** for the user-facing workflow. See
 [Building With Deferred Delivery](building-with-deferred-delivery.md) for the
 operating model, then
@@ -151,8 +150,8 @@ cache keys from content hashes.
 provider calls concurrently.
 
 **Extract:** Transforms API responses into a stable
-[`ResultEnvelope`](sending-content.md#resultenvelope-reference) with
-`answers`, optional `structured` data, and `usage` metadata.
+[`Output`](sending-content.md#output-and-outputcollection-reference) with
+`text`, optional `structured` data, and `usage` metadata.
 
 This separation is what lets Pollux handle multimodal inputs and provider
 differences without forcing callers to reimplement orchestration logic.
@@ -216,10 +215,10 @@ leaves domain-level decisions and workflow orchestration to your code.
 | **Tool execution** | Implementing and calling tools | Surfacing tool-call requests and passing results back |
 | **Multi-turn loops** | Loop control, exit conditions, state | Single-turn request/response with conversation continuity |
 | **Deferred lifecycle** | Persistence, polling cadence, scheduling, cross-job orchestration | Provider submission, lifecycle normalization, ordered collection |
-| **Result aggregation** | Collecting, comparing, and storing answers | Normalizing each response into `ResultEnvelope` |
+| **Result aggregation** | Collecting, comparing, and storing answers | Normalizing each response into `Output` / `OutputCollection` |
 | **Error recovery** | Deciding what to retry or skip at the workflow level | Retrying transient API failures within a single call |
 | **Concurrency** | Parallelizing across files or workflows | Concurrent API calls within a single `run_many()` |
-| **Output validation** | Domain-specific checks on answers | Structured parsing via `response_schema` |
+| **Output validation** | Domain-specific checks on answers | Structured parsing via `output` schema |
 
 This boundary is intentional. Keeping workflow orchestration in your code
 means Pollux never imposes opinions about loop structures, error policies,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
-<!-- Intent: Reference page for Config and Options fields. Cover API key
-     resolution, mock mode, performance/cost controls, RetryPolicy, and Options
-     per-prompt overrides. Do NOT include tutorials or extended examples,
+<!-- Intent: Reference page for Config fields. Cover API key
+     resolution, mock mode, performance/cost controls, RetryPolicy, and execution
+     parameters. Do NOT include tutorials or extended examples,
      link to the relevant guide pages. Register: reference. -->
 
 # Configuring Pollux
@@ -119,7 +119,7 @@ config = Config(
 | Need | Direction |
 |---|---|
 | Fast iteration without API calls | `use_mock=True` |
-| Reduce token spend on repeated context | Use `create_cache()`. See [Reducing Costs with Context Caching](caching.md) |
+| Reduce token spend on repeated context | Use `prepare_environment(cache=CachePolicy(...))`. See [Reducing Costs with Context Caching](caching.md) |
 | Higher throughput for many prompts/sources | Increase `request_concurrency` |
 | Better resilience to transient failures | Customize `retry=RetryPolicy(...)` |
 
@@ -152,55 +152,72 @@ All `RetryPolicy` fields (defaults shown):
 When a provider returns a `Retry-After` hint, Pollux respects it (whichever
 is longer: the computed backoff or the server hint).
 
-## Options
+## Execution and Generation Parameters
 
-`Config` establishes the infrastructure requirements for a provider connection. `Options` is different: it controls per-prompt inference overrides. This split lets you tune how text is generated on a call-by-call basis without tearing down or recreating the underlying client.
+In Pollux v2, generation and execution constraints are passed as first-class keyword arguments to the execution functions (`run()`, `run_many()`, `interact()`, `stream()`, and `defer()`).
+
+For stable setups (such as tools, system instructions, or caching policies), you define them on a reusable `Environment`. Per-turn inputs (conversation state, tool results, prompt content) are passed via `Input`.
+
+Here is an example showing the keyword arguments you can pass directly:
 
 ```python
-from pollux import Options
-
-options = Options(
-    system_instruction="You are a concise analyst.",  # Optional global behavior guide
+# Pass options as direct kwargs
+result = await run(
+    "Solve this problem.",
+    config=config,
+    output=MyPydanticModel,           # Structured output schema
     temperature=0.7,                  # Generation tuning
     top_p=0.9,                        # Generation tuning
-    tools=[{"name": "get_weather"}],  # Native tool calling
-    tool_choice="auto",               # Tool calling mode ('auto', 'required', 'none', or dict)
-    response_schema=MyPydanticModel,  # Structured output extraction
-    reasoning_effort="medium",        # Controls model thinking depth
-    # reasoning_budget_tokens=0,      # Explicit reasoning token budget where supported
-    max_tokens=4096,                  # Provider-specific output cap
-    implicit_caching=True,            # Auto-cache prefix (Anthropic only)
+    max_tokens=4096,                  # Output token ceiling
+    seed=123,                         # Sampling seed where supported
+    reasoning_effort="medium",        # Qualitative thinking depth
+    # reasoning_budget_tokens=2048,   # Or explicit thinking token budget
+    tool_choice="auto",               # Tool-choice control
     provider_options={                # Raw provider escape hatch
         "openai": {"tools": [{"type": "web_search_preview"}]},
     },
 )
 ```
 
-| Field | Type | Default | Description |
+### Supported Parameters
+
+| Parameter | Type | Default | Description |
 |---|---|---|---|
-| `system_instruction` | `str \| None` | `None` | Global system prompt |
+| `output` | `type[BaseModel] \| dict \| None` | `None` | Expected JSON response format. See [Extracting Structured Data](structured-data.md) |
 | `temperature` | `float \| None` | `None` | Sampling temperature |
 | `top_p` | `float \| None` | `None` | Nucleus sampling probability |
-| `tools` | `list[dict] \| None` | `None` | JSON schemas for Pollux-normalized function tools. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
-| `tool_choice` | `str \| dict \| None` | `None` | Tool execution strategy. See [Building an Agent Loop](agent-loop.md) |
-| `response_schema` | `type[BaseModel] \| dict` | `None` | Expected JSON response format. See [Extracting Structured Data](structured-data.md) |
-| `reasoning_effort` | `str \| None` | `None` | Controls model thinking depth. See [Writing Portable Code Across Providers](portable-code.md#choosing-a-reasoning-control) |
-| `reasoning_budget_tokens` | `int \| None` | `None` | Explicit reasoning token budget where supported. Mutually exclusive with `reasoning_effort`. See [Writing Portable Code Across Providers](portable-code.md#choosing-a-reasoning-control) |
-| `max_tokens` | `int \| None` | `None` | Output-token cap with provider-specific semantics. Anthropic applies provider defaults when omitted; other providers may ignore it. See [Provider Capabilities](reference/provider-capabilities.md) |
-| `history` | `list[dict] \| None` | `None` | Conversation history. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
-| `continue_from` | `ResultEnvelope \| None` | `None` | Resume from a prior result. See [Continuing Conversations Across Turns](conversations-and-agents.md) |
-| `cache` | `CacheHandle \| None` | `None` | Persistent explicit cache (Gemini). See [Reducing Costs with Context Caching](caching.md) |
-| `implicit_caching` | `bool \| None` | `None` | Enable or disable Anthropic implicit caching. Defaults to `True` for a single provider call and `False` for multi-call fan-out. `implicit_caching=True` raises on providers that do not support it. See [Reducing Costs with Context Caching](caching.md) |
+| `max_tokens` | `int \| None` | `None` | Output-token budget cap |
+| `seed` | `int \| None` | `None` | Optional sampling seed |
+| `reasoning_effort` | `str \| None` | `None` | Qualitative reasoning level (`"low"`, `"medium"`, `"high"`). See [Writing Portable Code Across Providers](portable-code.md#choosing-a-reasoning-control) |
+| `reasoning_budget_tokens` | `int \| None` | `None` | Explicit reasoning token budget. See [Writing Portable Code Across Providers](portable-code.md#choosing-a-reasoning-control) |
+| `tool_choice` | `str \| dict \| None` | `None` | Tool-choice control (`"auto"`, `"required"`, `"none"`, or dict). See [Building an Agent Loop](agent-loop.md) |
 | `provider_options` | `dict[str, dict] \| None` | `None` | Raw provider-scoped request options. Keys must be provider names. |
+
+### Environment Configuration
+
+For instructions, sources, and tool declarations, configure an `Environment` and pass it to `interact()`, `run()`, or `run_many()`:
+
+```python
+from pollux import Environment, ToolDeclaration, CachePolicy
+
+env = Environment(
+    instructions="You are a helpful assistant.",
+    sources=[Source.from_file("doc.pdf")],
+    tools=[ToolDeclaration(name="get_weather", description="...")],
+    cache=CachePolicy(ttl_seconds=3600), # Persistent caching policy
+)
+```
+
+Or for `run()` and `run_many()`, you can pass `instructions`, `sources` / `source`, and `tools` directly as inline keyword arguments, and Pollux will construct the `Environment` internally.
 
 ### Provider Options Escape Hatch
 
-`provider_options` is Pollux's one raw provider escape hatch. It is for
-provider-specific request fields that Pollux does not normalize, such as
-hosted/server tools, service tiers, or newly released provider knobs.
+`provider_options` is Pollux's one raw provider escape hatch. It is for provider-specific request fields that Pollux does not normalize, such as hosted/server tools, service tiers, or newly released provider knobs.
 
 ```python
-options = Options(
+result = await run(
+    prompt,
+    config=config,
     provider_options={
         "openai": {"tools": [{"type": "web_search_preview"}]},
         "gemini": {"seed": 123},
@@ -208,39 +225,19 @@ options = Options(
 )
 ```
 
-Only the active provider's dictionary is forwarded. If a raw key overlaps with
-a field Pollux already generated from first-class options, Pollux raises
-`ConfigurationError` instead of silently overriding either value. For example,
-do not pass both `Options(tools=[...])` and
-`provider_options={"openai": {"tools": [...]}}` in the same call.
+Only the active provider's dictionary is forwarded. If a raw key overlaps with a field Pollux already generated from first-class options, Pollux raises `ConfigurationError` instead of silently overriding either value. For example, do not pass both `tools=[...]` and `provider_options={"openai": {"tools": [...]}}` in the same call.
 
 !!! note
-    OpenAI GPT-5 family models (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`) reject
-    sampling controls like `temperature` and `top_p` with provider errors.
-    Older OpenAI models (for example `gpt-4.1-nano`) still accept them.
-    See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints)
-    for the full constraints mapping.
+    OpenAI GPT-5 family models (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`) reject sampling controls like `temperature` and `top_p` with provider errors. Older OpenAI models (for example `gpt-4.1-nano`) still accept them. See [Writing Portable Code Across Providers](portable-code.md#model-specific-constraints) for the full constraints mapping.
 
 !!! note
-    `reasoning_effort` and `reasoning_budget_tokens` are mutually exclusive.
-    Use `reasoning_effort` when the provider exposes named levels
-    (`"low"`, `"medium"`, `"high"`). Use `reasoning_budget_tokens` when you
-    need an exact token ceiling. Not every provider accepts both, and some
-    provider/model combinations may still reject a value at call time; see
-    [Reasoning Control Mapping](portable-code.md#reasoning-control-mapping).
+    `reasoning_effort` and `reasoning_budget_tokens` are mutually exclusive. Use `reasoning_effort` when the provider exposes named levels (`"low"`, `"medium"`, `"high"`). Use `reasoning_budget_tokens` when you need an exact token ceiling. Not every provider accepts both, and some provider/model combinations may still reject a value at call time; see [Reasoning Control Mapping](portable-code.md#reasoning-control-mapping).
 
 !!! note
-    `max_tokens` is not a portable "length knob" with identical behavior
-    everywhere. Anthropic uses it as the total output budget and applies a
-    provider default when you omit it. OpenRouter forwards it to the routed
-    model. Other providers may ignore it in the current release.
+    `max_tokens` is not a portable "length knob" with identical behavior everywhere. Anthropic uses it as the total output budget and applies a provider default when you omit it. OpenRouter forwards it to the routed model. Other providers may ignore it in the current release.
 
-!!! warning "Cache handle restrictions"
-    When `cache` is set, `system_instruction`, `tools`, and `tool_choice`
-    **must not** be passed in the same `Options`. `system_instruction` and
-    `tools` can be baked into `create_cache()`, while `tool_choice` must be
-    set only on uncached calls. See
-    [Reducing Costs with Context Caching](caching.md) for details.
+!!! warning "Cache environment restrictions"
+    When persistent `cache` is configured on an `Environment`, `instructions` and `tools` are baked directly into the cache. Modifying them requires preparing a new `Environment` (which creates a new cache). See [Reducing Costs with Context Caching](caching.md) for details.
 
 ## Safety Notes
 

--- a/docs/conversations-and-agents.md
+++ b/docs/conversations-and-agents.md
@@ -1,8 +1,8 @@
-<!-- Intent: Teach conversation continuity mechanics: continue_from, manual
+<!-- Intent: Teach conversation continuity mechanics: continuation, manual
      history, and tool messages in history. Also cover tool calling setup
-     (defining tools, reading tool_calls, continue_tool). Do NOT include the
-     complete agent loop — that's on its own page. Assumes the reader
-     understands run() and ResultEnvelope. Register: guided applied. -->
+     (defining tools, reading tool_calls, interact). Do NOT include the
+     complete agent loop (which is on its own page). Assumes the reader
+     understands run() and Output. Register: guided applied. -->
 
 # Continuing Conversations Across Turns
 
@@ -23,54 +23,47 @@ next turn.
 
 !!! info "Boundary"
     **Pollux owns:** delivering tool definitions to the provider, surfacing
-    `tool_calls` in the result envelope, carrying conversation state via
-    `continue_from`, and translating history formats across providers.
+    `tool_calls` in the Output model, carrying conversation state via
+    `continuation`, and translating history formats across providers.
 
     **You own:** the loop structure, tool implementations, turn limits,
     error handling per turn, deciding when to stop, and persisting history
     across sessions.
 
-## Continuing a Conversation with `continue_from`
+## Continuing a Conversation with `Continuation`
 
-Pass a prior `ResultEnvelope` back into `Options(continue_from=...)` to
-automatically resume a conversation. Pollux unpacks the initial prompt,
-the assistant's previous response, and any tool calls directly into the
-context payload without requiring manual dictionary manipulation.
+Pass a prior result's `continuation` back into the next `Input(continuation=...)` to automatically resume a conversation. Pollux unpacks the initial prompt, the assistant's previous response, and any tool calls directly into the context payload.
 
-To use `continue_from`, the first turn must opt into conversation tracking
-by passing `history=[]` (an empty list is enough). Without it, Pollux
-treats the call as stateless and does not build conversation state.
+To get a `continuation` for subsequent turns in plain conversational calls, the first turn must opt into conversation tracking by passing `history=[]` (or an empty list/tuple). Without it, Pollux treats the call as stateless and does not build continuation state.
 
 !!! note
-    When tool calling is active, Pollux auto-populates conversation state
-    whenever the model returns `tool_calls` — no explicit `history=[]`
-    needed. The opt-in requirement only applies to plain conversational
-    calls without tools.
+    When tool calling is active, Pollux auto-populates continuation state whenever the model returns `tool_calls`, so no explicit `history=[]` is needed. The opt-in requirement only applies to plain conversational calls without tools.
 
 ```python
 import asyncio
-from pollux import Config, Options, run
+from pollux import Config, Environment, Input, interact
 
 async def chat_loop() -> None:
     config = Config(provider="gemini", model="gemini-2.5-flash-lite")
+    env = Environment()
 
     # Turn 1: opt into conversation tracking with history=[]
     print("User: Hello! Please remember my name is Sean.")
-    result1 = await run(
-        "Hello! Please remember my name is Sean.",
+    result1 = await interact(
+        env,
+        Input(content="Hello! Please remember my name is Sean.", history=[]),
         config=config,
-        options=Options(history=[]),  # Enable conversation state
     )
-    print(f"Assistant: {result1['answers'][0]}")
+    print(f"Assistant: {result1.text}")
 
-    # Turn 2: continue from prior result
+    # Turn 2: continue from prior result's continuation
     print("\nUser: What is my name?")
-    result2 = await run(
-        "What is my name?",
+    result2 = await interact(
+        env,
+        Input(continuation=result1.continuation, content="What is my name?"),
         config=config,
-        options=Options(continue_from=result1),  # Picks up where result1 left off
     )
-    print(f"Assistant: {result2['answers'][0]}")
+    print(f"Assistant: {result2.text}")
 
 asyncio.run(chat_loop())
 ```
@@ -85,25 +78,26 @@ and `content`:
 
 ```python
 import asyncio
-from pollux import Config, Options, run
+from pollux import Config, Environment, Input, Message, interact
 
 async def manual_history_injection() -> None:
     config = Config(provider="openai", model="gpt-5-nano")
+    env = Environment()
 
-    # Imagine this was pulled from a database
+    # Pull from database, wrapped in Message objects
     previous_chat = [
-        {"role": "user", "content": "What is the capital of France?"},
-        {"role": "assistant", "content": "The capital of France is Paris."}
+        Message(role="user", content="What is the capital of France?"),
+        Message(role="assistant", content="The capital of France is Paris.")
     ]
 
-    # Resume the chat by passing history into Options
-    result = await run(
-        "And what is its population?",
+    # Resume the chat by passing history into Input
+    result = await interact(
+        env,
+        Input(content="And what is its population?", history=previous_chat),
         config=config,
-        options=Options(history=previous_chat),
     )
 
-    print(f"Assistant: {result['answers'][0]}")
+    print(f"Assistant: {result.text}")
 
 asyncio.run(manual_history_injection())
 ```
@@ -118,109 +112,93 @@ retrieved it, and now you must return it), `history` is how you manually
 format tool responses:
 
 ```python
+from pollux import Input, Message, ToolCall, interact
+
 history = [
-    {"role": "user", "content": "What's the weather in NYC?"},
-    {"role": "assistant", "content": "", "tool_calls": [...]},
-    # Format your tool response like this:
-    {"role": "tool", "tool_call_id": "call_1", "content": '{"temp_f": 72}'},
+    Message(role="user", content="What's the weather in NYC?"),
+    Message(role="assistant", content="", tool_calls=(
+        ToolCall.from_text(id="call_1", name="get_weather", arguments_text='{"location": "NYC"}'),
+    )),
+    Message(role="tool", tool_call_id="call_1", content='{"temp_f": 72}'),
 ]
 
-result = await run(
-    "Given that weather, what should I wear?",
+result = await interact(
+    env,
+    Input(content="Given that weather, what should I wear?", history=history),
     config=config,
-    options=Options(history=history, tools=[...]),
 )
 ```
 
 ## Setting Up Tool Calling
 
-Pollux passes function tool definitions to providers and surfaces tool call
-responses in the result envelope. `Options.tools` is for Pollux-normalized
-client/application tools that your code executes. Provider-hosted server tools
-such as web search or code execution are provider-specific and belong in
-`Options(provider_options=...)`.
+Pollux passes function tool definitions to providers and surfaces tool call responses in the output. `Environment.tools` is for Pollux-normalized client/application tools that your code executes. Provider-hosted server tools such as web search or code execution are provider-specific and belong in the `provider_options=` keyword argument.
 
-**Defining tools:** pass a list of tool schemas in `Options.tools`:
+**Defining tools:** pass `ToolDeclaration` objects in `Environment.tools`:
 
 ```python
-from pollux import Options
+from pollux import Environment, ToolDeclaration
 
-options = Options(
+env = Environment(
     tools=[
-        {
-            "name": "get_weather",
-            "description": "Get weather for a location",
-            "parameters": {
+        ToolDeclaration(
+            name="get_weather",
+            description="Get weather for a location",
+            parameters={
                 "type": "object",
                 "properties": {"location": {"type": "string"}},
             },
-        }
+        )
     ],
-    tool_choice="auto",  # "auto", "required", "none", or {"name": "..."}
 )
 ```
 
-Pollux normalizes tool parameter schemas at the provider boundary. For OpenAI
-(which defaults to strict mode), `additionalProperties: false` and `required`
-are injected automatically. For Gemini, unsupported fields like
-`additionalProperties` are stripped. You can define one schema and use it
-across all providers without modification.
+Pollux normalizes tool parameter schemas at the provider boundary. For OpenAI (which defaults to strict mode), `additionalProperties: false` and `required` are injected automatically. For Gemini, unsupported fields like `additionalProperties` are stripped. You can define one schema and use it across all providers without modification.
 
-**Reading tool calls:** when the model invokes tools, the result envelope
-includes a `tool_calls` field:
+**Reading tool calls:** when the model invokes tools, the completed `Output` includes a `tool_calls` field:
 
 ```python
-result = await run("What's the weather in NYC?", config=config, options=options)
+result = await interact(env, Input("What's the weather in NYC?"), config=config, tool_choice="auto")
 
-if "tool_calls" in result:
-    for call in result["tool_calls"][0]:  # per-prompt list
-        print(call["name"], call["arguments"])
+if result.tool_calls:
+    for call in result.tool_calls:
+        print(call.name, call.arguments)
 ```
 
-## Feeding Tool Results Back with `continue_tool()`
+## Feeding Tool Results Back with `interact()`
 
-When the model requests tool calls, you execute them in your code and feed the
-results back for the next turn. `continue_tool()` handles this handoff: it
-takes the previous `ResultEnvelope` (which contains the model's tool-call
-requests and conversation state) along with your tool-result messages, and
-returns the model's next response.
+When the model requests tool calls, you execute them in your code and feed the results back for the next turn. `interact()` handles this handoff: it takes the previous `Output`'s `continuation` handle along with your tool results, and returns the model's next response.
 
 ```python
-from pollux import continue_tool
+from pollux import Input, ToolResult, interact
 
 # After executing the tool calls from a previous result...
 tool_results = [
-    {"role": "tool", "tool_call_id": "call_1", "content": '{"temp_f": 72}'},
+    ToolResult(call_id="call_1", content='{"temp_f": 72}'),
 ]
 
-next_result = await continue_tool(
-    continue_from=result,       # The ResultEnvelope containing tool_calls
-    tool_results=tool_results,  # Your tool outputs
+next_result = await interact(
+    env,
+    Input(continuation=result.continuation, tool_results=tool_results),
     config=config,
-    options=Options(tools=tools),
 )
 ```
 
-`continue_tool()` internally reconstructs the conversation history from the
-previous envelope's state, appends your tool results, and calls `run()` to get
-the model's next response. The returned `ResultEnvelope` may contain another
-round of `tool_calls` (if the model needs more data) or a final text answer.
+`interact()` internally reconstructs the conversation history from the previous continuation, appends your tool results, and calls the provider to get the model's next response. The returned `Output` may contain another round of `tool_calls` or a final text answer.
 
 ## What to Watch For
 
-- **`tool_calls` is per-prompt.** `result["tool_calls"]` is a list of
-  lists, one per prompt. For `run()` (single prompt), access
-  `result["tool_calls"][0]`.
-- **Conversation continuity requires one prompt.** Both `history` and
-  `continue_from` work with single-prompt `run()` calls, not `run_many()`.
+- **`tool_calls` is flat on `Output`.** When using `interact()`, `result.tool_calls`
+  is a flat tuple of `ToolCall` objects.
+- **Conversation continuity requires one prompt.** `interact()` takes a single
+  `Input` turn.
 - **Plain conversations need `history=[]` on the first turn.** Without
-  `history` or `continue_from`, Pollux treats a call as stateless and
-  does not produce conversation state. Pass `history=[]` on the first
-  turn to enable `continue_from` on subsequent turns.
-- **Tool-call responses auto-populate conversation state.** When `run()`
-  returns tool calls, Pollux builds conversation state automatically, even
-  without explicit `history` or `continue_from`. This means `continue_tool()`
-  works on any result that contains tool calls — no opt-in needed.
+  `history` or `continuation`, Pollux treats a call as stateless and
+  does not produce continuation state. Pass `history=[]` on the first
+  turn to enable `continuation` on subsequent turns.
+- **Tool-call responses auto-populate continuation.** When a call returns
+  tool calls, Pollux builds the `continuation` state automatically, even
+  without explicit `history=[]`. This means continuation works for the next
+  turn of any tool call, with no opt-in needed.
 - **Provider differences exist.** Gemini, OpenAI, and Anthropic support tool
   calling and tool messages in history. OpenRouter supports them on models
   that advertise tool support. See

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -2,7 +2,7 @@
      hierarchy, failure triage, production error patterns (category-specific
      catching, circuit breakers, partial failures, resume-on-failure). Do NOT
      re-explain tool calling or conversation mechanics. Assumes the reader has
-     used run() and understands Config/Options. Register: reference + guided
+     used run() and understands Config. Register: reference + guided
      applied (patterns). -->
 
 # Handling Errors and Recovery
@@ -50,7 +50,7 @@ strings.
 
 !!! info "Boundary"
     **Pollux owns:** retrying transient API failures (rate limits, server
-    errors) within a single `run()` or `run_many()` call, respecting
+    errors) within a single `run()`, `run_many()`, or `interact()` call, respecting
     `Retry-After` headers, and raising typed exceptions with `.hint`.
 
     **You own:** workflow-level retry decisions (should I retry this file?),
@@ -153,17 +153,17 @@ async def safe_analyze(path: Path, prompt: str) -> str | None:
             source=Source.from_file(str(path)),
             config=config,
         )
-        if result["status"] == "partial":
-            log.warning("%s: partial result (some answers empty)", path.name)
-        return result["answers"][0]
+        if result.metrics.completion_status != "clean":
+            log.warning("%s: incomplete result (status: %s)", path.name, result.metrics.completion_status)
+        return result.text
 
     except ConfigurationError as exc:
-        # Bad config — nothing to retry, abort early
+        # Bad config: nothing to retry, abort early
         log.error("Configuration error: %s (hint: %s)", exc, exc.hint)
         raise  # Let the caller abort the pipeline
 
     except SourceError as exc:
-        # Bad input file — skip it, process the rest
+        # Bad input file: skip it, process the rest
         log.warning("Skipping %s: %s (hint: %s)", path.name, exc, exc.hint)
         return None
 
@@ -175,7 +175,7 @@ async def safe_analyze(path: Path, prompt: str) -> str | None:
         return None
 
     except APIError as exc:
-        # Other provider errors — log details for diagnosis
+        # Other provider errors: log details for diagnosis
         log.error(
             "API error on %s: %s [status=%s, retryable=%s] (hint: %s)",
             path.name, exc, exc.status_code, exc.retryable, exc.hint,
@@ -234,7 +234,7 @@ asyncio.run(process_collection("./papers", "Summarize the key findings."))
 | `ConfigurationError` at startup | Missing API key | `export GEMINI_API_KEY="your-key"` (or `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY`) or pass `api_key` in `Config(...)` |
 | Outputs look like `echo: ...` | `use_mock=True` is set | Set `use_mock=False` (default) and ensure the API key is present |
 | `ConfigurationError` at request time | Provider/model mismatch | Verify the model belongs to the selected provider |
-| `status: "partial"` | Some prompts returned empty answers | Check individual entries in `answers` to identify which prompts failed |
+| `status: "partial"` | Some prompts returned empty answers | Check individual entries in `collection.answers` to identify which prompts failed |
 | Remote source rejected | Unsupported MIME type on OpenAI | OpenAI remote URL support is limited to PDFs and images |
 | Keys show as `***redacted***` | Intentional redaction | Your key is still being used. `Config` hides it from string representations |
 | `APIError: Cannot reach local server` | Local server not running, or wrong `base_url` | Start the server and confirm its URL; check `POLLUX_LOCAL_BASE_URL` and the `/v1` suffix |
@@ -319,18 +319,18 @@ but the output is incomplete:
 ```python
 result = await run_many(prompts, sources=sources, config=config)
 
-if result["status"] == "ok":
-    # All answers populated — process normally
+if result.status == "ok":
+    # All answers populated: process normally
     pass
-elif result["status"] == "partial":
-    # Some answers are empty strings — decide per-answer
-    for i, answer in enumerate(result["answers"]):
+elif result.status == "partial":
+    # Some answers are empty strings: decide per-answer
+    for i, answer in enumerate(result.answers):
         if answer:
             process_answer(i, answer)
         else:
             log.warning("Empty answer for prompt %d", i)
-elif result["status"] == "error":
-    # All answers empty — treat as a failure
+elif result.status == "error":
+    # All answers empty: treat as a failure
     log.error("All answers empty")
 ```
 
@@ -371,7 +371,7 @@ python -m cookbook production/resume-on-failure \
 - **`RateLimitError` means retries were exhausted.** Pollux already waited
   and retried. If you still get `RateLimitError`, reduce concurrency or add
   a longer backoff at the workflow level.
-- **Check `result["status"]` even on success.** A successful call can return
+- **Check `result.status` or `completion_status` even on success.** A successful call can return
   `"partial"` status with some empty answers. Don't assume all answers are
   populated because no exception was raised.
 - **Don't catch `Exception` when you mean `PolluxError`.** Catching too

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,8 +70,7 @@ async def main() -> None:
         ),
         config=config,
     )
-    print(result["status"])
-    print(result["answers"][0])
+    print(result.text)
 
 asyncio.run(main())
 ```
@@ -88,20 +87,19 @@ use `Config(provider="openrouter", model="google/gemma-3-27b-it:free")`.
 ## 4. See the Output
 
 ```
-ok
 The key points are: (1) Pollux supports three execution patterns (fan-out,
 fan-in, and broadcast); (2) it provides context caching to avoid
 re-uploading the same content for repeated prompts.
 ```
 
-That's your first Pollux result. The `status` is `ok` and the answer
+That's your first Pollux result. The `result.text` contains the answer and
 references details from the source text. When this works, swap to your real
 input: `Source.from_file("document.pdf")`.
 
 !!! info "What happened?"
     **Pollux owned:** normalizing your prompt and source into a request,
     planning the API call, executing it, and extracting the answer into a
-    standard [ResultEnvelope](sending-content.md#resultenvelope-reference).
+    standard [Output](sending-content.md#output-and-outputcollection-reference).
 
     **You owned:** writing the prompt, choosing what to analyze, and deciding
     what to do with the result.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ content. No boilerplate.
 management saves tokens and money.
 
 **Deferred delivery.** Submit non-urgent work once, persist a handle, and
-collect later in the same `ResultEnvelope` format.
+collect later in the same `OutputCollection` / `Output` format.
 
 **Built for reliability.** Async pipeline, retries with backoff, structured
 output, usage tracking.

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -86,7 +86,7 @@ result = await run(
         model="gemini-2.5-flash-lite",
     ),
 )
-print(result["answers"][0])</code></pre>
+print(result.text)</code></pre>
     </div>
   </div>
 </section>

--- a/docs/portable-code.md
+++ b/docs/portable-code.md
@@ -2,7 +2,7 @@
      from pipeline logic, graceful degradation, model tier mapping, and testing
      with mock mode. Cover model-specific constraints (GPT-5 sampling, Gemini
      reasoning). Do NOT re-explain tool calling or conversation mechanics.
-     Assumes the reader has used run() and understands Config/Options.
+     Assumes the reader has used run() and understands Config.
      Register: guided applied (architectural patterns). -->
 
 # Writing Portable Code Across Providers
@@ -13,8 +13,8 @@ This page shows the patterns that make that work.
 
 Pollux is capability-transparent, not capability-equalizing. All providers
 support the core text pipeline, but some features are provider-specific. For
-example, Gemini uses explicit caching (`create_cache()`), Anthropic uses
-implicit caching (`Options(implicit_caching=True)`), and OpenRouter exposes
+example, Gemini uses persistent caching (`CachePolicy`), Anthropic uses
+implicit caching (`Environment(cache="auto")`), and OpenRouter exposes
 tool calling and structured outputs only on models that advertise those
 features.
 When you use an unsupported feature for a provider, Pollux raises a
@@ -22,9 +22,9 @@ When you use an unsupported feature for a provider, Pollux raises a
 This keeps behavior legible in both development and production.
 
 !!! info "Boundary"
-    **Pollux owns:** translating your `Config`, `Options`, `Source`, and
+    **Pollux owns:** translating your `Config`, `Environment`, `Input`, and
     prompts into provider-specific API calls, and normalizing responses
-    into a stable `ResultEnvelope`.
+    into stable `Output` / `OutputCollection` models.
 
     **You own:** choosing which features to use (sticking to the portable
     subset or gracefully degrading), selecting provider-appropriate models,
@@ -46,7 +46,7 @@ from dataclasses import dataclass
 
 from pydantic import BaseModel
 
-from pollux import APIError, Config, ConfigurationError, Options, Source, run
+from pollux import APIError, Config, ConfigurationError, Source, run
 
 
 class DocumentSummary(BaseModel):
@@ -83,17 +83,16 @@ async def analyze_document(
     *,
     provider_name: str = "gemini",
 ) -> DocumentSummary:
-    """Analyze a document — works with any supported provider."""
+    """Analyze a document. This function works with any supported provider."""
     config = make_config(provider_name)
-    options = Options(response_schema=DocumentSummary)
 
     result = await run(
         prompt,
         source=Source.from_file(file_path),
         config=config,
-        options=options,
+        output=DocumentSummary,
     )
-    return result["structured"][0]
+    return result.structured
 
 
 async def main() -> None:
@@ -119,8 +118,8 @@ asyncio.run(main())
    its model. Your analysis functions never reference provider names or
    models directly.
 
-2. **Handle features conditionally.** Explicit caching (`create_cache()`) is
-   Gemini-specific, while implicit caching (`implicit_caching=True`) is
+2. **Handle features conditionally.** Persistent caching (`prepare_environment()`) is
+   Gemini-specific, while implicit caching is
    Anthropic-specific. Some providers also cache repeated prefixes
    automatically. Gate these conditional optimizations on the provider name
    or handle them near the call site; see
@@ -152,10 +151,10 @@ models (like `gpt-4.1-nano`) still accept them.
 
 ```python
 # This will fail with an APIError for gpt-5 family models
-options = Options(temperature=0.8, top_p=0.9)
+result = await run(prompt, config=config, temperature=0.8, top_p=0.9)
 
 # Instead, use the default behavior or rely on reasoning_effort
-options = Options(reasoning_effort="medium")
+result = await run(prompt, config=config, reasoning_effort="medium")
 ```
 
 ### Choosing a Reasoning Control
@@ -176,20 +175,18 @@ it, but model-specific acceptance and minimums remain provider-defined.
 result = await run(
     "Solve this step by step...",
     config=Config(provider="gemini", model="gemini-3-flash-preview"),
-    options=Options(reasoning_effort="high"),
+    reasoning_effort="high",
 )
 
 # Use an explicit budget on a provider that accepts token-based reasoning.
 result = await run(
     "Think briefly, then answer.",
     config=Config(provider="anthropic", model="claude-haiku-4-5"),
-    options=Options(reasoning_budget_tokens=2048),
+    reasoning_budget_tokens=2048,
 )
 
-if "reasoning" in result:
-    for text in result["reasoning"]:
-        if text:
-            print("Thinking:", text)
+if result.reasoning:
+    print("Thinking:", result.reasoning)
 ```
 
 Exact budget floors are provider-defined. Pollux validates the shape
@@ -242,21 +239,18 @@ async def analyze_with_reasoning(
             prompt,
             source=Source.from_file(file_path),
             config=config,
-            options=Options(reasoning_effort="high"),
+            reasoning_effort="high",
         )
-        reasoning = None
-        if "reasoning" in result and result["reasoning"][0]:
-            reasoning = result["reasoning"][0]
-        return result["answers"][0], reasoning
+        return result.text, result.reasoning
 
     except (ConfigurationError, APIError):
-        # Provider or model doesn't support this reasoning mode — retry without it
+        # Provider or model doesn't support this reasoning mode; retry without it
         result = await run(
             prompt,
             source=Source.from_file(file_path),
             config=config,
         )
-        return result["answers"][0], None
+        return result.text, None
 ```
 
 ### Running against a self-hosted model
@@ -305,8 +299,8 @@ async def test_analyze_document_mock(provider: str) -> None:
         source=Source.from_text("Test content."),
         config=config,
     )
-    assert result["status"] == "ok"
-    assert len(result["answers"]) == 1
+    assert result.metrics.completion_status == "clean"
+    assert result.text
 ```
 
 ## What to Watch For

--- a/docs/reference/provider-capabilities.md
+++ b/docs/reference/provider-capabilities.md
@@ -29,7 +29,7 @@ before dispatch or the provider page below calls out why it is out of scope.
 |---|---|---|---|---|---|---|
 | Text generation | ✅ | ✅ | ✅ | ✅ | ✅ | Core feature |
 | Multi-prompt execution (`run_many`) | ✅ | ✅ | ✅ | ✅ | ✅ | One call per prompt, shared context |
-| Structured outputs (`response_schema`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (JSON schema mode) | Local sends `json_schema`; schema enforcement quality varies by server |
+| Structured outputs (`output` schema) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (JSON schema mode) | Local sends `json_schema`; schema enforcement quality varies by server |
 | Deferred delivery (`defer`, `inspect_deferred`, `collect_deferred`, `cancel_deferred`) | ✅ | ✅ | ✅ | ❌ | ❌ | Use the deferred API directly |
 
 ### Inputs
@@ -54,14 +54,14 @@ before dispatch or the provider page below calls out why it is out of scope.
 
 | Capability | Gemini | OpenAI | Anthropic | OpenRouter | Local | Notes |
 |---|---|---|---|---|---|---|
-| Reasoning output (`result["reasoning"]`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ⚠️ server/model-dependent | Pollux surfaces reasoning text when providers return it |
+| Reasoning output (`result.reasoning`) | ✅ | ✅ | ✅ | ⚠️ model-dependent | ⚠️ server/model-dependent | Pollux surfaces reasoning text when providers return it |
 | `reasoning_effort` | ✅ | ✅ | ✅ | ⚠️ model-dependent | ❌ | Qualitative level (`"low"`, `"medium"`, `"high"`, etc.); exact model support remains provider-defined |
 | `reasoning_budget_tokens` | ✅ | ❌ | ✅ | ❌ | ❌ | Explicit token ceiling; mutually exclusive with `reasoning_effort` |
 | Function tool calling | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Pollux-normalized client/application tools; local trusts the server, no capability probe |
 | Provider-hosted tools | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ via `provider_options` | ⚠️ server-dependent | Raw provider escape hatch; not normalized by Pollux |
 | Tool message pass-through in history | ✅ | ✅ | ✅ | ⚠️ model-dependent | ✅ (server-dependent) | Local replays assistant tool calls and `tool`-role results verbatim |
 | Streaming (`stream()` → `Event`) | ✅ | ✅ | ✅ | ✅ | ✅ | Streamed `done.output` matches the non-streaming `Output` |
-| Conversation continuity (`history`, `continue_from`) | ✅ | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
+| Conversation continuity (`history`, `continuation`) | ✅ | ✅ | ✅ | ✅ | ✅ | Single prompt per call |
 
 For when deferred delivery is a fit and how to structure code around provider
 jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.md).
@@ -87,7 +87,7 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   carried entirely via `history`.
 - Tool parameter schemas are normalized at the provider boundary:
   `additionalProperties` is stripped because the Gemini API rejects it.
-- Reasoning: Gemini returns full thinking text in `ResultEnvelope.reasoning`
+- Reasoning: Gemini returns full thinking text in `output.reasoning`
   when the selected model and reasoning mode support it. Pollux forwards both
   `reasoning_effort` and `reasoning_budget_tokens`; model-specific acceptance
   is enforced by the Gemini API.
@@ -114,8 +114,8 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   false` and `required` are injected automatically. Callers who set `strict:
   false` on a tool definition bypass normalization.
 - Reasoning: OpenAI provides reasoning summaries (not raw traces) in
-  `ResultEnvelope.reasoning`. Token counts appear in
-  `ResultEnvelope.usage["reasoning_tokens"]` when the model returns them.
+  `output.reasoning`. Token counts appear in
+  `output.usage.reasoning_tokens` when the model returns them.
   Some older models reject `reasoning_effort`. OpenAI does not accept
   `reasoning_budget_tokens`; Pollux raises `ConfigurationError` before the
   request is dispatched.
@@ -133,7 +133,7 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   `Environment` to opt out.
 - See [current caching scope](../caching.md#current-pollux-scope) for what
   Pollux exposes from Anthropic's caching surface.
-- Reasoning: thinking text appears in `ResultEnvelope.reasoning`.
+- Reasoning: thinking text appears in `output.reasoning`.
   `reasoning_effort` and `reasoning_budget_tokens` are both forwarded for
   Anthropic models that support them. Exact model support and budget floors
   are enforced by Anthropic. Pollux routes current Opus adaptive-thinking
@@ -144,7 +144,7 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   holds for `stream()` too: signed thinking blocks are reassembled from the
   stream, so a streamed extended-thinking + tool turn continues identically to
   the non-streaming path.
-- `Options.max_tokens`: limits the output length. Default is `16384` for Anthropic,
+- `max_tokens`: limits the output length. Default is `16384` for Anthropic,
   which leaves room for thinking output at all effort levels. Other providers
   currently ignore this option.
 
@@ -157,9 +157,9 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
   continuity, model-gated structured outputs, model-gated tool calling, and
   verified image/PDF inputs.
 - Pollux does not expose OpenRouter routing controls in the public API.
-- `continue_from` works through Pollux conversation state replay; there is no
+- `continuation` works through Pollux conversation state replay; there is no
   OpenRouter-specific equivalent to OpenAI's `previous_response_id`.
-- `continue_tool()` works through the same replay path. Pollux carries prior
+- `interact()` and `stream()` work through the same replay path. Pollux carries prior
   assistant tool calls and tool-result messages forward through history when
   the selected OpenRouter model supports tool calling.
 - Structured outputs and tool calling are model-dependent on OpenRouter.
@@ -189,8 +189,8 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - OpenRouter supports automatic prompt caching on many routed providers.
   Pollux does not expose OpenRouter-specific cache controls.
 - Reasoning: works on OpenRouter models that support reasoning. Thinking text
-  appears in `ResultEnvelope.reasoning`, and token counts in
-  `ResultEnvelope.usage["reasoning_tokens"]` when available. OpenRouter does
+  appears in `output.reasoning`, and token counts in
+  `output.usage.reasoning_tokens` when available. OpenRouter does
   not accept `reasoning_budget_tokens`; Pollux raises `ConfigurationError`
   before dispatch. Under `stream()`, reasoning text is surfaced for display but
   the `reasoning_details` replay state is not reconstructed from the stream
@@ -220,10 +220,10 @@ jobs, see [Building With Deferred Delivery](../building-with-deferred-delivery.m
 - Structured outputs use OpenAI-compatible JSON schema mode
   (`response_format={"type": "json_schema", ...}`). Server-side schema
   enforcement quality varies. Pydantic schema inputs are validated downstream
-  when building `ResultEnvelope.structured`; raw JSON Schema dicts rely on the
+  when building `output.structured`; raw JSON Schema dicts rely on the
   local server's schema enforcement. When a server returns non-JSON text, or a
   Pydantic response fails model validation, the corresponding entry in
-  `ResultEnvelope.structured` is `None`.
+  `output.structured` is `None`.
 - Automatic prompt caching depends entirely on the backing inference engine.
   Pollux does not expose a toggle for it.
 - Conversation continuity uses `history`; there is no server-side session ID

--- a/docs/sending-content.md
+++ b/docs/sending-content.md
@@ -1,5 +1,5 @@
 <!-- Intent: Teach the three core mechanics: creating Sources, calling run()
-     and run_many(), and reading ResultEnvelope. Do NOT cover source patterns
+     and run_many(), and reading Output / OutputCollection. Do NOT cover source patterns
      in depth (that's the next page), tool calling, or conversation history.
      Assumes the reader has completed Getting Started. Register: guided applied. -->
 
@@ -12,7 +12,7 @@ a `Source`, which entry point to call, and how to read the result.
 !!! info "Boundary"
     **Pollux owns:** uploading and caching source content, attaching it to
     provider API calls, running prompts concurrently, and normalizing
-    responses into a stable `ResultEnvelope`.
+    responses into stable `Output` / `OutputCollection` models.
 
     **You own:** choosing what to analyze, writing prompts, and processing
     the returned answers.
@@ -78,9 +78,9 @@ source = Source.from_uri(
 ```
 
 Use this only when you have chosen Gemini. URL Context retrieval metadata is
-available in `result["diagnostics"]["raw_responses"][i]["artifacts"]`. Because
+available in `result.diagnostics.raw["raw_responses"][i]["artifacts"]`. Because
 retrieval happens at request time, URL Context sources cannot be baked into
-`create_cache()`.
+`prepare_environment()`.
 
 ### Gemini Video Controls
 
@@ -110,7 +110,7 @@ async def main() -> None:
         source=source,
         config=config,
     )
-    print(result["answers"][0])
+    print(result.text)
 
 asyncio.run(main())
 ```
@@ -142,8 +142,7 @@ async def main() -> None:
         source=Source.from_file("paper.pdf"),
         config=config,
     )
-    print(result["status"])   # "ok"
-    print(result["answers"][0])
+    print(result.text)
 
 asyncio.run(main())
 ```
@@ -151,7 +150,6 @@ asyncio.run(main())
 Output:
 
 ```
-ok
 The paper concludes that context caching reduces repeated token cost by up to
 90% for fan-out workloads, with diminishing returns below 3 prompts per source.
 ```
@@ -168,8 +166,9 @@ The paper concludes that context caching reduces repeated token cost by up to
 3. **Call `run()`.** Pass the prompt, source, and config. Pollux normalizes the
    request, plans the API call, executes it, and extracts the answer.
 
-4. **Read `result["answers"]`.** The first (and only) element contains the
-   model's response. Check `result["status"]` to confirm the call succeeded.
+4. **Read `result.text`.** The `text` property contains the
+   model's response. You can also inspect `result.metrics.completion_status`
+   to confirm the call succeeded cleanly.
 
 ## Multiple Prompts: `run_many()`
 
@@ -194,9 +193,9 @@ async def main() -> None:
         "List key findings.",
     ]
 
-    envelope = await run_many(prompts, sources=sources, config=config)
-    print(envelope["status"])
-    for i, answer in enumerate(envelope["answers"], 1):
+    collection = await run_many(prompts, sources=sources, config=config)
+    print(collection.status)
+    for i, answer in enumerate(collection.answers, 1):
         print(f"Q{i}: {answer[:80]}...")
 
 asyncio.run(main())
@@ -220,59 +219,65 @@ Q2: Key findings: (1) fan-out caching saves 85-92% of input tokens; (2) broad...
 | Many questions against the same shared source set | `run_many()` | Fan-out over a combined context |
 | Many questions per file in a collection | Outer loop + `run_many()` | Broadcast pattern; see [Source Patterns](source-patterns.md) |
 | Non-urgent work you will collect later | `defer()` | Background provider execution with a serializable handle |
-| Returning tool results to the model | `continue_tool()` | Feeds tool outputs back into the conversation |
+| Returning tool results to the model | `interact()` / `stream()` | Feeds tool outputs back into the conversation |
 
 Rule of thumb: if prompts or sources are plural and every prompt should receive
 the same shared context, reach for `run_many()`. If you need one result record
 per file, write the outer file loop yourself and call `run_many()` inside it.
 If the workload can wait, reach for `defer()`.
 
-`continue_tool()` is a specialized entry point for agent loops. It takes a
-previous `ResultEnvelope` containing tool calls and your tool results, and
-returns the model's next response. See
-[Feeding Tool Results Back with `continue_tool()`](conversations-and-agents.md#feeding-tool-results-back-with-continue_tool)
+`interact()` (and its streaming sibling `stream()`) is the canonical entry point
+for multi-turn conversations and tool-calling loops. It takes an `Environment`
+(defining instructions, tools, etc.) and an `Input` turn (carrying prompts,
+tool results, and continuation state). See
+[Feeding Tool Results Back with `interact()`](conversations-and-agents.md#feeding-tool-results-back-with-interact)
 for details.
 
 `run()` is a convenience wrapper that delegates to `run_many()` with a single
 prompt. In benchmarks, `run_many()` is typically faster for multi-prompt
 workloads because it shares uploads and runs prompts concurrently.
 
-## ResultEnvelope Reference
+## Output and OutputCollection Reference
 
-Every `run()`, `run_many()`, and `collect_deferred()` call returns a
-`ResultEnvelope`: a dict with a stable shape that works the same regardless of
-provider.
+Execution functions return either an `Output` object (for single interactions like `run()` and `interact()`) or an `OutputCollection` (for multi-prompt execution like `run_many()` or deferred collection).
 
-| Field | Type | Always present | Description |
-|---|---|---|---|
-| `status` | `"ok" \| "partial" \| "error"` | Yes | `ok` = all answers populated; `partial` = some empty; `error` = all empty |
-| `answers` | `list[str]` | Yes | One string per prompt |
-| `structured` | `list[Any]` | Only with `response_schema` | Parsed objects matching your schema |
-| `reasoning` | `list[str \| None]` | No | Provider reasoning traces (when available) |
-| `tool_calls` | `list[list[dict]]` | Only with tool calling | Per-prompt list of tool-call requests. See [Conversations](conversations-and-agents.md) |
-| `confidence` | `float` | Yes | Heuristic: `0.9` for ok, `0.5` otherwise |
-| `extraction_method` | `str` | Yes | Always `"text"` |
-| `usage` | `dict[str, int]` | Yes | Token counts (`input_tokens`, `output_tokens`, `total_tokens`, and optional `reasoning_tokens`, `cached_tokens`). See [Observing Cache Hits](caching.md#observing-cache-hits) for `cached_tokens` semantics. |
-| `metrics` | `dict[str, Any]` | Yes | `duration_s`, `n_calls`, `cache_used` ([persistent caching](caching.md#persistent-caching-gemini) only), `finish_reasons` (per-prompt, e.g. `"stop"`, `"max_tokens"`). Deferred results also add `metrics["deferred"] = True`. |
-| `diagnostics` | `dict[str, Any]` | Yes | Low-level diagnostics. All calls include `raw_responses`. Deferred results also add `diagnostics["deferred"]` with `job_id`, timing, and per-request lifecycle items. |
+### Output Fields (Single Interaction)
 
-Example of a complete envelope:
+An `Output` is a frozen dataclass with the following attributes:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `text` | `str` | The primary text response from the model |
+| `structured` | `Any` | The parsed Pydantic model or JSON dict (when `output` schema is set) |
+| `reasoning` | `str \| None` | Model reasoning/thinking text when supported and returned by the provider |
+| `tool_calls` | `tuple[ToolCall, ...]` | Tuple of `ToolCall` requests emitted by the model |
+| `continuation` | `Continuation \| None` | State handle to continue the interaction in a subsequent turn |
+| `usage` | `Usage` | Token usage details (`input_tokens`, `output_tokens`, `total_tokens`, `reasoning_tokens`, `cached_tokens`) |
+| `metrics` | `Metrics` | Execution metadata (`duration_s`, `n_calls`, `cache_used`, `cache_mode`, `cache_hit`, `finish_reason`, `completion_status`) |
+| `diagnostics` | `Diagnostics` | Low-level debug detail (e.g. `raw_responses` lists) |
+
+### OutputCollection Fields (Multi-Prompt / Deferred Result)
+
+An `OutputCollection` aggregates results from multi-prompt source-pattern executions:
+
+| Attribute/Property | Type | Description |
+|---|---|---|
+| `outputs` | `tuple[Output, ...]` | Individual `Output` objects in submission order |
+| `answers` | `list[str]` | Property helper returning a list of primary text responses |
+| `structured` | `list[Any]` | Property helper returning a list of parsed structured payloads |
+| `status` | `"ok" \| "partial" \| "error"` | Aggregate status based on whether all, some, or no answers were returned |
+| `usage` | `Usage` | Token usage summed across all interactions in the collection |
+
+Example of serializing a completed result to JSON:
 
 ```python
-{
-    "status": "ok",
-    "answers": ["The paper concludes that..."],
-    "confidence": 0.9,
-    "extraction_method": "text",
-    "usage": {"input_tokens": 1250, "output_tokens": 89, "total_tokens": 1339},
-    "metrics": {"duration_s": 1.42, "n_calls": 1, "cache_used": False, "finish_reasons": ["stop"]},
-    "diagnostics": {"raw_responses": [...]},
-}
+# Output and OutputCollection objects serialize via .to_jsonable()
+print(result.to_jsonable())
 ```
 
 ## Notes
 
-- Conversation continuity (`history`, `continue_from`) works with one
+- Conversation continuity (`history`, `continuation`) works with one
   prompt per call. See
   [Continuing Conversations Across Turns](conversations-and-agents.md).
 - Deferred work uses `defer()`, `inspect_deferred()`,

--- a/docs/source-patterns.md
+++ b/docs/source-patterns.md
@@ -1,7 +1,7 @@
 <!-- Intent: Teach collection-level analysis workflows using source patterns
      (fan-out, fan-in, broadcast). Show the two-level loop pattern (your outer
      loop + Pollux's inner call). Do NOT cover structured output, tool calling,
-     or caching mechanics — link to those pages. Assumes the reader understands
+     or caching mechanics. Link to those pages. Assumes the reader understands
      run() and run_many() from Sending Content. Register: guided applied. -->
 
 # Analyzing Collections with Source Patterns
@@ -67,7 +67,7 @@ results into a summary dictionary:
 import asyncio
 from pathlib import Path
 
-from pollux import Config, Options, Source, run_many
+from pollux import Config, Source, run_many
 
 config = Config(provider="gemini", model="gemini-2.5-flash-lite")
 
@@ -87,10 +87,10 @@ async def analyze_file(path: Path) -> dict:
     )
     return {
         "file": path.name,
-        "status": result["status"],
-        "main_argument": result["answers"][0],
-        "key_findings": result["answers"][1],
-        "tokens": result["usage"]["total_tokens"],
+        "status": result.status,
+        "main_argument": result.answers[0],
+        "key_findings": result.answers[1],
+        "tokens": result.usage.total_tokens,
     }
 
 
@@ -110,7 +110,7 @@ async def process_directory(directory: str) -> list[dict]:
             results.append(summary)
             print(f"  {path.name}: {summary['status']} ({summary['tokens']} tokens)")
         except Exception as exc:
-            print(f"  {path.name}: FAILED — {exc}")
+            print(f"  {path.name}: FAILED: {exc}")
             results.append({"file": path.name, "status": "error", "error": str(exc)})
 
     succeeded = sum(1 for r in results if r["status"] == "ok")
@@ -159,7 +159,7 @@ async def synthesize_collection(directory: str, question: str) -> str:
         sources=sources,
         config=config,
     )
-    return result["answers"][0]
+    return result.answers[0]
 ```
 
 This sends all sources to the model in one call. Useful for comparative
@@ -167,7 +167,7 @@ questions: "Which paper has the strongest methodology?" or "What themes
 appear across all documents?"
 
 For structured comparisons with typed output (similarities, differences,
-strengths), combine fan-in with a `response_schema`. See
+strengths), combine fan-in with an `output` schema. See
 [Extracting Structured Data](structured-data.md).
 
 ## Concurrent File Processing
@@ -237,8 +237,8 @@ async def process_to_jsonl(directory: str, output: str) -> None:
 - **Memory with large collections.** Each `Source.from_file()` reads the
   file for hashing. For very large collections, process in batches rather
   than loading all sources at once.
-- **Caching helps fan-out, not iteration.** `create_cache()` saves
-  tokens when the *same source* gets reused across multiple prompts. It
+- **Caching helps fan-out, not iteration.** `prepare_environment()` with a `CachePolicy`
+  saves tokens when the *same source* gets reused across multiple prompts. It
   does not help when each file is different. See
   [Reducing Costs with Context Caching](caching.md).
 

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -1,7 +1,7 @@
-<!-- Intent: Teach structured output extraction via response_schema. Cover
+<!-- Intent: Teach structured output extraction via the output argument. Cover
      Pydantic models, JSON schema dicts, nested models, and combining with
      reasoning. Do NOT cover tool calling, conversation history, or caching.
-     Assumes the reader understands run() and ResultEnvelope from Sending
+     Assumes the reader understands run() and Output from Sending
      Content. Register: guided applied. -->
 
 # Extracting Structured Data
@@ -19,21 +19,21 @@ regex extraction.
 !!! info "Boundary"
     **Pollux owns:** translating your schema to the provider's structured
     output format, parsing the response into typed objects, and populating
-    `result["structured"]`.
+    `result.structured`.
 
     **You own:** defining Pydantic models (or JSON schema dicts), building
     the extraction pipeline, validating domain constraints beyond what the
     schema expresses, and writing results to storage.
 
-## The `response_schema` Option
+## The output Argument
 
-Pass a Pydantic model (or JSON schema dict) via `Options(response_schema=...)`
-to get typed, validated output in `envelope["structured"]`.
+Pass a Pydantic model (or JSON schema dict) via the `output=` keyword argument
+to get typed, validated output in `result.structured`.
 
 ```python
 import asyncio
 from pydantic import BaseModel
-from pollux import Config, Options, Source, run
+from pollux import Config, Source, run
 
 class PaperSummary(BaseModel):
     title: str
@@ -41,22 +41,21 @@ class PaperSummary(BaseModel):
 
 async def main() -> None:
     config = Config(provider="openai", model="gpt-5-nano")
-    options = Options(response_schema=PaperSummary)
     result = await run(
         "Extract a structured summary.",
         source=Source.from_text("Title: Caching Study. Findings: tokens saved, latency reduced."),
         config=config,
-        options=options,
+        output=PaperSummary,
     )
-    summary = result["structured"][0]
+    summary = result.structured
     print(summary.title)       # "Caching Study"
     print(summary.findings)    # ["tokens saved", "latency reduced"]
 
 asyncio.run(main())
 ```
 
-When `response_schema` is set, the `structured` field contains one parsed
-object per prompt. The raw text is still available in `answers`.
+When `output` is set on `run()`, the `structured` property contains the parsed
+object. The raw text is still available in `text`.
 
 ## Complete Extraction Pipeline
 
@@ -71,7 +70,7 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
-from pollux import Config, Options, Source, run
+from pollux import Config, Source, run
 
 
 class PaperMetadata(BaseModel):
@@ -84,9 +83,6 @@ class PaperMetadata(BaseModel):
 
 
 config = Config(provider="gemini", model="gemini-2.5-flash-lite")
-options = Options(response_schema=PaperMetadata)
-
-
 async def extract_metadata(path: Path) -> PaperMetadata:
     """Extract structured metadata from a single paper."""
     result = await run(
@@ -95,9 +91,9 @@ async def extract_metadata(path: Path) -> PaperMetadata:
         "methodology used.",
         source=Source.from_file(str(path)),
         config=config,
-        options=options,
+        output=PaperMetadata,
     )
-    return result["structured"][0]
+    return result.structured
 
 
 async def build_catalog(directory: str, output: str) -> None:
@@ -111,7 +107,7 @@ async def build_catalog(directory: str, output: str) -> None:
                 f.write(metadata.model_dump_json() + "\n")
                 print(f"  {path.name}: {metadata.title} ({metadata.year})")
             except Exception as exc:
-                print(f"  {path.name}: FAILED — {exc}")
+                print(f"  {path.name}: FAILED: {exc}")
 
     print(f"\nWrote catalog to {output}")
 
@@ -125,13 +121,14 @@ asyncio.run(build_catalog("./papers", "catalog.jsonl"))
    and types you expect. The model constrains both the LLM's output format
    and your downstream code's type expectations.
 
-2. **Pass the schema via `Options`.** `Options(response_schema=PaperMetadata)`
+2. **Pass the schema via `output`.** `output=PaperMetadata`
    tells Pollux to request structured output from the provider. Pollux
    handles the translation to provider-specific schema formats.
 
-3. **Read from `result["structured"]`.** When `response_schema` is set,
-   `result["structured"]` contains one parsed object per prompt. For
-   `run()` (single prompt), access `result["structured"][0]`.
+3. **Read from `result.structured`.** When `output` is set on `run()`,
+   `result.structured` contains the parsed Pydantic object. For
+   `run_many()`, `collection.structured` contains a list of parsed objects
+   (one per prompt) in input order.
 
 4. **Serialize to storage.** Pydantic models serialize cleanly to JSON via
    `model_dump_json()`. Write one object per line for JSONL, or use
@@ -156,11 +153,10 @@ schema = {
     "required": ["title", "topics"],
 }
 
-options = Options(response_schema=schema)
-result = await run(prompt, source=source, config=config, options=options)
+result = await run(prompt, source=source, config=config, output=schema)
 
-# result["structured"][0] is a dict (no Pydantic model to parse into)
-print(result["structured"][0]["title"])
+# result.structured is a dict (no Pydantic model to parse into)
+print(result.structured["title"])
 ```
 
 ## Nested Models
@@ -190,20 +186,21 @@ enforces. The response is parsed back into the full nested structure.
 
 ## Structured Output with Reasoning
 
-Combine `response_schema` with `reasoning_effort` to get both structured
+Combine `output` schema with `reasoning_effort` to get both structured
 data and the model's reasoning trace:
 
 ```python
-options = Options(
-    response_schema=PaperMetadata,
+result = await run(
+    prompt,
+    source=source,
+    config=config,
+    output=PaperMetadata,
     reasoning_effort="high",
 )
 
-result = await run(prompt, source=source, config=config, options=options)
-
-metadata = result["structured"][0]       # Typed extraction
-if "reasoning" in result and result["reasoning"][0]:
-    print("Reasoning:", result["reasoning"][0][:200])  # Model's thought process
+metadata = result.structured       # Typed extraction
+if result.reasoning:
+    print("Reasoning:", result.reasoning[:200])  # Model's thought process
 ```
 
 This is useful when you need to audit *why* the model extracted specific
@@ -215,11 +212,11 @@ decisions.
 - **Schema complexity affects reliability.** Flat schemas with descriptive
   field names work best. Deeply nested schemas with many optional fields
   produce inconsistent results. Simplify where you can.
-- **Raw text is always available.** Even with `response_schema`, the raw
-  model response is in `result["answers"]`. Useful for debugging when the
+- **Raw text is always available.** Even with `output` schemas, the raw
+  model response is in `result.text`. Useful for debugging when the
   structured output doesn't match expectations.
 - **Structured output is provider- and model-dependent.** Gemini, OpenAI, and
-  Anthropic support `response_schema`. OpenRouter supports it on models that
+  Anthropic support structured outputs. OpenRouter supports them on models that
   advertise `response_format` or `structured_outputs`. See
   [Provider Capabilities](reference/provider-capabilities.md) for details.
 - **Pydantic v2 is required.** Pollux uses `model_json_schema()` for schema


### PR DESCRIPTION
## Summary

Aligns the user-facing documentation with the Pollux v2 API architecture and terminology, replacing deprecated parameters (e.g. `Options`, `response_schema`, `continue_from`, `continue_tool`) with their v2 equivalents (`Environment`, `output`, `continuation`, `interact`, `stream`).

## Related issue

None

## Test plan

Non-behavioral change (documentation updates). Verified that:
- `just lint` (Ruff formatting, ruff check, rumdl link checks) runs and passes cleanly.
- `just docs-build` (MkDocs compilation) builds successfully without warnings.
- `just typecheck` and `just test` run successfully to confirm no regressions.

## Notes

All documentation files have also been audited against internal styling guidelines.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
