### PR TITLE
feat(core): harden the local provider for multimodal agent loops

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,11 +32,12 @@ All fields and their defaults:
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `provider` | `"gemini" \| "openai" \| "anthropic" \| "openrouter" \| "local"` | *(required)* | Provider to use |
-| `model` | `str` | *(required)* | Model identifier |
+| `model` | `str \| None` | `None` | Model identifier. Required for cloud providers; optional for single-model local servers |
 | `api_key` | `str \| None` | `None` | Explicit key; auto-resolved from env if omitted. Optional for `provider="local"` |
 | `base_url` | `str \| None` | `None` | Required for `provider="local"`; rejected for cloud providers. Falls back to `POLLUX_LOCAL_BASE_URL` |
 | `use_mock` | `bool` | `False` | Use mock provider (no network calls) |
 | `request_concurrency` | `int` | `6` | Max concurrent API calls in multi-prompt execution |
+| `request_timeout_s` | `float` | `300.0` | HTTP request timeout in seconds for providers that own their transport, including `provider="local"` |
 | `retry` | `RetryPolicy` | `RetryPolicy()` | Retry configuration |
 
 ## API Key Resolution
@@ -67,13 +68,16 @@ project root for local development, but never commit it.
 ## Self-Hosted Models (`provider="local"`)
 
 Pollux supports self-hosted servers that speak the OpenAI Chat Completions wire
-format. Point `base_url` at the server; `api_key` is optional.
+format. Point `base_url` at the server; `api_key` is optional. If the server
+has a single configured model or rejects client-supplied model names, omit
+`model` and Pollux will leave the `model` request field out of local payloads.
 
 ```python
 config = Config(
     provider="local",
     model="gemma3:4b",
     base_url="http://localhost:11434/v1",
+    request_timeout_s=600,
 )
 ```
 

--- a/src/pollux/__init__.py
+++ b/src/pollux/__init__.py
@@ -668,9 +668,21 @@ def _build_openrouter(api_key: str | None, _base_url: str | None) -> Provider:
 
 
 def _build_local(api_key: str | None, base_url: str | None) -> Provider:
+    return _build_local_with_timeout(api_key, base_url, 300.0)
+
+
+def _build_local_with_timeout(
+    api_key: str | None,
+    base_url: str | None,
+    request_timeout_s: float,
+) -> Provider:
     from pollux.providers.local import LocalProvider
 
-    return LocalProvider(base_url=cast("str", base_url), api_key=api_key)
+    return LocalProvider(
+        base_url=cast("str", base_url),
+        api_key=api_key,
+        timeout_s=request_timeout_s,
+    )
 
 
 # Single source of truth for provider construction and lifecycle traits.
@@ -692,6 +704,7 @@ def _create_provider(
     *,
     use_mock: bool = False,
     base_url: str | None = None,
+    request_timeout_s: float = 300.0,
 ) -> Provider:
     """Instantiate a provider client from explicit parameters."""
     if use_mock:
@@ -724,6 +737,12 @@ def _create_provider(
             hint=f"Set {env_var} or pass Config(api_key=...).",
         )
 
+    if provider == "local":
+        return _build_local_with_timeout(
+            api_key,
+            base_url,
+            request_timeout_s,
+        )
     return spec.build(api_key, base_url)
 
 
@@ -734,6 +753,7 @@ def _get_provider(config: Config) -> Provider:
         config.api_key,
         use_mock=config.use_mock,
         base_url=config.base_url,
+        request_timeout_s=config.request_timeout_s,
     )
 
 

--- a/src/pollux/cache.py
+++ b/src/pollux/cache.py
@@ -298,8 +298,15 @@ async def create_cache_impl(
                     hint="Ensure all items in the tools list are dictionaries.",
                 )
 
+    if config.model is None:
+        raise ConfigurationError(
+            "create_cache() requires a configured model",
+            hint="Pass Config(model=...) when preparing persistent provider caches.",
+        )
+    model = config.model
+
     key = compute_cache_key(
-        config.model,
+        model,
         src_tuple,
         provider=config.provider,
         api_key=config.api_key,
@@ -312,7 +319,7 @@ async def create_cache_impl(
         cache_name, expires_at = cached
         return CacheHandle(
             name=cache_name,
-            model=config.model,
+            model=model,
             provider=config.provider,
             expires_at=expires_at,
         )
@@ -323,7 +330,7 @@ async def create_cache_impl(
         provider,
         _registry,
         key=key,
-        model=config.model,
+        model=model,
         raw_parts=raw_parts,
         system_instruction=system_instruction,
         tools=tools,
@@ -341,7 +348,7 @@ async def create_cache_impl(
 
     return CacheHandle(
         name=cache_name,
-        model=config.model,
+        model=model,
         provider=config.provider,
         expires_at=expires_at,
     )

--- a/src/pollux/config.py
+++ b/src/pollux/config.py
@@ -55,7 +55,9 @@ def _resolve_local_base_url() -> str | None:
 class Config:
     """Immutable configuration for Pollux execution.
 
-    Provider and model are required—Pollux does not guess what you want.
+    Provider and model are required for cloud providers—Pollux does not guess
+    what you want. Local OpenAI-compatible servers may omit ``model`` when the
+    server has a single configured model or otherwise does not require it.
     API keys are auto-resolved from standard environment variables.
 
     Example:
@@ -67,7 +69,7 @@ class Config:
     """
 
     provider: ProviderName
-    model: str
+    model: str | None = None
     #: Auto-resolved from the provider-specific API key env var when *None*.
     #: Optional for ``provider="local"``.
     api_key: str | None = None
@@ -76,6 +78,9 @@ class Config:
     base_url: str | None = None
     use_mock: bool = False
     request_concurrency: int = 6
+    #: HTTP request timeout in seconds for providers that own their transport.
+    #: Currently applied by the local OpenAI-compatible provider.
+    request_timeout_s: float = 300.0
     retry: RetryPolicy = field(default_factory=RetryPolicy)
     #: Optional capability declarations that override the provider's static
     #: capabilities for this config (v2 interaction path). A declared capability
@@ -106,6 +111,16 @@ class Config:
                 f"request_concurrency must be ≥ 1, got {self.request_concurrency}",
                 hint="This controls how many API calls run in parallel.",
             )
+        if not isinstance(self.request_timeout_s, int | float):
+            raise ConfigurationError(
+                f"request_timeout_s must be numeric, got {type(self.request_timeout_s).__name__}",
+                hint="Pass a timeout in seconds, for example request_timeout_s=600.",
+            )
+        if self.request_timeout_s <= 0:
+            raise ConfigurationError(
+                f"request_timeout_s must be > 0, got {self.request_timeout_s}",
+                hint="Pass a positive timeout in seconds.",
+            )
 
         if self.provider == "local":
             # Local: resolve base_url for real calls, skip API-key resolution entirely.
@@ -122,6 +137,12 @@ class Config:
                     ),
                 )
             return
+
+        if not isinstance(self.model, str) or not self.model:
+            raise ConfigurationError(
+                f"model required for provider={self.provider!r}",
+                hint="Pass the provider model name, for example model='gpt-5-nano'.",
+            )
 
         # Cloud providers: base_url is not a meaningful override here.
         if self.base_url is not None:

--- a/src/pollux/deferred.py
+++ b/src/pollux/deferred.py
@@ -205,6 +205,11 @@ async def submit_deferred(
         if provider_handle.submitted_at is not None
         else time.time()
     )
+    if config.model is None:
+        raise ConfigurationError(
+            "defer() requires a configured model",
+            hint="Pass Config(model=...) for provider-side deferred jobs.",
+        )
     return DeferredHandle(
         job_id=provider_handle.job_id,
         provider=config.provider,

--- a/src/pollux/providers/anthropic.py
+++ b/src/pollux/providers/anthropic.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import inspect
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pollux.errors import APIError, ConfigurationError
 from pollux.interaction.tools import ToolCallDelta
@@ -255,7 +255,7 @@ class AnthropicProvider:
         config: Config,
     ) -> dict[str, Any]:
         """Build the raw Anthropic Messages API request body."""
-        model = config.model
+        model = cast("str", config.model)
         history, _previous_response_id, provider_state = _compile.prior_turns(input)
         messages = self._build_messages(parts, history or None, provider_state)
         system_instruction = _compile.system_instruction(snapshot)
@@ -556,9 +556,10 @@ class AnthropicProvider:
             requirements.reasoning_effort is not None
             or requirements.reasoning_budget_tokens is not None
         )
-        if wants_reasoning and _model_lacks_extended_thinking(config.model):
+        model = cast("str", config.model)
+        if wants_reasoning and _model_lacks_extended_thinking(model):
             raise ConfigurationError(
-                f"Model {config.model!r} does not support extended thinking",
+                f"Model {model!r} does not support extended thinking",
                 hint=(
                     "Remove reasoning_effort/reasoning_budget_tokens, or use a "
                     "model with extended thinking (Claude 3.7 or 4.x)."

--- a/src/pollux/providers/local.py
+++ b/src/pollux/providers/local.py
@@ -17,13 +17,18 @@ vary too much to query reliably).
 from __future__ import annotations
 
 import asyncio
+import base64
 from collections.abc import Mapping
 import json
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 
-from pollux.errors import APIError, ConfigurationError, walk_exception_chain
+from pollux.errors import (
+    APIError,
+    ConfigurationError,
+    walk_exception_chain,
+)
 from pollux.providers import _compile
 from pollux.providers._errors import wrap_provider_error
 from pollux.providers._openai_compat import (
@@ -58,13 +63,19 @@ if TYPE_CHECKING:
     from pollux.interaction.input import Input
     from pollux.interaction.requirements import OutputRequirements
 
-_LOCAL_TIMEOUT_S = 300.0
+_DEFAULT_LOCAL_TIMEOUT_S = 300.0
 
 
 class LocalProvider:
     """Chat Completions provider for self-hosted OpenAI-compatible servers."""
 
-    def __init__(self, base_url: str, api_key: str | None = None) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        *,
+        timeout_s: float = _DEFAULT_LOCAL_TIMEOUT_S,
+    ) -> None:
         """Initialize with the server's base URL and an optional auth token.
 
         Most local servers ignore the Authorization header; some require
@@ -73,6 +84,7 @@ class LocalProvider:
         """
         self._base_url = base_url
         self._api_key = api_key or "local"
+        self._timeout_s = timeout_s
         self._client: Any = None
 
     @property
@@ -80,7 +92,7 @@ class LocalProvider:
         """Return supported feature flags (narrow by design)."""
         return ProviderCapabilities(
             persistent_cache=False,
-            uploads=False,
+            uploads=True,
             structured_outputs=True,
             reasoning=False,
             reasoning_budget_tokens=False,
@@ -88,8 +100,8 @@ class LocalProvider:
             conversation=True,
             implicit_caching=False,
             file_rejection_hint=(
-                "Pass file content as text via Source.from_text(). "
-                "Images, PDFs, and remote URIs are not supported."
+                "Local supports text, image, and audio inputs through "
+                "OpenAI-compatible Chat Completions content parts."
             ),
         )
 
@@ -105,7 +117,7 @@ class LocalProvider:
                     "Authorization": f"Bearer {self._api_key}",
                     "Content-Type": "application/json",
                 },
-                timeout=_LOCAL_TIMEOUT_S,
+                timeout=self._timeout_s,
                 limits=httpx.Limits(
                     max_connections=None, max_keepalive_connections=None
                 ),
@@ -135,12 +147,13 @@ class LocalProvider:
                 ),
             )
         for part in _compile.request_parts(snapshot, input):
-            if not _is_text_part(part):
+            if not _is_supported_local_part(part):
                 raise ConfigurationError(
-                    "Local provider does not support file or multimodal input",
+                    "Local provider does not support this input MIME type",
                     hint=(
-                        "Pass file content as text via Source.from_text(). "
-                        "Images, PDFs, and remote URIs are not supported."
+                        "Local supports text, image, and audio inputs. "
+                        "Use a provider with broader multimodal support for "
+                        "PDF, video, or arbitrary binary files."
                     ),
                 )
 
@@ -164,10 +177,9 @@ class LocalProvider:
             history or None,
             system_instruction=_compile.system_instruction(snapshot),
         )
-        payload: dict[str, Any] = {
-            "model": config.model,
-            "messages": messages,
-        }
+        payload: dict[str, Any] = {"messages": messages}
+        if config.model is not None:
+            payload["model"] = config.model
         if requirements.temperature is not None:
             payload["temperature"] = requirements.temperature
         if requirements.top_p is not None:
@@ -296,12 +308,42 @@ class LocalProvider:
             ) from e
 
     async def upload_file(self, path: Path, mime_type: str) -> ProviderFileAsset:
-        """Reject uploads because local provider takes inline content only."""
-        _ = path, mime_type
-        raise _local_api_error(
-            "Local provider does not support file uploads",
-            phase="upload",
-            hint="Pass file content as text via Source.from_text().",
+        """Inline local files for OpenAI-compatible Chat Completions."""
+        try:
+            data = path.read_bytes()
+        except Exception as exc:
+            raise _local_api_error(
+                f"Failed to read local file for inline input: {path}",
+                phase="upload",
+            ) from exc
+
+        if _is_text_like_mime_type(mime_type):
+            try:
+                text = data.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ConfigurationError(
+                    f"Local text input is not valid UTF-8: {path}",
+                    hint="Use a valid UTF-8 text file or pass a binary media type.",
+                ) from exc
+            return ProviderFileAsset(
+                file_id=text,
+                provider="local",
+                mime_type=mime_type,
+                file_name=path.name,
+                is_inline_fallback=True,
+            )
+
+        if mime_type.startswith(("image/", "audio/")):
+            return ProviderFileAsset(
+                file_id=_to_data_url(data, mime_type),
+                provider="local",
+                mime_type=mime_type,
+                file_name=path.name,
+            )
+
+        raise ConfigurationError(
+            f"Unsupported local input MIME type: {mime_type}",
+            hint="Local supports text, image, and audio files.",
         )
 
     async def create_cache(
@@ -329,22 +371,35 @@ class LocalProvider:
         await client.aclose()
 
 
-def _is_text_part(part: Any) -> bool:
-    """Return True when *part* is plain text the local provider can send inline.
-
-    Mirrors OpenRouter's input-part discrimination: strings and
-    text-only dicts pass; ProviderFileAsset and dicts carrying
-    ``uri``/``mime_type`` are rejected.
-    """
+def _is_supported_local_part(part: Any) -> bool:
+    """Return True when *part* can become local Chat Completions content."""
     if part is None:
         return True
     if isinstance(part, str):
         return True
     if isinstance(part, ProviderFileAsset):
-        return False
+        return part.provider == "local" and (
+            part.is_inline_fallback or part.mime_type.startswith(("image/", "audio/"))
+        )
     if isinstance(part, Mapping):
+        mime_type = part.get("mime_type")
+        if "file_path" in part:
+            return isinstance(mime_type, str) and (
+                _is_text_like_mime_type(mime_type)
+                or mime_type.startswith(("image/", "audio/"))
+            )
         if "uri" in part or "mime_type" in part:
-            return False
+            uri = part.get("uri")
+            return (
+                isinstance(uri, str)
+                and isinstance(mime_type, str)
+                and (
+                    mime_type.startswith("image/")
+                    or (
+                        mime_type.startswith("audio/") and uri.startswith("data:audio/")
+                    )
+                )
+            )
         return isinstance(part.get("text"), str)
     return False
 
@@ -367,9 +422,9 @@ def _build_messages(
             if message is not None:
                 messages.append(message)
 
-    user_text = _join_text_parts(parts)
-    if user_text or not messages:
-        messages.append({"role": "user", "content": user_text})
+    user_content = _content_from_parts(parts)
+    if user_content or not messages:
+        messages.append({"role": "user", "content": user_content})
 
     return messages
 
@@ -401,15 +456,115 @@ def _history_message(item: Message) -> dict[str, Any] | None:
     return message
 
 
-def _join_text_parts(parts: list[Any]) -> str:
-    """Concatenate text parts into a single user message body."""
-    texts: list[str] = []
+def _content_from_parts(parts: list[Any]) -> str | list[dict[str, Any]]:
+    """Convert Pollux parts into local Chat Completions message content."""
+    content_parts: list[dict[str, Any]] = []
     for part in parts:
-        if isinstance(part, str):
-            texts.append(part)
-        elif isinstance(part, Mapping) and isinstance(part.get("text"), str):
-            texts.append(cast("str", part["text"]))
-    return "\n\n".join(texts)
+        normalized = _normalize_input_part(part)
+        if normalized is not None:
+            content_parts.append(normalized)
+    if not content_parts:
+        return ""
+    if all(part.get("type") == "text" for part in content_parts):
+        return "\n\n".join(cast("str", part["text"]) for part in content_parts)
+    return content_parts
+
+
+def _normalize_input_part(part: Any) -> dict[str, Any] | None:
+    """Convert one Pollux part into a local Chat Completions content item."""
+    if part is None:
+        return None
+    if isinstance(part, str):
+        return {"type": "text", "text": part}
+    if isinstance(part, Mapping) and isinstance(part.get("text"), str):
+        return {"type": "text", "text": cast("str", part["text"])}
+
+    if isinstance(part, ProviderFileAsset):
+        if part.provider != "local":
+            raise _local_api_error(
+                f"Local provider cannot use {part.provider} file assets.",
+                phase="generate",
+            )
+        if part.is_inline_fallback:
+            return {"type": "text", "text": part.file_id}
+        return _media_content_part(
+            uri=part.file_id,
+            mime_type=part.mime_type,
+            file_name=part.file_name,
+        )
+
+    if isinstance(part, Mapping):
+        uri = part.get("uri")
+        mime_type = part.get("mime_type")
+        if isinstance(uri, str) and isinstance(mime_type, str):
+            return _media_content_part(uri=uri, mime_type=mime_type)
+
+    raise ConfigurationError(
+        f"Unsupported local input part: {type(part).__name__}",
+        hint="Local supports text, image, and audio inputs.",
+    )
+
+
+def _media_content_part(
+    *, uri: str, mime_type: str, file_name: str | None = None
+) -> dict[str, Any]:
+    """Build an OpenAI-compatible media content item for local servers."""
+    _ = file_name
+    if mime_type.startswith("image/"):
+        return {"type": "image_url", "image_url": {"url": uri}}
+    if mime_type.startswith("audio/"):
+        data, audio_format = _audio_payload(uri=uri, mime_type=mime_type)
+        return {
+            "type": "input_audio",
+            "input_audio": {"data": data, "format": audio_format},
+        }
+    raise ConfigurationError(
+        f"Unsupported local input MIME type: {mime_type}",
+        hint="Local supports text, image, and audio inputs.",
+    )
+
+
+def _audio_payload(*, uri: str, mime_type: str) -> tuple[str, str]:
+    """Return base64 audio payload and format for Chat Completions."""
+    if not uri.startswith("data:"):
+        raise ConfigurationError(
+            "Local audio input requires a data URL",
+            hint="Use Source.from_file(...) for local audio files.",
+        )
+    marker = ";base64,"
+    if marker not in uri:
+        raise ConfigurationError(
+            "Local audio data URL must be base64 encoded",
+            hint="Use Source.from_file(...) for local audio files.",
+        )
+    data = uri.split(marker, 1)[1]
+    return data, _audio_format(mime_type)
+
+
+def _audio_format(mime_type: str) -> str:
+    """Return the Chat Completions audio format token for a MIME type."""
+    suffix = mime_type.split("/", 1)[1].split(";", 1)[0].lower()
+    if suffix in {"mpeg", "mpga"}:
+        return "mp3"
+    return suffix
+
+
+def _is_text_like_mime_type(mime_type: str) -> bool:
+    """Return True when local should inline file bytes as text."""
+    if mime_type.startswith("text/"):
+        return True
+    return mime_type in {
+        "application/json",
+        "application/xml",
+        "application/yaml",
+        "application/x-yaml",
+    } or mime_type.endswith(("+json", "+xml"))
+
+
+def _to_data_url(data: bytes, mime_type: str) -> str:
+    """Encode raw file bytes as a base64 data URL."""
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
 
 
 def _parse_response(
@@ -464,8 +619,8 @@ def _hint_for_local_error(exc: BaseException, *, base_url: str) -> str | None:
             )
         if isinstance(e, httpx.ReadTimeout):
             return (
-                f"Local inference timed out after {_LOCAL_TIMEOUT_S:.0f}s. "
-                f"The model may be too slow for your hardware."
+                "Local inference timed out. Increase Config.request_timeout_s "
+                "or reduce input size."
             )
 
     if isinstance(exc, httpx.HTTPStatusError):

--- a/src/pollux/providers/openrouter.py
+++ b/src/pollux/providers/openrouter.py
@@ -270,7 +270,7 @@ class OpenRouterProvider:
                 ),
             )
 
-        model = config.model
+        model = cast("str", config.model)
         metadata = await self._get_model_metadata(model)
         _require_text_io(metadata, model=model)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 def make_interaction(
     *,
-    model: str,
+    model: str | None,
     provider: str = "mock",
     content: str | None = None,
     prepared_parts: Sequence[Any] = (),

--- a/tests/pipeline/test_cache_and_uploads.py
+++ b/tests/pipeline/test_cache_and_uploads.py
@@ -6,6 +6,7 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
+import httpx
 import pytest
 
 import pollux
@@ -16,6 +17,7 @@ from pollux.errors import (
     APIError,
     ConfigurationError,
 )
+from pollux.providers.local import LocalProvider
 from pollux.providers.models import (
     ProviderFileAsset,
     ProviderResponse,
@@ -361,10 +363,36 @@ async def test_provider_validation_runs_before_uploads(
 
 
 @pytest.mark.asyncio
-async def test_local_file_sources_raise_local_specific_guidance(tmp_path: Any) -> None:
-    """Local file inputs should fail with the text-only local provider guidance."""
+async def test_local_file_sources_are_inlined_for_chat_completions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Local file inputs should be converted into inline Chat Completions parts."""
+
+    class _FakeLocalClient:
+        def __init__(self) -> None:
+            self.last_json: dict[str, Any] | None = None
+            self.closed = False
+
+        async def post(self, path: str, json: dict[str, Any]) -> httpx.Response:
+            self.last_json = json
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "ok"}}],
+                    "usage": {"total_tokens": 1},
+                },
+                request=httpx.Request("POST", f"http://localhost:8080/v1/{path}"),
+            )
+
+        async def aclose(self) -> None:
+            self.closed = True
+
     file_path = tmp_path / "note.txt"
     file_path.write_text("hello", encoding="utf-8")
+    fake_client = _FakeLocalClient()
+    provider = LocalProvider(base_url="http://localhost:8080/v1")
+    provider._client = fake_client
+    monkeypatch.setattr(pollux, "_get_provider", lambda _config: provider)
 
     cfg = Config(
         provider="local",
@@ -372,17 +400,17 @@ async def test_local_file_sources_raise_local_specific_guidance(tmp_path: Any) -
         base_url="http://localhost:8080/v1",
     )
 
-    with pytest.raises(
-        ConfigurationError, match="Provider does not support file or multimodal input"
-    ) as exc:
-        await pollux.run(
-            "Summarize this.",
-            source=Source.from_file(file_path, mime_type="text/plain"),
-            config=cfg,
-        )
+    out = await pollux.run(
+        "Summarize this.",
+        source=Source.from_file(file_path, mime_type="text/plain"),
+        config=cfg,
+    )
 
-    assert exc.value.hint is not None
-    assert "Source.from_text()" in exc.value.hint
+    assert out.text == "ok"
+    assert fake_client.last_json is not None
+    assert (
+        fake_client.last_json["messages"][-1]["content"] == "hello\n\nSummarize this."
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_local_contract.py
+++ b/tests/providers/test_local_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from typing import Any
 
@@ -93,7 +94,7 @@ def test_local_capabilities_are_narrow() -> None:
     caps = LocalProvider(base_url=_LOCAL_BASE_URL).capabilities
 
     assert caps.persistent_cache is False
-    assert caps.uploads is False
+    assert caps.uploads is True
     assert caps.structured_outputs is True
     assert caps.reasoning is False
     assert caps.reasoning_budget_tokens is False
@@ -142,6 +143,25 @@ async def test_local_generate_builds_chat_completions_payload() -> None:
         "output_tokens": 5,
         "total_tokens": 15,
     }
+
+
+@pytest.mark.asyncio
+async def test_local_generate_omits_model_when_unset() -> None:
+    """Local can target single-model servers that reject or ignore model names."""
+    fake = _FakeLocalClient()
+    provider = _make_local_provider(fake)
+    snapshot, input, requirements, config = make_interaction(
+        provider="local",
+        base_url=_LOCAL_BASE_URL,
+        model=None,
+        content="Hello",
+    )
+
+    await provider.generate(snapshot, input, requirements, config)
+
+    assert fake.last_json is not None
+    assert "model" not in fake.last_json
+    assert fake.last_json["messages"] == [{"role": "user", "content": "Hello"}]
 
 
 @pytest.mark.asyncio
@@ -527,34 +547,74 @@ async def test_local_generate_parses_tool_calls() -> None:
 
 
 @pytest.mark.asyncio
-async def test_local_generate_rejects_non_text_parts() -> None:
-    """Multimodal / file parts are explicitly unsupported on local."""
+async def test_local_generate_sends_multimodal_content_parts() -> None:
+    """Local should send image/audio content through Chat Completions parts."""
+    fake = _FakeLocalClient()
+    provider = _make_local_provider(fake)
+    audio = base64.b64encode(b"audio").decode("ascii")
+
+    await provider.generate(
+        *_local(
+            content="Describe these.",
+            prepared_parts=[
+                {"uri": "https://example.com/photo.jpg", "mime_type": "image/jpeg"},
+                {"uri": f"data:audio/wav;base64,{audio}", "mime_type": "audio/wav"},
+            ],
+        )
+    )
+
+    assert fake.last_json is not None
+    assert fake.last_json["messages"][-1] == {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/photo.jpg"},
+            },
+            {
+                "type": "input_audio",
+                "input_audio": {"data": audio, "format": "wav"},
+            },
+            {"type": "text", "text": "Describe these."},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_local_generate_rejects_unsupported_media_parts() -> None:
+    """Unsupported local media should fail with MIME-specific guidance."""
     provider = _make_local_provider(_FakeLocalClient())
 
-    with pytest.raises(ConfigurationError, match="file or multimodal input"):
+    with pytest.raises(ConfigurationError, match="input MIME type"):
         await provider.generate(
             *_local(
-                content="Describe this image.",
+                content="Describe this.",
                 prepared_parts=[
-                    {"uri": "https://example.com/photo.jpg", "mime_type": "image/jpeg"},
+                    {
+                        "uri": "https://example.com/doc.pdf",
+                        "mime_type": "application/pdf",
+                    },
                 ],
             )
         )
 
 
 @pytest.mark.asyncio
-async def test_local_upload_file_raises_api_error(tmp_path: Any) -> None:
-    """Uploads are unsupported; should raise APIError, not silently noop."""
+async def test_local_upload_file_inlines_text_and_media(tmp_path: Any) -> None:
+    """Local upload_file prepares inline Chat Completions assets."""
     provider = LocalProvider(base_url=_LOCAL_BASE_URL)
     text_path = tmp_path / "note.txt"
     text_path.write_text("hello", encoding="utf-8")
+    image_path = tmp_path / "photo.png"
+    image_path.write_bytes(b"png")
 
-    with pytest.raises(APIError, match="does not support file uploads") as exc:
-        await provider.upload_file(text_path, "text/plain")
+    text_asset = await provider.upload_file(text_path, "text/plain")
+    image_asset = await provider.upload_file(image_path, "image/png")
 
-    err = exc.value
-    assert err.provider == "local"
-    assert err.phase == "upload"
+    assert text_asset.provider == "local"
+    assert text_asset.file_id == "hello"
+    assert text_asset.is_inline_fallback is True
+    assert image_asset.file_id.startswith("data:image/png;base64,")
 
 
 @pytest.mark.asyncio
@@ -614,5 +674,18 @@ async def test_local_provider_configures_timeout() -> None:
     assert isinstance(client.timeout, httpx.Timeout)
     assert client.timeout.connect == 300.0
     assert client.timeout.read == 300.0
+
+    await provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_local_provider_accepts_custom_timeout() -> None:
+    """Agent harnesses can extend local timeouts for slow bulk generations."""
+    provider = LocalProvider(base_url=_LOCAL_BASE_URL, timeout_s=45.0)
+    client = provider._get_client()
+
+    assert isinstance(client.timeout, httpx.Timeout)
+    assert client.timeout.connect == 45.0
+    assert client.timeout.read == 45.0
 
     await provider.aclose()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,6 +198,18 @@ def test_non_integer_request_concurrency_raises_clear_error(gemini_model: str) -
     assert exc.value.hint is not None
 
 
+def test_non_positive_request_timeout_raises_clear_error(gemini_model: str) -> None:
+    """Request timeouts must fail at config construction, not during transport."""
+    with pytest.raises(ConfigurationError, match="request_timeout_s must be") as exc:
+        Config(
+            provider="gemini",
+            model=gemini_model,
+            use_mock=True,
+            request_timeout_s=0,
+        )
+    assert exc.value.hint is not None
+
+
 def test_local_requires_base_url_without_mock(
     monkeypatch: pytest.MonkeyPatch,
     local_model: str,
@@ -209,6 +221,20 @@ def test_local_requires_base_url_without_mock(
         Config(provider="local", model=local_model)
     assert exc.value.hint is not None
     assert "POLLUX_LOCAL_BASE_URL" in exc.value.hint
+
+
+def test_local_model_can_be_omitted() -> None:
+    """Single-model local servers can rely on their server-side default model."""
+    cfg = Config(provider="local", base_url="http://localhost:11434/v1")
+
+    assert cfg.model is None
+
+
+def test_cloud_provider_requires_model() -> None:
+    """Only local OpenAI-compatible servers may omit model."""
+    with pytest.raises(ConfigurationError, match="model required") as exc:
+        Config(provider="gemini", api_key="key")
+    assert exc.value.hint is not None
 
 
 def test_local_resolves_base_url_from_env(


### PR DESCRIPTION
## Summary

Make `provider="local"` a first-class agent backend against self-hosted, OpenAI-compatible servers. Local now accepts multimodal input, supports single-model servers that don't take a `model` field, and exposes a configurable request timeout.

- **Multimodal input**: inline image and audio through Chat Completions content parts (`uploads=True`) and inline text files; unsupported MIME types raise specific guidance instead of a blanket "text-only" error.
- **Optional model**: `Config.model` may be omitted for single-model local servers; the `model` field is then left out of local payloads. Cloud providers still require `model`, and `create_cache()`/`defer()` raise clearly when it is missing.
- **Configurable timeout**: `Config.request_timeout_s` (default `300.0`) for providers that own their transport, plumbed through to `LocalProvider`.

## Related issue

None

## Test plan

`just check` passes (ruff format, ruff check, mypy on 88 source files, 429 tests). New/updated tests:
- `tests/providers/test_local_contract.py`: multimodal content parts, unsupported-MIME rejection, `upload_file` inlining, `model`-omitted payload, custom timeout, `uploads=True` capability.
- `tests/pipeline/test_cache_and_uploads.py`: local file sources are inlined for Chat Completions.
- `tests/test_config.py`: optional `model` for local, cloud `model` required, `request_timeout_s` validation.

## Notes

First of a 3-PR stack hardening Pollux for v2 RC agent loops. Stacked PRs follow: error taxonomy + OpenAI interop, then the `Session` runtime + readiness probes. This PR targets `main` and stands alone.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)
