### PR TITLE
feat(core): introduce ToolCall.arguments_dict and ToolResult.from_value

### DIFF
--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -29,7 +29,6 @@ Type it out (or paste it) and run it. We'll break it down afterward.
 
 ```python
 import asyncio
-import json
 
 from pollux import (
     Config,
@@ -76,16 +75,16 @@ def execute_tool_calls(tool_calls: tuple[ToolCall, ...]) -> list[ToolResult]:
     results = []
     for tc in tool_calls:
         try:
-            # Arguments are already parsed by ToolCall
-            args = tc.arguments if isinstance(tc.arguments, dict) else {}
+            # Raises ConfigurationError if the model emitted malformed or non-object JSON.
+            args = tc.arguments_dict()
             output = TOOL_DISPATCH[tc.name](args)
-            content = json.dumps(output)
+            results.append(ToolResult.from_value(call_id=tc.id, value=output))
         except Exception as exc:
-            content = json.dumps({"error": str(exc)})
-        results.append(ToolResult(
-            call_id=tc.id,
-            content=content,
-        ))
+            results.append(ToolResult.from_value(
+                call_id=tc.id,
+                value={"error": str(exc)},
+                is_error=True,
+            ))
     return results
 
 
@@ -282,6 +281,9 @@ the control flow.
 - **Return errors as tool results, don't raise.** If a tool fails, return a
   JSON error message so the model can reason about the failure. Raising an
   exception breaks the loop.
+- **Use `ToolCall.arguments_dict()` for dispatch.** It accepts object-shaped
+  JSON arguments and rejects malformed or non-object arguments with an actionable
+  error, instead of silently treating them as `{}`.
 - **`tool_calls` is a flat tuple on `Output`.** When using `interact()` or `run()`,
   `out.tool_calls` is a flat tuple of `ToolCall` objects.
 - **The model can request multiple tools in one turn.** The example handles

--- a/src/pollux/interaction/output.py
+++ b/src/pollux/interaction/output.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
+from pydantic import BaseModel
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -133,6 +135,13 @@ class Diagnostics:
         return dict(self.raw) if self.raw else {}
 
 
+def _jsonable_structured(value: Any) -> Any:
+    """Return a JSON-compatible structured payload where Pollux can guarantee it."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    return value
+
+
 @dataclass(frozen=True, slots=True)
 class Output:
     """The completed result of one model interaction, as named facets."""
@@ -150,7 +159,7 @@ class Output:
         """Serialize to a JSON-compatible dict (optional facets omitted)."""
         payload: dict[str, Any] = {"text": self.text}
         if self.structured is not None:
-            payload["structured"] = self.structured
+            payload["structured"] = _jsonable_structured(self.structured)
         if self.reasoning is not None:
             payload["reasoning"] = self.reasoning
         if self.tool_calls:

--- a/src/pollux/interaction/tools.py
+++ b/src/pollux/interaction/tools.py
@@ -110,6 +110,27 @@ class ToolCall:
             provider_state=provider_state,
         )
 
+    def arguments_dict(self) -> dict[str, Any]:
+        """Return parsed JSON-object arguments or raise an explicit config error.
+
+        Agent loops usually dispatch tools from object-shaped JSON arguments.
+        This helper keeps that path strict: malformed JSON and non-object JSON
+        are rejected instead of being silently treated as an empty dict.
+        """
+        if self.arguments_error is not None:
+            raise ConfigurationError(
+                f"Tool call {self.name!r} has invalid JSON arguments",
+                hint=self.arguments_error,
+            )
+        if self.arguments is None:
+            return {}
+        if not isinstance(self.arguments, dict):
+            raise ConfigurationError(
+                f"Tool call {self.name!r} arguments must be a JSON object",
+                hint="Define tool parameters as an object schema and retry the turn.",
+            )
+        return dict(self.arguments)
+
     def to_jsonable(self) -> dict[str, Any]:
         """Serialize to a compact JSON-compatible dict (optional facets omitted)."""
         payload: dict[str, Any] = {
@@ -150,6 +171,32 @@ class ToolResult:
     call_id: str
     content: str
     is_error: bool = False
+
+    @classmethod
+    def from_value(
+        cls,
+        *,
+        call_id: str,
+        value: JSONValue,
+        is_error: bool = False,
+    ) -> ToolResult:
+        """Build a tool result from a JSON value, serializing non-strings.
+
+        Strings are preserved as-is. Other JSON values are encoded compactly so
+        agent loops can return structured tool output without repeating
+        ``json.dumps`` at every dispatch site.
+        """
+        if isinstance(value, str):
+            content = value
+        else:
+            try:
+                content = json.dumps(value, ensure_ascii=False, sort_keys=True)
+            except (TypeError, ValueError) as exc:
+                raise ConfigurationError(
+                    "ToolResult.from_value() requires a JSON-serializable value",
+                    hint="Return a string, dict, list, number, boolean, or None.",
+                ) from exc
+        return cls(call_id=call_id, content=content, is_error=is_error)
 
     def to_jsonable(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dict."""

--- a/tests/interaction/test_output.py
+++ b/tests/interaction/test_output.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pydantic import BaseModel
 import pytest
 
 from pollux.interaction.output import (
@@ -13,6 +14,10 @@ from pollux.interaction.output import (
 from pollux.interaction.tools import ToolCall
 
 pytestmark = pytest.mark.unit
+
+
+class _StructuredAnswer(BaseModel):
+    value: int
 
 
 @pytest.mark.parametrize(
@@ -66,6 +71,11 @@ def test_output_to_jsonable_has_named_facets_without_v1_vestiges():
     assert "confidence" not in payload
     assert "status" not in payload
     assert "extraction_method" not in payload
+
+
+def test_output_to_jsonable_serializes_pydantic_structured_output():
+    output = Output(text="", structured=_StructuredAnswer(value=7))
+    assert output.to_jsonable()["structured"] == {"value": 7}
 
 
 def test_output_omits_empty_optional_facets():

--- a/tests/interaction/test_tools.py
+++ b/tests/interaction/test_tools.py
@@ -32,6 +32,28 @@ def test_tool_call_empty_arguments_is_not_an_error():
     assert call.arguments_error is None
 
 
+def test_tool_call_arguments_dict_returns_parsed_object():
+    call = ToolCall.from_text(id="c1", name="f", arguments_text='{"city": "Paris"}')
+    assert call.arguments_dict() == {"city": "Paris"}
+
+
+def test_tool_call_arguments_dict_treats_empty_arguments_as_empty_object():
+    call = ToolCall.from_text(id="c1", name="f")
+    assert call.arguments_dict() == {}
+
+
+def test_tool_call_arguments_dict_rejects_invalid_json():
+    call = ToolCall.from_text(id="c1", name="f", arguments_text="{not json")
+    with pytest.raises(ConfigurationError, match="invalid JSON arguments"):
+        call.arguments_dict()
+
+
+def test_tool_call_arguments_dict_rejects_non_object_json():
+    call = ToolCall.from_text(id="c1", name="f", arguments_text='["not", "object"]')
+    with pytest.raises(ConfigurationError, match="must be a JSON object"):
+        call.arguments_dict()
+
+
 def test_tool_call_to_jsonable_omits_unset_facets():
     call = ToolCall.from_text(id="c1", name="f", arguments_text='{"a": 1}')
     payload = call.to_jsonable()
@@ -76,3 +98,21 @@ def test_tool_result_to_jsonable():
         "content": "boom",
         "is_error": True,
     }
+
+
+def test_tool_result_from_value_preserves_strings():
+    assert ToolResult.from_value(call_id="c1", value="ok").content == "ok"
+
+
+def test_tool_result_from_value_serializes_json_values():
+    result = ToolResult.from_value(
+        call_id="c1",
+        value={"temp_f": 72, "conditions": ["sunny"]},
+    )
+    assert result.content == '{"conditions": ["sunny"], "temp_f": 72}'
+
+
+def test_tool_result_from_value_marks_errors():
+    result = ToolResult.from_value(call_id="c1", value={"error": "boom"}, is_error=True)
+    assert result.is_error is True
+    assert result.to_jsonable()["is_error"] is True


### PR DESCRIPTION
## Summary

This PR adds ergonomics and safety improvements for handling tool arguments and results, and guarantees structured output serialization:
- Adds `ToolCall.arguments_dict()` to strictly validate and retrieve parsed JSON-object arguments, failing fast with a `ConfigurationError` on malformed JSON or non-object arguments.
- Adds `ToolResult.from_value()` constructor to automatically serialize non-string values to compact JSON and handle error payloads.
- Updates `Output.to_jsonable()` to properly serialize Pydantic `BaseModel` structured outputs using `value.model_dump(mode="json")`.
- Modernizes `docs/agent-loop.md` to teach these recommended v2 patterns.

## Related issue

None

## Test plan

Run the local checking tool to execute all tests:
```bash
just check
```
Verified that 423 tests passed, including new unit tests covering:
- JSON parsing and object-shape validation for `arguments_dict()`.
- Automatic serialization of generic JSON value types and strings for `from_value()`.
- Clean serialization of Pydantic models in `to_jsonable()`.

## Notes

None

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
