### PR TITLE
docs: align public guidance with v2 release candidate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  # Keep deploys serialized, but do not let one PR preview cancel another.
+  group: "pages-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'deploy' }}"
   cancel-in-progress: true
 
 jobs:
@@ -121,14 +122,20 @@ jobs:
             default_version="${{ inputs.default_version }}"
           elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             release="${ref_name#v}"
-            version="${release%.*}"
-            title="${version}"
-            major="${version%%.*}"
-            if [[ "${major}" == "1" ]]; then
-              aliases="v1"
+            if [[ "${release}" == *-* ]]; then
+              # Keep prereleases addressable without promoting them to latest.
+              version="${release}"
+              title="${release}"
             else
-              aliases="latest"
-              default_version="latest"
+              version="${release%.*}"
+              title="${version}"
+              major="${version%%.*}"
+              if [[ "${major}" == "1" ]]; then
+                aliases="v1"
+              else
+                aliases="latest"
+                default_version="latest"
+              fi
             fi
           elif [[ "${ref_name}" == "v1" ]]; then
             version="v1"

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Multimodal orchestration for LLM APIs.
 
 > You describe what to analyze. Pollux handles source patterns, context caching, deferred delivery, and multimodal content.
 
-[Documentation](https://polluxlib.dev/) ·
-[Getting Started](https://polluxlib.dev/getting-started/) ·
-[Building With Deferred Delivery](https://polluxlib.dev/building-with-deferred-delivery/)
+[Documentation](https://polluxlib.dev/next/) ·
+[Getting Started](https://polluxlib.dev/next/getting-started/) ·
+[Building With Deferred Delivery](https://polluxlib.dev/next/building-with-deferred-delivery/)
 
 [![PyPI](https://img.shields.io/pypi/v/pollux-ai)](https://pypi.org/project/pollux-ai/)
 [![CI](https://github.com/seanbrar/pollux/actions/workflows/ci.yml/badge.svg)](https://github.com/seanbrar/pollux/actions/workflows/ci.yml)
@@ -22,6 +22,11 @@ Multimodal orchestration for LLM APIs.
 [![Testing: MTMT](https://img.shields.io/badge/testing-MTMT_v0.1.0-blue)](https://github.com/seanbrar/minimal-tests-maximum-trust)
 ![Python](https://img.shields.io/badge/Python-3.10%2B-brightgreen)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
+
+> [!IMPORTANT]
+> This branch documents the Pollux 2.0 release candidate. Install with
+> `pip install --pre --upgrade pollux-ai`. The default PyPI install remains the
+> stable v1 line until 2.0 reaches its stable release.
 
 ## Quick Start
 
@@ -53,7 +58,7 @@ For a self-hosted OpenAI-compatible server (text, image, and audio):
 Single-model servers can omit `model`.
 
 For a full walkthrough (install, key setup, first result), see
-[Getting Started](https://polluxlib.dev/getting-started/).
+[Getting Started](https://polluxlib.dev/next/getting-started/).
 
 ## Which Entry Point Should I Use?
 
@@ -139,7 +144,7 @@ asyncio.run(main())
 `Output.tool_calls` exposes any tools the model wants to run; return their
 results on the next `Input` to drive an agent loop. For tool declarations,
 dispatch, and streaming, see
-[Building an Agent Loop](https://polluxlib.dev/agent-loop/).
+[Building an Agent Loop](https://polluxlib.dev/next/agent-loop/).
 
 ## When the Work Can Wait
 
@@ -174,20 +179,20 @@ if snapshot.is_terminal:
 
 In production code, persist `handle.to_dict()` and restore it later with
 `DeferredHandle.from_dict(...)`. For the full lifecycle, read
-[Submitting Work for Later Collection](https://polluxlib.dev/submitting-work-for-later-collection/)
+[Submitting Work for Later Collection](https://polluxlib.dev/next/submitting-work-for-later-collection/)
 and
-[Building With Deferred Delivery](https://polluxlib.dev/building-with-deferred-delivery/).
+[Building With Deferred Delivery](https://polluxlib.dev/next/building-with-deferred-delivery/).
 
 ## Where Pollux Ends
 
 Pollux owns content delivery, context caching, and provider translation. Prompt
 design, workflow orchestration, and what you do with results are yours. See
-[Core Concepts](https://polluxlib.dev/concepts/) for the full boundary model.
+[Core Concepts](https://polluxlib.dev/next/concepts/) for the full boundary model.
 
 ## Installation
 
 ```bash
-pip install pollux-ai
+pip install --pre --upgrade pollux-ai
 ```
 
 Set your provider's API key:
@@ -206,22 +211,22 @@ For `provider="local"`, no API key is required; point `base_url` (or
 
 ## Documentation
 
-- [Getting Started](https://polluxlib.dev/getting-started/): first result in 2 minutes
-- [Core Concepts](https://polluxlib.dev/concepts/): mental model and vocabulary
-- [Building an Agent Loop](https://polluxlib.dev/agent-loop/): multi-turn threads, tool calls, and streaming
-- [Submitting Work for Later Collection](https://polluxlib.dev/submitting-work-for-later-collection/): deferred lifecycle API
-- [Migrating to 2.0](https://polluxlib.dev/migrating-to-v2/): moving from the v1 API
-- [Building With Deferred Delivery](https://polluxlib.dev/building-with-deferred-delivery/): when deferred is worth it
-- [API Reference](https://polluxlib.dev/reference/api/): entry points and types
-- [Cookbook](https://polluxlib.dev/reference/cli/): runnable end-to-end recipes
+- [Getting Started](https://polluxlib.dev/next/getting-started/): first result in 2 minutes
+- [Core Concepts](https://polluxlib.dev/next/concepts/): mental model and vocabulary
+- [Building an Agent Loop](https://polluxlib.dev/next/agent-loop/): multi-turn threads, tool calls, and streaming
+- [Submitting Work for Later Collection](https://polluxlib.dev/next/submitting-work-for-later-collection/): deferred lifecycle API
+- [Migrating to 2.0](https://polluxlib.dev/next/migrating-to-v2/): moving from the v1 API
+- [Building With Deferred Delivery](https://polluxlib.dev/next/building-with-deferred-delivery/): when deferred is worth it
+- [API Reference](https://polluxlib.dev/next/reference/api/): entry points and types
+- [Cookbook](https://polluxlib.dev/next/reference/cli/): runnable end-to-end recipes
 
-Full docs at [polluxlib.dev](https://polluxlib.dev/).
+Full v2 RC docs at [polluxlib.dev/next](https://polluxlib.dev/next/).
 
 ## Contributing
 
-See [CONTRIBUTING](https://polluxlib.dev/contributing/) and [TESTING.md](./TESTING.md) for guidelines.
+See [CONTRIBUTING](https://polluxlib.dev/next/contributing/) and [TESTING.md](./TESTING.md) for guidelines.
 
-Built during [Google Summer of Code 2025](https://summerofcode.withgoogle.com/) with Google DeepMind. [Learn more](https://polluxlib.dev/#about)
+Built during [Google Summer of Code 2025](https://summerofcode.withgoogle.com/) with Google DeepMind. [Learn more](https://polluxlib.dev/next/#about)
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,14 +5,14 @@ This roadmap is intentionally scope-constrained. Pollux is already past the
 trustworthy, more legible, and harder to misuse.
 
 - **Intent**: communicate priorities and scope boundaries, not promises.
-- **Last updated**: 2026-06-12
-- **Current release**: v1.8 adds reasoning budget tokens, normalized
-  `cached_tokens` usage reporting, a text-only `local` provider, serialized
-  continuation state stamps, and Anthropic pre-flight rejection of
-  extended-thinking requests on Claude 3 models. It also removes the deprecated
-  `Options.delivery_mode` shim.
-- **Next major**: v2.0 is planned as a major-version cleanup of Pollux's
-  interaction model. See `docs/migrating-to-v2.md` for the migration direction.
+- **Last updated**: 2026-07-11
+- **Current prerelease**: v2.0.0-rc.1 ships the v2 interaction model on the
+  `release/2.0.0` line. The stable 2.0 release has not shipped yet.
+- **Maintenance line**: v1.8 remains on the dedicated `v1` branch for 1.x
+  maintenance releases.
+- **Next release**: continue validating the v2 API through release candidates,
+  then promote it to stable 2.0 from `main`. See `docs/migrating-to-v2.md` for
+  the shipped migration contract.
 - **Status tracking**: Issues and PRs are the source of truth for active work.
 
 ## Product Strategy
@@ -36,9 +36,11 @@ trustworthy, more legible, and harder to misuse.
 The core library now covers the main orchestration responsibilities it set out
 to own:
 
-- Stable entry points for realtime and deferred execution:
-  `run()`, `run_many()`, `defer()`, `defer_many()`,
-  `inspect_deferred()`, `collect_deferred()`, `cancel_deferred()`.
+- Typed entry points for realtime, streaming, and deferred execution:
+  `run()`, `run_many()`, `interact()`, `stream()`, `defer()`,
+  `inspect_deferred()`, `collect_deferred()`, and `cancel_deferred()`.
+- A reusable `Session` runtime, typed `Environment` / `Input` interaction
+  primitives, and public `Continuation` state for multi-turn applications.
 - Multimodal source handling across the supported cloud provider matrix, plus
   a text-only `local` provider for self-hosted OpenAI-compatible servers.
 - Source patterns: fan-out, fan-in, and broadcast.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,11 +10,12 @@ Let's get Pollux running and see your first result.
 ## 1. Install
 
 ```bash
-pip install pollux-ai
+pip install --pre --upgrade pollux-ai
 ```
 
-Or download the latest wheel from
-[Releases](https://github.com/seanbrar/pollux/releases/latest).
+The `--pre` flag selects the 2.0 release candidate. Without it, pip installs
+the stable v1 line until 2.0 reaches its stable release. You can also download
+the RC wheel from [Releases](https://github.com/seanbrar/pollux/releases).
 
 ## 2. Set Your API Key
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,8 +38,11 @@ output, usage tracking.
 ## Install
 
 ```bash
-pip install pollux-ai
+pip install --pre --upgrade pollux-ai
 ```
+
+The `next` documentation describes the 2.0 release candidate. The default
+PyPI install remains the stable v1 line until 2.0 reaches stable release.
 
 ## Documentation
 

--- a/docs/migrating-to-v2.md
+++ b/docs/migrating-to-v2.md
@@ -1,20 +1,20 @@
-<!-- Intent: Preview the planned Pollux 2.0 migration path for 1.x users.
-     Teach what is expected to stay familiar, what is expected to move, and
-     what users can do in 1.x to reduce future churn. Do NOT present the v2 API
-     as final or require users to rewrite code before v2 is released. Assumes
-     the reader has used Pollux 1.x. Register: warm guide with precise caveats. -->
+<!-- Intent: Guide Pollux 1.x users to the shipped 2.0 release-candidate API.
+     Teach what stayed familiar, what changed, and how to migrate without
+     implying that the RC has stable-release guarantees. Assumes the reader
+     has used Pollux 1.x. Register: warm guide with precise caveats. -->
 
 # Migrating to Pollux 2.0
 
-!!! warning "Planned, not released"
-    Pollux 2.0 has not shipped. This page describes the migration direction so
-    you can write 1.x code with less future churn. Names, signatures, and exact
-    replacement snippets may change before release.
+!!! warning "Release candidate"
+    Pollux 2.0 is available as a release candidate, not a stable release. The
+    API on this page is shipped in the RC and on `main`, but interaction details
+    may still change before stable 2.0. Install it with
+    `pip install --pre --upgrade pollux-ai`.
 
-Pollux 2.0 is planned as a major-version cleanup of the interaction model. The
-goal is to name the pieces of a model interaction directly: the environment the
-model runs in, the input for this turn, the output requirements, and the
-continuation state that carries work forward.
+Pollux 2.0 is a major-version cleanup of the interaction model. It names the
+pieces of a model interaction directly: the environment the model runs in, the
+input for this turn, the output requirements, and the continuation state that
+carries work forward.
 
 Most one-shot code should remain recognizable. The bigger changes affect code
 that builds agent loops, persists continuation state, prepares caches, submits
@@ -35,11 +35,11 @@ You should read this page if your 1.x code uses any of these:
 - Dictionary-style result access such as `result["text"]`.
 
 If your code calls `run()` with a prompt, sources, and config, the migration is
-expected to be small.
+small.
 
 ## What Stays Familiar
 
-These 1.x entry points are expected to keep their role:
+These entry points keep their 1.x role:
 
 - `run()` for one realtime interaction.
 - `run_many()` for source-pattern collections: fan-out, fan-in, and broadcast.
@@ -51,11 +51,10 @@ In other words, the first Pollux program still starts with `run()`.
 
 ## What Changes
 
-The planned changes move behavior out of special-case helpers and into named
-interaction pieces. Treat the right column as migration direction until the v2
-API lands.
+The changes move behavior out of special-case helpers and into named
+interaction pieces.
 
-| 1.x | Planned 2.0 shape | Why |
+| 1.x | 2.0 RC shape | Why |
 | --- | --- | --- |
 | `Options(...)` | `Environment`, `Input`, and `OutputRequirements` | Provider, turn input, and output contract become separate objects. |
 | `continue_tool(env, results)` | `interact(environment, Input(continuation=..., tool_results=...))` | Tool-result replay becomes part of continuing an interaction. |
@@ -72,7 +71,7 @@ Here is the expected direction for result handling:
 text = result["text"]
 payload = dict(result)
 
-# 2.0 planned shape
+# 2.0 RC
 text = result.text
 payload = result.to_jsonable()
 ```
@@ -84,7 +83,7 @@ interaction-shaped API:
 # 1.x
 next_result = await continue_tool(env, tool_results)
 
-# 2.0 planned shape
+# 2.0 RC
 next_result = await interact(
     environment,
     Input(continuation=continuation, tool_results=tool_results),
@@ -113,8 +112,8 @@ rebuild the request when that is the right recovery path.
 
 ## What To Do In 1.x
 
-You do not need to rewrite working 1.x code before 2.0 exists. To make future
-migration easier:
+You do not need to migrate working 1.x code while 2.0 is in RC. When you are
+ready to test the RC:
 
 - Keep provider setup, prompts, sources, and output requirements separated in
   your own code.
@@ -127,9 +126,9 @@ migration easier:
 - Use `run()` and `run_many()` for realtime source patterns, and `defer()`
   only when provider-side deferred delivery is the workflow you want.
 
-## What Is Available Now
+## What Is Available In The RC
 
-The 2.0 interaction model is landing incrementally on `main`:
+The 2.0 interaction model is available in `v2.0.0-rc.1` and on `main`:
 
 - `run()` and `run_many()` now return the 2.0 result model: `run()` returns an
   `Output` (named facets `text`, `structured`, `reasoning`, `tool_calls`,
@@ -152,14 +151,14 @@ and `collect_deferred()` returns an `OutputCollection`. Persistent caching
 returns through `prepare_environment()` / `Environment(cache=...)`.
 `create_cache()`, `defer_many()`, and `Options` are removed.
 
-## As The Design Settles
+## During The RC Cycle
 
-This page will change as the 2.0 API moves from plan to release candidate. Use
-it as the public migration guide; exact replacement snippets will become more
-specific as names and signatures settle.
+This page is the public migration contract for the release-candidate cycle. It
+will track any deliberate pre-stable changes so downstream developers can test
+the exact API that is being prepared for stable 2.0.
 
 ---
 
-For the concepts behind the planned model, read [Core Concepts](concepts.md).
+For the concepts behind the model, read [Core Concepts](concepts.md).
 For the current provider contract, see
 [Provider Capabilities](reference/provider-capabilities.md).


### PR DESCRIPTION
## Summary

Aligns public documentation with the shipped v2 release candidate: `main` now installs the prerelease explicitly, links to the versioned `next` docs instead of stable v1 docs, and describes the v2 API as shipped in RC rather than merely planned. It also fixes docs workflow behavior so concurrent PR previews do not cancel each other and prerelease tags retain their full version without taking the `latest` alias.

## Related issue

None

## Test plan

- `just check` — Ruff, rumdl, mypy, and 450 non-API tests passed.
- `uv run mkdocs build --strict --clean` — strict docs build passed.
- `actionlint .github/workflows/docs.yml` — passed.
- Exercised the tag-version shell logic for `v2.0.0-rc.1`, `v2.0.0`, and `v1.8.1`; results were respectively `2.0.0-rc.1` with no aliases, `2.0` with `latest`, and `1.8` with `v1`.
- Verified `git diff --check` passes.

## Notes

The GitHub `github-pages` environment previously allowed only `main`, which rejected the `v2.0.0-rc.1` tag deployment and would also reject `v1`. Its deployment policies have been updated separately to allow only `main`, branch `v1`, and tags matching `v*`.

The failed RC deployment was protective in hindsight: the old workflow would have shortened `v2.0.0-rc.1` to `2.0.0-rc` and promoted it to `latest`. This change prevents prerelease tags from changing the stable docs default.

---

- [x] PR title follows [conventional commits](https://polluxlib.dev/contributing/)
- [x] `just check` passes
- [x] Tests cover the meaningful cases, not just the happy path
- [x] Docs updated (if this changes public API or user-facing behavior)