### PR TITLE
docs: clarify agent integration boundaries

### DIFF
--- a/docs/agent-loop.md
+++ b/docs/agent-loop.md
@@ -171,6 +171,18 @@ Within each iteration, Pollux handled:
 The boundary is clean: Pollux executes turns, you decide what happens
 *between* them.
 
+### Async-native execution
+
+Pollux's execution API is async-native. Agent harnesses that expose a
+synchronous command-line interface can wrap Pollux with `asyncio.run(...)` at
+their own process boundary, as the example does above. Keep that sync bridge in
+your application adapter instead of pushing it into Pollux.
+
+Do not call `asyncio.run(...)` from inside an already-running event loop
+(for example, from an async web server, notebook kernel, or another agent
+runtime). In those environments, keep your Pollux adapter async and `await`
+`interact()`, `run()`, or `stream()` directly.
+
 ## Variations
 
 These are all small modifications to the same loop structure.
@@ -221,8 +233,9 @@ out = await interact(
 )
 ```
 
-If your agent already stores OpenAI Chat Completions-style messages, import
-that replay list into Pollux instead of rewriting each message by hand:
+If your application owns an OpenAI Chat Completions-style transcript for resume,
+compaction, or audit logs, keep that transcript as the durable record and import
+it into a fresh Pollux continuation for each turn:
 
 ```python
 from pollux import Continuation, Input
@@ -237,7 +250,11 @@ out = await interact(
 
 `ToolCall.to_openai()`, `Message.to_openai()`, and
 `Continuation.to_openai_messages()` provide the reverse mapping for harnesses
-that still dispatch OpenAI-shaped tool calls.
+that still dispatch OpenAI-shaped tool calls. For supported text and tool
+message shapes, importing with `Continuation.from_openai_messages(...)` and
+exporting with `to_openai_messages()` preserves `role`, `content`,
+`tool_calls`, and `tool_call_id`. Display reasoning is output data and is not
+replayed as transcript history.
 
 ### Guiding tool use with system instructions
 
@@ -301,7 +318,9 @@ the control flow.
   exception breaks the loop.
 - **Use `ToolCall.arguments_dict()` for dispatch.** It accepts object-shaped
   JSON arguments and rejects malformed or non-object arguments with an actionable
-  error, instead of silently treating them as `{}`.
+  error, instead of silently treating them as `{}`. If your application wants a
+  compatibility fallback for a specific local model, put that policy in your
+  dispatcher and log it; Pollux keeps the typed tool-call object strict.
 - **`tool_calls` is a flat tuple on `Output`.** When using `interact()` or `run()`,
   `out.tool_calls` is a flat tuple of `ToolCall` objects.
 - **The model can request multiple tools in one turn.** The example handles

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,8 +6,8 @@
 # Configuring Pollux
 
 You need to tell Pollux which provider, model, and API key to use. The
-`Config` object captures these choices explicitly. No global state, no
-implicit defaults.
+`Config` object captures these choices explicitly. No implicit provider or
+model defaults.
 
 !!! info "Boundary"
     **Pollux owns:** validating config, resolving API keys from the
@@ -39,6 +39,27 @@ All fields and their defaults:
 | `request_concurrency` | `int` | `6` | Max concurrent API calls in multi-prompt execution |
 | `request_timeout_s` | `float` | `300.0` | HTTP request timeout in seconds for providers that own their transport, including `provider="local"` |
 | `retry` | `RetryPolicy` | `RetryPolicy()` | Retry configuration |
+| `capabilities` | `Mapping[str, bool] \| None` | `None` | Optional v2 interaction capability overrides, mainly for local OpenAI-compatible servers whose feature support varies |
+
+### Field Categories
+
+`Config` is intentionally a low-level library object. If you are building an
+application or agent framework on top of Pollux, you will usually expose a
+smaller product-specific selector and translate it into `Config`.
+
+| Category | Fields | Meaning |
+|---|---|---|
+| Provider identity | `provider`, `model` | Which provider adapter and model Pollux should call. Cloud providers require both fields. A local OpenAI-compatible server may omit `model` when the server owns model selection. |
+| Transport settings | `base_url`, `request_timeout_s` | How Pollux reaches a provider endpoint. `base_url` is only for `provider="local"` and is rejected for cloud providers. |
+| Credentials | `api_key` or provider env vars | Authentication material. Pass an explicit key, or let Pollux resolve it from the provider-specific environment variable. |
+| Capability overrides | `capabilities` | Advanced escape hatch for declaring provider capabilities when static provider defaults are too broad or too narrow, especially for local servers. |
+| Per-execution controls | `request_concurrency`, `retry`, `use_mock` | Pollux execution behavior around concurrency, retries, and mock/no-network operation. Generation controls such as `temperature`, `max_tokens`, `reasoning_effort`, and `tool_choice` are passed to `run()`, `run_many()`, `interact()`, `stream()`, or `defer()`, not stored on `Config`. |
+
+For application settings, keep product concerns outside Pollux. For example,
+an agent harness might keep `provider = "local"` and `model = "gemma3:4b"` in
+its own TOML file, then construct `Config(provider="local", model="gemma3:4b")`
+at the Pollux boundary. Pollux still owns provider credential discovery and
+provider validation.
 
 ## API Key Resolution
 
@@ -62,8 +83,11 @@ You can also pass a key directly:
 config = Config(provider="openai", model="gpt-5-nano", api_key="sk-...")
 ```
 
-Pollux auto-loads `.env` files via `python-dotenv`. Create a `.env` in your
-project root for local development, but never commit it.
+If an expected environment variable is not already set, Pollux lazily asks
+`python-dotenv` to load a `.env` file and checks again. A `.env` file is
+convenient for local development, but it is not required: exported process
+environment variables, shell profiles, secret managers, CI secrets, or explicit
+`api_key=` values all work. Never commit real keys.
 
 ## Self-Hosted Models (`provider="local"`)
 
@@ -90,6 +114,11 @@ export POLLUX_LOCAL_BASE_URL="http://localhost:11434/v1"
 ```python
 config = Config(provider="local", model="gemma3:4b")
 ```
+
+As with API keys, `POLLUX_LOCAL_BASE_URL` can come from the process
+environment, a shell profile, CI configuration, or a `.env` file. Applications
+do not need to require a Pollux-specific `.env`; they can read their own
+settings and pass `base_url=` directly.
 
 The supported surface is narrow by design: text in, text or JSON out. Pollux
 also surfaces model-native reasoning text when the local server returns it.

--- a/docs/conversations-and-agents.md
+++ b/docs/conversations-and-agents.md
@@ -71,7 +71,8 @@ asyncio.run(chat_loop())
 ## Using `history` for Manual Control
 
 If you need to inject mid-conversation context, groom old context out to
-save tokens, or resume a chat from a database, `continue_from` won't cut it.
+save tokens, or resume a chat from a database, a prior `continuation` alone
+is not enough.
 
 Instead, pass an explicit `history` list of dictionaries containing `role`
 and `content`:
@@ -103,7 +104,60 @@ asyncio.run(manual_history_injection())
 ```
 
 Pollux treats the `history` block chronologically *before* the prompt you
-provide to `run()`.
+provide to `interact()`.
+
+## Persisting Agent Transcripts
+
+For agent frameworks, persist Pollux continuation state separately from your
+product transcript:
+
+- Keep the `output.continuation.to_jsonable()` serialization when `output.continuation` is
+  present and you want Pollux to continue a provider-correct interaction later.
+- Maintain your own user-visible transcript for display, search, audit logs, and
+  summarization.
+- Capture media-bearing inputs as application records that can be reconstructed
+  as `Source` values, or send them as current-turn input. Do not flatten PDFs,
+  images, audio, video, or provider-native media parts into replay messages.
+
+### Application-Owned Transcripts
+
+If your application is the source of truth for history because it supports
+resume, compaction, truncation, or audit logs, keep that transcript in your own
+store and rebuild a `Continuation` for each Pollux turn. In this pattern,
+`Continuation` is the provider replay object for the next call, not the durable
+application transcript.
+
+`Continuation.from_openai_messages(...)` is a compatibility bridge for text
+Chat Completions-style transcripts and tool turns. It extracts text from
+OpenAI text parts, preserves tool calls, and deliberately does not turn
+provider-shaped media attachments into Pollux `Source` objects. That keeps
+media explicit at the Pollux boundary:
+
+```python
+from pollux import Continuation, Environment, Input, Source, interact
+
+continuation = Continuation.from_openai_messages(text_messages, provider="local")
+env = Environment(sources=[Source.from_file("current-report.pdf")])
+
+result = await interact(
+    env,
+    Input(content="Continue the analysis.", continuation=continuation),
+    config=config,
+)
+```
+
+For supported text and tool message shapes,
+`Continuation.from_openai_messages(messages).to_openai_messages()` is a
+lossless round trip for `role`, `content`, `tool_calls`, and `tool_call_id`.
+Display reasoning is not part of that replay contract: `Output.reasoning` is
+diagnostic/output data and should not be copied into future transcript messages.
+Provider-specific opaque reasoning blocks are replayed through
+`provider_state` only when a provider requires them.
+
+If you need to resume an older session that included files or images, load
+those application records and rebuild `Source.from_file(...)`,
+`Source.from_uri(...)`, or another source constructor explicitly. Pollux's
+replay messages are for conversation turns, not hidden media transport.
 
 ## Handling Tool Messages in History
 
@@ -199,6 +253,12 @@ next_result = await interact(
   tool calls, Pollux builds the `continuation` state automatically, even
   without explicit `history=[]`. This means continuation works for the next
   turn of any tool call, with no opt-in needed.
+- **Reasoning is output data unless a provider requires opaque replay.**
+  Pollux surfaces reasoning text on `Output.reasoning` for display and
+  debugging. Provider-specific signed thinking or reasoning blocks are kept
+  inside continuation `provider_state` only when the provider requires them
+  for valid follow-up turns; do not copy display reasoning into future user or
+  assistant messages yourself.
 - **Provider differences exist.** Gemini, OpenAI, and Anthropic support tool
   calling and tool messages in history. OpenRouter supports them on models
   that advertise tool support. See

--- a/tests/interaction/test_continuation.py
+++ b/tests/interaction/test_continuation.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 import pytest
 
 from pollux.errors import PolluxError
 from pollux.interaction.continuation import SCHEMA_VERSION, Continuation, Message
 from pollux.interaction.tools import ToolCall
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 pytestmark = pytest.mark.unit
 
@@ -93,6 +98,38 @@ def test_openai_messages_import_tool_calls():
     assert continuation.messages[1].tool_calls[0].name == "get_weather"
     assert continuation.messages[1].tool_calls[0].arguments_dict() == {"city": "Paris"}
     assert continuation.messages[2].tool_call_id == "call_1"
+
+
+def test_openai_messages_round_trip_supported_transcript_shapes():
+    messages: list[Mapping[str, Any]] = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "What is the weather?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    },
+                    "index": 0,
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": '{"temp_c": 21}',
+        },
+        {"role": "assistant", "content": "It is 21 C in Paris."},
+    ]
+
+    continuation = Continuation.from_openai_messages(messages, provider="local")
+
+    assert continuation.to_openai_messages() == messages
 
 
 def test_openai_messages_round_trip_tool_call_arguments_text():


### PR DESCRIPTION
## Summary

Clarifies the async boundary, application-owned transcript pattern, continuation/media replay contract, configuration ownership, and strict tool-argument behavior for agent-framework integrations. Adds a boundary test for the documented supported OpenAI transcript round trip.

## Related issue

None

## Test plan

- `uv run pytest tests/providers/test_errors.py tests/interaction/test_continuation.py -v` — 28 passed.
- `uv run rumdl check docs/agent-loop.md docs/configuration.md docs/conversations-and-agents.md` — passed.
- `uv run mkdocs build --strict` — passed.
- `just check` — Ruff, rumdl, mypy, and 450 non-API tests passed.

## Notes

The docs keep media transport explicit: OpenAI-style text/tool transcripts can be imported, while PDFs, images, audio, video, and provider-native media remain application records reconstructed as Pollux `Source` values. Display reasoning is documented as output data rather than replay history.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)