### PR TITLE
fix(providers): detect local context overflow errors

### DIFF
--- a/src/pollux/providers/_errors.py
+++ b/src/pollux/providers/_errors.py
@@ -131,6 +131,17 @@ def _auth_hint(
 
 def _detect_error_category(exc: BaseException, status_code: int | None) -> str | None:
     """Detect normalized error category based on status code, message, and exception type."""
+    # Self-hosted servers phrase context overflow inconsistently, so before the
+    # substring scan we classify on an extractable (n_tokens, n_ctx) pair where
+    # the request exceeds the window. This sits ahead of the priority checks
+    # below safely: it is gated on a 400/bad-request, which is mutually exclusive
+    # with the rate-limit (429), auth (401/403), and capacity (5xx) categories,
+    # so it cannot shadow them.
+    if (
+        status_code == 400 or _has_bad_request_error(exc)
+    ) and _has_context_overflow_counts(exc):
+        return "context_overflow"
+
     for e in walk_exception_chain(exc):
         name = type(e).__name__
         msg = str(e).lower()
@@ -177,6 +188,12 @@ def _detect_error_category(exc: BaseException, status_code: int | None) -> str |
                 "token limit",
                 "exceeds limit",
                 "prompt length",
+                "context size",
+                "exceeds context",
+                "context window",
+                "n_ctx",
+                "kv cache",
+                "context shift",
             )
         ):
             return "context_overflow"
@@ -191,6 +208,11 @@ def _detect_error_category(exc: BaseException, status_code: int | None) -> str |
             return "capacity"
 
     return None
+
+
+def _has_bad_request_error(exc: BaseException) -> bool:
+    """Return whether the exception chain includes an SDK bad-request error."""
+    return any(type(e).__name__ == "BadRequestError" for e in walk_exception_chain(exc))
 
 
 _TOKEN_PAIR_PATTERNS = (
@@ -220,6 +242,15 @@ def _extract_context_window(exc: BaseException) -> tuple[int | None, int | None]
                 n_ctx = int(match.group("n_ctx").replace(",", ""))
                 return n_tokens, n_ctx
     return None, None
+
+
+def _has_context_overflow_counts(exc: BaseException) -> bool:
+    """Return whether error text carries requested/allowed context counts."""
+    # wrap_provider_error re-runs _extract_context_window to populate the
+    # ContextOverflowError counts, so an overflow 400 parses twice. The input is
+    # a short error string, so the duplicate regex pass is not worth caching.
+    n_tokens, n_ctx = _extract_context_window(exc)
+    return n_tokens is not None and n_ctx is not None and n_tokens >= n_ctx
 
 
 def wrap_provider_error(

--- a/tests/providers/test_errors.py
+++ b/tests/providers/test_errors.py
@@ -284,3 +284,97 @@ def test_wrap_provider_error_returns_context_overflow_with_token_counts() -> Non
     assert err.error_category == "context_overflow"
     assert err.n_tokens == 12345
     assert err.n_ctx == 8192
+
+
+@pytest.mark.parametrize(
+    ("body", "n_tokens", "n_ctx"),
+    [
+        (
+            "llama.cpp error: request (9,216 tokens) exceeds context size "
+            "(8,192 tokens)",
+            9216,
+            8192,
+        ),
+        (
+            "vLLM: This model's maximum context length is 4096 tokens. "
+            "However, you requested 5000 tokens in the messages.",
+            5000,
+            4096,
+        ),
+        (
+            "Ollama: prompt exceeds context window of 2048 tokens: "
+            "2300 tokens requested",
+            2300,
+            2048,
+        ),
+        (
+            "TGI input validation error: maximum allowed context is "
+            "4,096 tokens, received 5,120 tokens",
+            5120,
+            4096,
+        ),
+    ],
+)
+def test_wrap_provider_error_categorizes_self_hosted_context_overflow_bodies(
+    body: str,
+    n_tokens: int,
+    n_ctx: int,
+) -> None:
+    class _SdkError(Exception):
+        status_code: int
+
+    exc = _SdkError(body)
+    exc.status_code = 400
+
+    err = wrap_provider_error(
+        exc,
+        provider="local",
+        phase="generate",
+        allow_network_errors=True,
+    )
+
+    assert isinstance(err, ContextOverflowError)
+    assert err.error_category == "context_overflow"
+    assert err.n_tokens == n_tokens
+    assert err.n_ctx == n_ctx
+
+
+def test_wrap_provider_error_uses_token_counts_for_novel_context_overflow_wording() -> (
+    None
+):
+    class _SdkError(Exception):
+        status_code: int
+
+    exc = _SdkError(
+        "request contains 12,000 tokens, model ctx capacity is 8,192 tokens"
+    )
+    exc.status_code = 400
+
+    err = wrap_provider_error(
+        exc,
+        provider="local",
+        phase="generate",
+        allow_network_errors=True,
+    )
+
+    assert isinstance(err, ContextOverflowError)
+    assert err.n_tokens == 12000
+    assert err.n_ctx == 8192
+
+
+def test_wrap_provider_error_does_not_use_token_counts_below_context_window() -> None:
+    class _SdkError(Exception):
+        status_code: int
+
+    exc = _SdkError("request contains 512 tokens, model ctx window is 8,192 tokens")
+    exc.status_code = 400
+
+    err = wrap_provider_error(
+        exc,
+        provider="local",
+        phase="generate",
+        allow_network_errors=True,
+    )
+
+    assert not isinstance(err, ContextOverflowError)
+    assert err.error_category is None


### PR DESCRIPTION
## Summary

Recognizes context-window failures from self-hosted OpenAI-compatible servers even when their wording differs, using parsed requested/allowed token counts for 400 and SDK bad-request errors. This preserves normalized `ContextOverflowError` behavior and token-count diagnostics for llama.cpp, vLLM, Ollama, TGI, and novel equivalent messages.

## Related issue

None

## Test plan

- `uv run pytest tests/providers/test_errors.py tests/interaction/test_continuation.py -v` — 28 passed.
- `uv run ruff check src/pollux/providers/_errors.py tests/providers/test_errors.py tests/interaction/test_continuation.py` — passed.
- `uv run mypy src/pollux/providers/_errors.py` — passed.
- `just check` — Ruff, rumdl, mypy, and 450 non-API tests passed.

## Notes

The count-based path is restricted to HTTP 400 / SDK `BadRequestError` failures and only classifies an overflow when the requested count is at least the parsed context limit. This avoids shadowing rate-limit, authentication, and capacity categories.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)